### PR TITLE
ci: enable CI actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,70 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please switch to the latest version of this charm
+        before posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        Provide a description of the issue you are facing. If applicable, add screenshots to help explain the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behaviour.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju integrate ...`
+        3. `juju status --integrations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay`. Additional details on how to retrieve logs are available in the juju
+        documentation at https://juju.is/docs/juju/log.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,91 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: slurm charms tests
+on:
+  workflow_call:
+  pull_request:
+    branches:
+      - main
+      - experimental
+
+
+jobs:
+  inclusive-naming-check:
+    name: Inclusive naming check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run tests
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox run -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run tests
+        run: tox run -e unit
+
+  type-check:
+    name: Static type checking
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run tests
+        run: tox run -e type
+
+  integration-test:
+    strategy:
+      fail-fast: true
+      matrix:
+        bases:
+          - ubuntu@22.04
+    name: Integration tests (LXD) | ${{ matrix.bases }}
+    runs-on: ubuntu-latest
+    needs:
+      - inclusive-naming-check
+      - lint
+      - unit-test
+      - type-check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: 3.4/stable
+      - name: Run tests
+        run: tox run -e integration -- --charm-base=${{ matrix.bases }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ on:
       - main
       - experimental
 
-
 jobs:
   inclusive-naming-check:
     name: Inclusive naming check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,52 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci-tests:
+    uses: ./.github/workflows/ci.yaml
+
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs:
+      - ci-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        charm: [slurmctld, slurmd, slurmdbd, slurmrestd]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@2.5.0-rc
+        id: channel
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Stage charm
+        run: tox run -e stage -- ${{ matrix.charm }} --clean
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"
+          charm-path: "./_build/${{ matrix.charm }}"
+          tag-prefix: "${{ matrix.charm }}"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 version
 .ruff_cache/
 _build
+.charmhub.secret

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -16,7 +16,7 @@ description: |
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
 
-  issues: 
+  issues:
   - https://github.com/charmed-hpc/slurmctld-operator/issues
 
   source:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -103,8 +103,11 @@ async def test_build_and_deploy_against_edge(
     await ops_test.model.integrate(f"{SLURMDBD}:database", f"{SLURMDBD}-{ROUTER}:database")
     # Reduce the update status frequency to accelerate the triggering of deferred events.
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[SLURMCTLD], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(apps=[SLURMCTLD, SLURMD, SLURMDBD, SLURMRESTD], status="active", timeout=1000)
         assert ops_test.model.applications["slurmctld"].units[0].workload_status == "active"
+        assert ops_test.model.applications["slurmd"].units[0].workload_status == "active"
+        assert ops_test.model.applications["slurmdbd"].units[0].workload_status == "active"
+        assert ops_test.model.applications["slurmrestd"].units[0].workload_status == "active"
 
 
 @pytest.mark.abort_on_fail

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,14 @@ deps = pyyaml
 commands =
     python3 {toxinidir}/repository.py -v fetch-lib {posargs}
 
+[testenv:stage]
+description = Stages all the specified slurm charms
+basepython = python3
+deps =
+    pyyaml
+commands =
+    python3 {toxinidir}/repository.py -v stage {posargs}
+
 [testenv:build]
 description = Build all the specified slurm charms
 basepython = python3
@@ -87,3 +95,10 @@ deps =
     -r{toxinidir}/test-requirements.txt
 commands =
     python3 {toxinidir}/repository.py -v integration -- {posargs}
+
+[testenv:generate-token]
+basepython = python3
+deps =
+    pyyaml
+commands =
+    python3 {toxinidir}/repository.py -v generate-token


### PR DESCRIPTION
This adds another command in tox to generate a Charmhub token, which should be useful to regenerate it in an easier way.