### PR TITLE
chore(deps): Bump ops from 2.14.0 to 2.15.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-ops==2.14.0
+ops==2.15.0
 distro==1.9.0
 pycryptodome==3.20.0
 dbus-fast>=1.90.2


### PR DESCRIPTION
Fix CVE-2024-41129

Bumps ops to version 2.14.0 in our test requirements. Needed to author this PR manually as for some reason Dependabot could not parse the project _pyproject.toml_ file.