### PR TITLE
fix parsing of nested k=v config values

### DIFF
--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -22,6 +22,10 @@ links:
   source:
   - https://github.com/charmed-hpc/slurm-charms
 
+peers:
+  slurmctld-peer:
+    interface: slurmctld-peer
+
 requires:
   slurmd:
     interface: slurmd

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -405,14 +405,11 @@ class SlurmctldCharm(CharmBase):
     def _ingress_address(self) -> str:
         """Return the ingress_address from the slurmd relation if it exists."""
         if (peer_binding := self.model.get_binding(PEER_RELATION)) is not None:
-            try:
-                logger.debug(
-                    "Getting ingress_address: %s",
-                    peer_binding.network.ingress_address,
-                )
-                return str(peer_binding.network.ingress_address)
-            except TypeError:
-                pass
+            logger.debug(
+                "Getting ingress_address: %s",
+                peer_binding.network.ingress_address,
+            )
+            return str(peer_binding.network.ingress_address)
         raise IngressAddressUnavailableError
 
     @property

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -3,6 +3,8 @@
 """This module provides constants for the slurmctld-operator charm."""
 from pathlib import Path
 
+PEER_RELATION = "slurmctld-peer"
+
 SLURM_CONF_PATH = Path("/etc/slurm/slurm.conf")
 SLURM_USER = "slurm"
 SLURM_GROUP = "slurm"

--- a/charms/slurmctld/src/custom_exceptions.py
+++ b/charms/slurmctld/src/custom_exceptions.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright 2020 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This module has custom exceptions for slurmctld-operator.
+
+Exception: IngressAddressUnavailableError
+"""
+
+
+class IngressAddressUnavailableError(Exception):
+    """Exception raised when Ingress Adreess is not yet availability."""
+
+    def __init__(self, message="Ingress address unavailable"):
+        self.message = message
+        super().__init__(self.message)

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -171,3 +171,12 @@ class TestCharm(unittest.TestCase):
         """Test that the on_slurmdbd_unavailable method works."""
         self.harness.charm._slurmdbd.on.slurmdbd_unavailable.emit()
         self.assertEqual(self.harness.charm._stored.slurmdbd_host, "")
+
+    def test_get_user_supplied_parameters(self) -> None:
+        """Test that user supplied parameters are parsed correctly."""
+        self.harness.add_relation('slurmctld-peer', 'slurmctld')
+        self.harness.update_config({"slurm-conf-parameters": 'JobAcctGatherFrequency=task=30,network=40'})
+        self.assertEqual(
+            self.harness.charm._assemble_slurm_conf()["JobAcctGatherFrequency"],
+            "task=30,network=40"
+        )

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -174,9 +174,11 @@ class TestCharm(unittest.TestCase):
 
     def test_get_user_supplied_parameters(self) -> None:
         """Test that user supplied parameters are parsed correctly."""
-        self.harness.add_relation('slurmctld-peer', 'slurmctld')
-        self.harness.update_config({"slurm-conf-parameters": 'JobAcctGatherFrequency=task=30,network=40'})
+        self.harness.add_relation("slurmctld-peer", "slurmctld")
+        self.harness.update_config(
+            {"slurm-conf-parameters": "JobAcctGatherFrequency=task=30,network=40"}
+        )
         self.assertEqual(
             self.harness.charm._assemble_slurm_conf()["JobAcctGatherFrequency"],
-            "task=30,network=40"
+            "task=30,network=40",
         )


### PR DESCRIPTION
These changes fix the parser so that it correctly parses user defined input where the values contain nested k=v.

Adds a peer relation to get the slurmctld ingress_address from.

Fixes #14 