### PR TITLE
add TaskPlugin to default parameters

### DIFF
--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -311,6 +311,7 @@ class SlurmctldCharm(CharmBase):
             "SlurmctldHost": self.hostname,
             "SlurmctldParameters": _assemble_slurmctld_parameters(),
             "ProctrackType": "proctrack/linuxproc" if is_container() else "proctrack/cgroup",
+            "TaskPlugin": "task/affinity" if is_container() else "task/cgroup,task/affinity",
             **accounting_params,
             **CHARM_MAINTAINED_SLURM_CONF_PARAMETERS,
             **slurmd_parameters,


### PR DESCRIPTION
These changes address #16 by adding sane defaults for the [TaskPlugin](https://slurm.schedmd.com/slurm.conf.html#OPT_TaskPlugin) based on the output of `is_container()`.