### PR TITLE
fix(slurmctld): correctly parse nested config

### DIFF
--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -326,7 +326,7 @@ class SlurmctldCharm(CharmBase):
         user_supplied_parameters = {}
         if custom_config := self.config.get("slurm-conf-parameters"):
             user_supplied_parameters = {
-                line.split("=")[0]: line.split("=")[1]
+                line.split("=")[0]: line.split("=", 1)[1]
                 for line in str(custom_config).split("\n")
                 if not line.startswith("#") and line.strip() != ""
             }

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -171,3 +171,14 @@ class TestCharm(unittest.TestCase):
         """Test that the on_slurmdbd_unavailable method works."""
         self.harness.charm._slurmdbd.on.slurmdbd_unavailable.emit()
         self.assertEqual(self.harness.charm._stored.slurmdbd_host, "")
+
+    def test_get_user_supplied_parameters(self) -> None:
+        """Test that user supplied parameters are parsed correctly."""
+        self.harness.add_relation("slurmd", "slurmd")
+        self.harness.update_config(
+            {"slurm-conf-parameters": "JobAcctGatherFrequency=task=30,network=40"}
+        )
+        self.assertEqual(
+            self.harness.charm._assemble_slurm_conf()["JobAcctGatherFrequency"],
+            "task=30,network=40",
+        )


### PR DESCRIPTION
These changes modify the user supplied config parser so that it correctly handles nested user supplied configuration values.

Fixes #14