### PR TITLE
feat: add terraform modules for deploying slurm charms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,6 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
-[*.{yaml,yml}]
+[*.{yaml,yml,tf}]
 indent_style = space
 indent_size = 2

--- a/charms/slurmctld/terraform/main.tf
+++ b/charms/slurmctld/terraform/main.tf
@@ -1,0 +1,27 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "juju_application" "slurmctld" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name     = "slurmctld"
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config = var.config
+  units  = var.units
+}

--- a/charms/slurmctld/terraform/outputs.tf
+++ b/charms/slurmctld/terraform/outputs.tf
@@ -1,0 +1,25 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "app_name" {
+  value = juju_application.slurmctld.name
+}
+
+output "requires" {
+  value = {
+    slurmd     = "slurmd"
+    slurmdbd   = "slurmdbd"
+    slurmrestd = "slurmrestd"
+  }
+}

--- a/charms/slurmctld/terraform/variables.tf
+++ b/charms/slurmctld/terraform/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "app_name" {
+  description = "Name of the slurmctld application within the Juju model."
+  type        = string
+}
+
+variable "channel" {
+  description = "Channel to deploy the slurmctld charm from."
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Initial configuration for deployed slurmctld charm."
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Name of model to deploy slurmctld charm to."
+  type        = string
+}
+
+variable "revision" {
+  description = "Revision of the slurmctld charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of slurmctld units to deploy."
+  type        = number
+  default     = 1
+}

--- a/charms/slurmctld/terraform/versions.tf
+++ b/charms/slurmctld/terraform/versions.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.13.0"
+    }
+  }
+}

--- a/charms/slurmd/terraform/main.tf
+++ b/charms/slurmd/terraform/main.tf
@@ -1,0 +1,27 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "juju_application" "slurmd" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name     = "slurmd"
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config = var.config
+  units  = var.units
+}

--- a/charms/slurmd/terraform/outputs.tf
+++ b/charms/slurmd/terraform/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "app_name" {
+  value = juju_application.slurmd.name
+}
+
+output "provides" {
+  value = {
+    slurmctld = "slurmctld"
+  }
+}

--- a/charms/slurmd/terraform/variables.tf
+++ b/charms/slurmd/terraform/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "app_name" {
+  description = "Name of the slurmd application within the Juju model."
+  type        = string
+}
+
+variable "channel" {
+  description = "Channel to deploy the slurmd charm from."
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Initial configuration for deployed slurmd charm."
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Name of model to deploy slurmd charm to."
+  type        = string
+}
+
+variable "revision" {
+  description = "Revision of the slurmd charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of slurmd units to deploy."
+  type        = number
+  default     = 1
+}

--- a/charms/slurmd/terraform/versions.tf
+++ b/charms/slurmd/terraform/versions.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.13.0"
+    }
+  }
+}

--- a/charms/slurmdbd/terraform/main.tf
+++ b/charms/slurmdbd/terraform/main.tf
@@ -1,0 +1,26 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "juju_application" "slurmdbd" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name    = "slurmdbd"
+    channel = var.channel
+  }
+
+  config = var.config
+  units  = var.units
+}

--- a/charms/slurmdbd/terraform/outputs.tf
+++ b/charms/slurmdbd/terraform/outputs.tf
@@ -1,0 +1,29 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "app_name" {
+  value = juju_application.slurmdbd.name
+}
+
+output "provides" {
+  value = {
+    slurmctld = "slurmctld"
+  }
+}
+
+output "requires" {
+  value = {
+    database = "database"
+  }
+}

--- a/charms/slurmdbd/terraform/variables.tf
+++ b/charms/slurmdbd/terraform/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "app_name" {
+  description = "Name of the slurmdbd application within the Juju model."
+  type        = string
+}
+
+variable "channel" {
+  description = "Channel to deploy the slurmdbd charm from."
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Initial configuration for deployed slurmdbd charm."
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Name of model to deploy slurmdbd charm to."
+  type        = string
+}
+
+variable "revision" {
+  description = "Revision of the slurmdbd charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of slurmdbd units to deploy."
+  type        = number
+  default     = 1
+}

--- a/charms/slurmdbd/terraform/versions.tf
+++ b/charms/slurmdbd/terraform/versions.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.13.0"
+    }
+  }
+}

--- a/charms/slurmrestd/terraform/main.tf
+++ b/charms/slurmrestd/terraform/main.tf
@@ -1,0 +1,26 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "juju_application" "slurmrestd" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name    = "slurmrestd"
+    channel = var.channel
+  }
+
+  config = var.config
+  units  = var.units
+}

--- a/charms/slurmrestd/terraform/outputs.tf
+++ b/charms/slurmrestd/terraform/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "app_name" {
+  value = juju_application.slurmrestd.name
+}
+
+output "provides" {
+  value = {
+    slurmctld = "slurmctld"
+  }
+}

--- a/charms/slurmrestd/terraform/variables.tf
+++ b/charms/slurmrestd/terraform/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "app_name" {
+  description = "Name of the slurmrestd application within the Juju model"
+  type        = string
+}
+
+variable "channel" {
+  description = "Channel to deploy the slurmrestd charm from."
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Initial configuration for deployed slurmrestd charm."
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Name of model to deploy slurmrestd charm to."
+  type        = string
+}
+
+variable "revision" {
+  description = "Revision of the slurmrestd charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of slurmrestd units to deploy."
+  type        = number
+  default     = 1
+}

--- a/charms/slurmrestd/terraform/versions.tf
+++ b/charms/slurmrestd/terraform/versions.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.13.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds terraform modules for deploying the Slurm charms as part of a Charmed HPC cluster. _I need the modules published so I can verify that they work_.

These modules will enable us to declare the deployment of Slurm without needing us to manually re-define things within the `charmed-hpc-bundles` repository. For example, here's how we can pull the Slurm charm into our Charmed HPC deployment plan:

```hcl
module "controller" {
  source = "git::https://github.com/charmed-hpc/slurm-charms/charms/slurmctld//terraform"
  model_name = "juju_model_name"
  app_name = "controller"
  units = 1
}

module "compute" {
  source = "git::https://github.com/charmed-hpc/slurm-charms/charms/slurmd//terraform"
  model_name = "juju_model_name"
  app_name = "compute"
  units = 1
}

resource "juju_integration" "slurmd-to-slurmctld" {
  model = var.model_name

  application {
    name = module.controller.app_name
    endpoint = module.controller.slurmd
  }

  application {
    name = module.compute.app_name
    endpoint = module.compute.slurmctld
  }
}
``` 