### PR TITLE
feat(slurmctld): add sane defaults for cgroup.conf

### DIFF
--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -74,8 +74,10 @@ config:
     cgroup-parameters:
       type: string
       default: |
-        CgroupAutomount=yes
         ConstrainCores=yes
+        ConstrainDevices=yes
+        ConstrainRAMSpace=yes
+        ConstrainSwapSpace=yes
       description: |
         User supplied configuration for `cgroup.conf`.
 


### PR DESCRIPTION
These changes add reasonable defaults for charm `cgroup.conf`.

Fixes #31 