### PR TITLE
Fix the resume action in the slurmctld charm

### DIFF
--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -204,7 +204,7 @@ class SlurmctldCharm(CharmBase):
         event.log(f"Resuming {nodes}.")
 
         try:
-            cmd = f"scontrol update nodename={nodes} state=resume"
+            cmd = f"scontrol update nodename={nodes} state=idle"
             subprocess.check_output(shlex.split(cmd))
             event.set_results({"status": "resuming", "nodes": nodes})
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
This PR fixes the *resume* action in the *slurmctld* charm. The source error can be seen on [this](https://app.warp.dev/block/MxGNPLvRGpmjegds477jJz) link.

Essentially, the command to resume the nodes has been patched from `scontrol update nodename=<names> state=resume` to `scontrol update nodename=<names> state=idle`.

As I understand [Slurm's documentation](https://slurm.schedmd.com/scontrol.html#OPT_RESUME), there's no operational change applied by this PR.