### PR TITLE
fix(ci): do not use destructive packing when building charms for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,3 +50,4 @@ jobs:
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: "./_build/${{ matrix.charm }}"
           tag-prefix: "${{ matrix.charm }}"
+          destructive-mode: false


### PR DESCRIPTION
This PR sets the `destructive-mode` option for the `upload-charm` action to false. Pulling the down the base LXD instance will add some extra time onto the workflow run, but it make us not be dependent on the base OS of the GitHub runner VM to release the Slurm charms. This is especially helpful for it we need to release multiple the Slurm charms with support for multiple bases. Eventually we'll either want to replace the `cryptography` dependency that takes so long to build, or use the `ccc` tool to cache the Slurm charms dependencies so that the build for them is quicker.

Just for added insurance, I also updated the `CHARMCRAFT_AUTH` secret.

### Related issues

* Fixes #39 