### PR TITLE
chore(slurmctld, slurmd): clean up relation data

### DIFF
--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -67,7 +67,7 @@ config:
   options:
     cluster-name:
       type: string
-      default: osd-cluster
+      default: "osd-cluster"
       description: |
         Name to be recorded in database for jobs from this cluster.
 

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -302,7 +302,7 @@ class SlurmctldCharm(CharmBase):
             }
 
         slurm_conf = SlurmConfig(
-            ClusterName=self.cluster_name,
+            ClusterName=self._cluster_name,
             SlurmctldAddr=self._slurmd_ingress_address,
             SlurmctldHost=[self._slurmctld.hostname],
             SlurmctldParameters=_assemble_slurmctld_parameters(),
@@ -377,7 +377,7 @@ class SlurmctldCharm(CharmBase):
         self._slurmctld.scontrol(update_cmd)
 
     @property
-    def cluster_name(self) -> str:
+    def _cluster_name(self) -> str:
         """Return the cluster name."""
         cluster_name = "charmedhpc"
         if cluster_name_from_config := self.config.get("cluster-name"):

--- a/charms/slurmctld/src/interface_slurmd.py
+++ b/charms/slurmctld/src/interface_slurmd.py
@@ -89,7 +89,6 @@ class Slurmd(Object):
             {
                 "munge_key": self._charm.get_munge_key(),
                 "slurmctld_host": self._charm.hostname,
-                "cluster_name": self._charm.cluster_name,
                 "nhc_params": health_check_params,
             }
         )

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -34,12 +34,12 @@ class TestCharm(TestCase):
         self.harness.begin()
 
     def test_cluster_name(self) -> None:
-        """Test that the cluster_name property works."""
-        self.assertEqual(self.harness.charm.cluster_name, "osd-cluster")
+        """Test that the _cluster_name property works."""
+        self.assertEqual(self.harness.charm._cluster_name, "osd-cluster")
 
     def test_cluster_info(self) -> None:
         """Test the cluster_info property works."""
-        self.assertEqual(type(self.harness.charm.cluster_name), str)
+        self.assertEqual(type(self.harness.charm._cluster_name), str)
 
     def test_is_slurm_installed(self) -> None:
         """Test that the is_slurm_installed method works."""

--- a/charms/slurmd/src/interface_slurmctld.py
+++ b/charms/slurmd/src/interface_slurmctld.py
@@ -24,14 +24,12 @@ class SlurmctldAvailableEvent(EventBase):
     def __init__(
         self,
         handle,
-        cluster_name,
         munge_key,
         nhc_params,
         slurmctld_host,
     ):
         super().__init__(handle)
 
-        self.cluster_name = cluster_name
         self.munge_key = munge_key
         self.nhc_params = nhc_params
         self.slurmctld_host = slurmctld_host
@@ -39,7 +37,6 @@ class SlurmctldAvailableEvent(EventBase):
     def snapshot(self):
         """Snapshot the event data."""
         return {
-            "cluster_name": self.cluster_name,
             "munge_key": self.munge_key,
             "nhc_params": self.nhc_params,
             "slurmctld_host": self.slurmctld_host,
@@ -47,7 +44,6 @@ class SlurmctldAvailableEvent(EventBase):
 
     def restore(self, snapshot):
         """Restore the snapshot of the event data."""
-        self.cluster_name = snapshot.get("cluster_name")
         self.munge_key = snapshot.get("munge_key")
         self.nhc_params = snapshot.get("nhc_params")
         self.slurmctld_host = snapshot.get("slurmctld_host")


### PR DESCRIPTION
These changes remove the unused "cluster_name" from the relation data sent to `slurmd` on the `slurmd` relation. Additionally, make the "cluster_name" property private.