### PR TITLE
enhancement(slurmctld): Make slurm respect memory constraints

### DIFF
--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -101,7 +101,6 @@ config:
         ConstrainDevices=yes
         ConstrainRAMSpace=yes
         ConstrainSwapSpace=yes
-        SignalChildrenProcesses=yes
       description: |
         User supplied configuration for `cgroup.conf`.
 

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -36,6 +36,10 @@ provides:
     interface: cos_agent
     limit: 1
 
+peers:
+  slurmctld-peer:
+    interface: slurmctld-peer
+
 assumes:
   - juju
 

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -67,7 +67,7 @@ config:
   options:
     cluster-name:
       type: string
-      default: osd-cluster
+      default: "osd-cluster"
       description: |
         Name to be recorded in database for jobs from this cluster.
 

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -101,6 +101,7 @@ config:
         ConstrainDevices=yes
         ConstrainRAMSpace=yes
         ConstrainSwapSpace=yes
+        SignalChildrenProcesses=yes
       description: |
         User supplied configuration for `cgroup.conf`.
 

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -302,7 +302,7 @@ class SlurmctldCharm(CharmBase):
             }
 
         slurm_conf = SlurmConfig(
-            ClusterName=self.cluster_name,
+            ClusterName=self._cluster_name,
             SlurmctldAddr=self._slurmd_ingress_address,
             SlurmctldHost=[self._slurmctld.hostname],
             SlurmctldParameters=_assemble_slurmctld_parameters(),
@@ -377,7 +377,7 @@ class SlurmctldCharm(CharmBase):
         self._slurmctld.scontrol(update_cmd)
 
     @property
-    def cluster_name(self) -> str:
+    def _cluster_name(self) -> str:
         """Return the cluster name."""
         cluster_name = "charmedhpc"
         if cluster_name_from_config := self.config.get("cluster-name"):

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -18,6 +18,7 @@ CHARM_MAINTAINED_SLURM_CONF_PARAMETERS = {
     "PluginDir": ["/usr/lib/x86_64-linux-gnu/slurm-wlm"],
     "PlugStackConfig": "/etc/slurm/plugstack.conf.d/plugstack.conf",
     "SelectType": "select/cons_tres",
+    "SelectTypeParameters": "CR_CPU_Memory",
     "SlurmctldPort": "6817",
     "SlurmdPort": "6818",
     "StateSaveLocation": "/var/lib/slurm/checkpoint",

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -3,6 +3,8 @@
 
 """This module provides constants for the slurmctld-operator charm."""
 
+PEER_RELATION = "slurmctld-peer"
+
 CHARM_MAINTAINED_SLURM_CONF_PARAMETERS = {
     "AuthAltParameters": {"jwt_key": "/var/lib/slurm/checkpoint/jwt_hs256.key"},
     "AuthAltTypes": ["auth/jwt"],

--- a/charms/slurmctld/src/exceptions.py
+++ b/charms/slurmctld/src/exceptions.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Omnivector Corp
+# See LICENSE file for licensing details.
+
+"""Custom exceptions for the slurmctld operator."""
+
+
+class IngressAddressUnavailableError(Exception):
+    """Exception raised when a slurm operation failed."""
+
+    @property
+    def message(self) -> str:
+        """Return message passed as argument to exception."""
+        return self.args[0]

--- a/charms/slurmctld/src/interface_slurmd.py
+++ b/charms/slurmctld/src/interface_slurmd.py
@@ -89,7 +89,6 @@ class Slurmd(Object):
             {
                 "munge_key": self._charm.get_munge_key(),
                 "slurmctld_host": self._charm.hostname,
-                "cluster_name": self._charm.cluster_name,
                 "nhc_params": health_check_params,
             }
         )

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -160,6 +160,7 @@ class TestCharm(TestCase):
     def test_get_user_supplied_parameters(self, *_) -> None:
         """Test that user supplied parameters are parsed correctly."""
         self.harness.add_relation("slurmd", "slurmd")
+        self.harness.add_relation("slurmctld-peer", self.harness.charm.app.name)
         self.harness.update_config(
             {"slurm-conf-parameters": "JobAcctGatherFrequency=task=30,network=40"}
         )

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -34,12 +34,12 @@ class TestCharm(TestCase):
         self.harness.begin()
 
     def test_cluster_name(self) -> None:
-        """Test that the cluster_name property works."""
-        self.assertEqual(self.harness.charm.cluster_name, "osd-cluster")
+        """Test that the _cluster_name property works."""
+        self.assertEqual(self.harness.charm._cluster_name, "osd-cluster")
 
     def test_cluster_info(self) -> None:
         """Test the cluster_info property works."""
-        self.assertEqual(type(self.harness.charm.cluster_name), str)
+        self.assertEqual(type(self.harness.charm._cluster_name), str)
 
     def test_is_slurm_installed(self) -> None:
         """Test that the is_slurm_installed method works."""

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -7,7 +7,6 @@
 import logging
 from typing import Any, Dict, cast
 
-from constants import CHARM_MAINTAINED_NODE_PARAMETERS
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent
 from ops import (
     ActionEvent,

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -7,6 +7,7 @@
 import logging
 from typing import Any, Dict, cast
 
+from constants import CHARM_MAINTAINED_NODE_PARAMETERS
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent
 from ops import (
     ActionEvent,
@@ -326,6 +327,7 @@ class SlurmdCharm(CharmBase):
         node = {
             "node_parameters": {
                 **machine.get_slurmd_info(),
+                **CHARM_MAINTAINED_NODE_PARAMETERS,
                 **self._user_supplied_node_parameters,
             },
             "new_node": self._new_node,

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -327,7 +327,7 @@ class SlurmdCharm(CharmBase):
         node = {
             "node_parameters": {
                 **machine.get_slurmd_info(),
-                **CHARM_MAINTAINED_NODE_PARAMETERS,
+                "MemSpecLimit": "1024",
                 **self._user_supplied_node_parameters,
             },
             "new_node": self._new_node,

--- a/charms/slurmd/src/constants.py
+++ b/charms/slurmd/src/constants.py
@@ -1,6 +1,0 @@
-# Copyright 2024 Omnivector, LLC.
-# See LICENSE file for licensing details.
-
-"""This module provides constants for the slurmd-operator charm."""
-
-CHARM_MAINTAINED_NODE_PARAMETERS = {"MemSpecLimit": "1024"}

--- a/charms/slurmd/src/constants.py
+++ b/charms/slurmd/src/constants.py
@@ -1,0 +1,6 @@
+# Copyright 2024 Omnivector, LLC.
+# See LICENSE file for licensing details.
+
+"""This module provides constants for the slurmd-operator charm."""
+
+CHARM_MAINTAINED_NODE_PARAMETERS = {"MemSpecLimit": "1024"}

--- a/charms/slurmd/src/interface_slurmctld.py
+++ b/charms/slurmd/src/interface_slurmctld.py
@@ -24,14 +24,12 @@ class SlurmctldAvailableEvent(EventBase):
     def __init__(
         self,
         handle,
-        cluster_name,
         munge_key,
         nhc_params,
         slurmctld_host,
     ):
         super().__init__(handle)
 
-        self.cluster_name = cluster_name
         self.munge_key = munge_key
         self.nhc_params = nhc_params
         self.slurmctld_host = slurmctld_host
@@ -39,7 +37,6 @@ class SlurmctldAvailableEvent(EventBase):
     def snapshot(self):
         """Snapshot the event data."""
         return {
-            "cluster_name": self.cluster_name,
             "munge_key": self.munge_key,
             "nhc_params": self.nhc_params,
             "slurmctld_host": self.slurmctld_host,
@@ -47,7 +44,6 @@ class SlurmctldAvailableEvent(EventBase):
 
     def restore(self, snapshot):
         """Restore the snapshot of the event data."""
-        self.cluster_name = snapshot.get("cluster_name")
         self.munge_key = snapshot.get("munge_key")
         self.nhc_params = snapshot.get("nhc_params")
         self.slurmctld_host = snapshot.get("slurmctld_host")


### PR DESCRIPTION
These changes introduce default values for `SelectTypeParameters` and `MemSpecLimit`.

`SelectTypeParameters=CR_CPU_Memory` to enable memory allocation enforcement.

`MemSpecLimit=1024` to ensure systems always have 1G available memory that jobs cannot consume.

Fixes: #36 