### PR TITLE
fix(ci): initialize lxd before packing charm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,10 @@ jobs:
         run: pipx install tox
       - name: Stage charm
         run: tox run -e stage -- ${{ matrix.charm }} --clean
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: 5.21/stable
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:


### PR DESCRIPTION
The `upload-charm` action does not initialize LXD which will cause the worklflow to fail if destructive-mode is set to false.

This PR is a follow-on fix for https://github.com/charmed-hpc/slurm-charms/pull/42 since the `upload-charm` action doesn't set up LXD itself.