### PR TITLE
chore(slurmctld): charm maintained cgroup config

### DIFF
--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -96,11 +96,7 @@ config:
 
     cgroup-parameters:
       type: string
-      default: |
-        ConstrainCores=yes
-        ConstrainDevices=yes
-        ConstrainRAMSpace=yes
-        ConstrainSwapSpace=yes
+      default: ""
       description: |
         User supplied configuration for `cgroup.conf`.
 

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -5,6 +5,13 @@
 
 PEER_RELATION = "slurmctld-peer"
 
+CHARM_MAINTAINED_CGROUP_CONF_PARAMETERS = {
+    "ConstrainCores": "yes",
+    "ConstrainDevices": "yes",
+    "ConstrainRAMSpace": "yes",
+    "ConstrainSwapSpace": "yes",
+}
+
 CHARM_MAINTAINED_SLURM_CONF_PARAMETERS = {
     "AuthAltParameters": {"jwt_key": "/var/lib/slurm/checkpoint/jwt_hs256.key"},
     "AuthAltTypes": ["auth/jwt"],


### PR DESCRIPTION
These changes move the cgroup config to the charm constants.py.