### PR TITLE
systemd start/stop and enable/disable

### DIFF
--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -108,9 +108,12 @@ class SlurmctldCharm(CharmBase):
                 self._stored.jwt_rsa = self._slurmctld.jwt.get()
                 self._slurmctld.munge.key.generate()
                 self._stored.munge_key = self._slurmctld.munge.key.get()
-                self._slurmctld.munge.service.restart()
-                self._slurmctld.service.restart()
+                self._slurmctld.munge.service.enable()
+                self._slurmctld.munge.service.start()
+                self._slurmctld.service.enable()
+                self._slurmctld.service.start()
                 self._slurmctld.exporter.service.enable()
+                self._slurmctld.exporter.service.start()
                 self.unit.set_workload_version(self._slurmctld.version())
 
                 self.slurm_installed = True
@@ -236,7 +239,7 @@ class SlurmctldCharm(CharmBase):
             return
 
         if slurm_config := self._assemble_slurm_conf():
-            self._slurmctld.service.disable()
+            self._slurmctld.service.stop()
             self._slurmctld.config.dump(slurm_config)
 
             # Write out any cgroup parameters to /etc/slurm/cgroup.conf.
@@ -246,7 +249,7 @@ class SlurmctldCharm(CharmBase):
                     cgroup_config.update(user_supplied_cgroup_params)
                 self._slurmctld.cgroup.dump(CgroupConfig(**cgroup_config))
 
-            self._slurmctld.service.enable()
+            self._slurmctld.service.start()
             self._slurmctld.scontrol("reconfigure")
 
             # Transitioning Nodes


### PR DESCRIPTION
These changes use systemd stop/start commands to facilitate the stop/start of the slurmctld daemon and remove the --now flag from the enable and disable commands..