### PR TITLE
fix(slurmctld): fix node-configured action

### DIFF
--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -389,9 +389,7 @@ class SlurmctldCharm(CharmBase):
 
     def _resume_nodes(self, nodelist: List[str]) -> None:
         """Run scontrol to resume the specified node list."""
-        nodes = ",".join(nodelist)
-        update_cmd = f"update nodename={nodes} state=resume"
-        self._slurmctld.scontrol(*shlex.split(update_cmd))
+        self._slurmctld.scontrol("update", f"nodename={','.join(nodelist)}", "state=resume")
 
     @property
     def _cluster_name(self) -> str:

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -391,7 +391,7 @@ class SlurmctldCharm(CharmBase):
         """Run scontrol to resume the specified node list."""
         nodes = ",".join(nodelist)
         update_cmd = f"update nodename={nodes} state=resume"
-        self._slurmctld.scontrol(update_cmd)
+        self._slurmctld.scontrol(*shlex.split(update_cmd))
 
     @property
     def _cluster_name(self) -> str:

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -168,3 +168,12 @@ class TestCharm(TestCase):
             self.harness.charm._assemble_slurm_conf().job_acct_gather_frequency,
             "task=30,network=40",
         )
+
+    def test_resume_nodes_valid_input(self) -> None:
+        """Test that the _resume_nodes method provides a valid scontrol command."""
+        self.harness.charm._slurmctld.scontrol = Mock()
+        self.harness.charm._resume_nodes(["juju-123456-1", "tester-node", "node-three"])
+        args, _ = self.harness.charm._slurmctld.scontrol.call_args
+        self.assertEqual(
+            args, ("update", "nodename=juju-123456-1,tester-node,node-three", "state=resume")
+        )


### PR DESCRIPTION
This PR splits the argument passed to `_slurmctld.scontrol` in `_resume_nodes` to fix a subsequent erroneous subprocess.run call in hpc-libs. Specifically, subprocess.run was being passed:

` ['scontrol', 'update nodename=<nodes> state=resume']`

rather than (the now corrected):

` ['scontrol', 'update', 'nodename=<nodes>', 'state=resume']`

A unit test for `_resume_nodes` has also been added.

This fixes `juju run slurmd/<id> node-configured` so `hook failed: "slurmd-relation-changed"` is no longer reported. Edit: Added the relevant log lines for the hook failure from the `slurmctld/0` log `/var/log/juju/unit-slurmctld-0.log`:

<details>

<summary>/var/log/juju/unit-slurmctld-0.log reported failure</summary>

```
2024-12-06 09:24:49 ERROR unit.slurmctld/0.juju-log server.go:325 slurmd:0: command ['scontrol', 'update nodename=juju-b8248f-1 state=resume'] failed with message invalid keyword: update nodename=juju-b8248f-1 state=resume

2024-12-06 09:24:49 ERROR unit.slurmctld/0.juju-log server.go:325 slurmd:0: Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/./src/charm.py", line 427, in <module>
    main.main(SlurmctldCharm)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/main.py", line 551, in main
    manager.run()
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/main.py", line 530, in run
    self._emit()
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/main.py", line 519, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/main.py", line 147, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/framework.py", line 348, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/framework.py", line 860, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/framework.py", line 950, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/src/interface_slurmd.py", line 134, in _on_relation_changed
    self.on.partition_available.emit()
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/framework.py", line 348, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/framework.py", line 860, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/venv/ops/framework.py", line 950, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/./src/charm.py", line 265, in _on_write_slurm_conf
    self._resume_nodes(transitioning_nodes)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/./src/charm.py", line 379, in _resume_nodes
    self._slurmctld.scontrol(update_cmd)
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/lib/charms/hpc_libs/v0/slurm_ops.py", line 891, in scontrol
    return _call("scontrol", *args).stdout
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/juju/agents/unit-slurmctld-0/charm/lib/charms/hpc_libs/v0/slurm_ops.py", line 141, in _call
    raise SlurmOpsError(f"command {cmd} failed. stderr:\n{result.stderr}")
charms.hpc_libs.v0.slurm_ops.SlurmOpsError: command ['scontrol', 'update nodename=juju-b8248f-1 state=resume'] failed. stderr:
invalid keyword: update nodename=juju-b8248f-1 state=resume
```

</details>

<details>

<summary>Hook Failure Reproducer Steps</summary>

```
$ juju deploy slurmctld --constraints="virt-type=virtual-machine" --channel "edge"
$ juju deploy slurmd --constraints="virt-type=virtual-machine" --channel "edge"
$ juju integrate slurmctld:slurmd slurmd:slurmctld
$ juju run slurmd/0 node-configured
$ juju status
(slurmctld/0* reports hook failed: "slurmd-relation-changed")
```

</details>