### PR TITLE
feat(all)!: upgrade Slurm charms to Noble

### DIFF
--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -44,28 +44,15 @@ assumes:
   - juju
 
 type: charm
-bases:
-  - build-on:
-      - name: ubuntu
-        channel: "22.04"
-    run-on:
-      - name: ubuntu
-        channel: "22.04"
-        architectures: [amd64]
+base: ubuntu@24.04
+platforms:
+  amd64:
 
 parts:
   charm:
-    charm-requirements: ["requirements.txt"]
-    override-build: |
-      cp /usr/bin/rustc-1.80 /usr/bin/rustc
-      craftctl default
-    build-packages:
-      - libffi-dev
-      - libssl-dev
-      - rustc-1.80
-      - cargo
-      - pkg-config
-      - git
+    charm-binary-python-packages:
+      - cryptography ~= 44.0.0
+      - pydantic
 
 config:
   options:

--- a/charms/slurmctld/requirements.txt
+++ b/charms/slurmctld/requirements.txt
@@ -1,3 +1,3 @@
 ops==2.15.0
 distro==1.9.0
-slurmutils~=0.8.0
+slurmutils~=0.9.0

--- a/charms/slurmd/charmcraft.yaml
+++ b/charms/slurmd/charmcraft.yaml
@@ -1,5 +1,4 @@
 name: slurmd
-type: charm
 
 summary: |
   Slurmd, the compute node daemon of Slurm.
@@ -24,28 +23,15 @@ links:
 assumes:
   - juju
 
-bases:
-  - build-on:
-      - name: ubuntu
-        channel: "22.04"
-    run-on:
-      - name: ubuntu
-        channel: "22.04"
-        architectures: [amd64]
+type: charm
+base: ubuntu@24.04
+platforms:
+  amd64:
 
 parts:
   charm:
-    charm-requirements: [ "requirements.txt" ]
-    override-build: |
-      cp /usr/bin/rustc-1.80 /usr/bin/rustc
-      craftctl default
-    build-packages:
-      - libffi-dev
-      - libssl-dev
-      - rustc-1.80
-      - cargo
-      - pkg-config
-      - git
+    charm-binary-python-packages:
+      - cryptography ~= 44.0.0
   nhc:
     plugin: nil
     build-packages:

--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -1,7 +1,7 @@
 # Copyright 2020-2024 Omnivector, LLC.
 # See LICENSE file for licensing details.
+
 name: slurmdbd
-type: charm
 
 assumes:
   - juju
@@ -25,28 +25,15 @@ links:
   source:
   - https://github.com/charmed-hpc/slurm-charms
 
-bases:
-  - build-on:
-      - name: ubuntu
-        channel: "22.04"
-    run-on:
-      - name: ubuntu
-        channel: "22.04"
-        architectures: [amd64]
+type: charm
+base: ubuntu@24.04
+platforms:
+  amd64:
 
 parts:
   charm:
-    charm-requirements: ["requirements.txt"]
-    override-build: |
-      cp /usr/bin/rustc-1.80 /usr/bin/rustc
-      craftctl default
-    build-packages:
-      - libffi-dev
-      - libssl-dev
-      - rustc-1.80
-      - cargo
-      - pkg-config
-      - git
+    charm-binary-python-packages:
+      - cryptography ~= 44.0.0
 
 requires:
   database:

--- a/charms/slurmdbd/requirements.txt
+++ b/charms/slurmdbd/requirements.txt
@@ -1,3 +1,3 @@
 ops==2.15.0
 distro==1.9.0
-slurmutils~=0.8.0
+slurmutils~=0.9.0

--- a/charms/slurmrestd/charmcraft.yaml
+++ b/charms/slurmrestd/charmcraft.yaml
@@ -23,28 +23,14 @@ assumes:
   - juju
 
 type: charm
-bases:
-  - build-on:
-      - name: ubuntu
-        channel: "22.04"
-    run-on:
-      - name: ubuntu
-        channel: "22.04"
-        architectures: [amd64]
+base: ubuntu@24.04
+platforms:
+  amd64:
 
 parts:
   charm:
-    charm-requirements: ["requirements.txt"]
-    override-build: |
-      cp /usr/bin/rustc-1.80 /usr/bin/rustc
-      craftctl default
-    build-packages:
-      - libffi-dev
-      - libssl-dev
-      - rustc-1.80
-      - cargo
-      - pkg-config
-      - git
+    charm-binary-python-packages:
+      - cryptography ~= 44.0.0
 
 provides:
   slurmctld:

--- a/charms/slurmrestd/requirements.txt
+++ b/charms/slurmrestd/requirements.txt
@@ -1,3 +1,3 @@
 ops==2.15.0
 distro==1.9.0
-slurmutils~=0.8.0
+slurmutils~=0.9.0

--- a/external/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/external/lib/charms/grafana_agent/v0/cos_agent.py
@@ -22,7 +22,6 @@ this charm library.
 Using the `COSAgentProvider` object only requires instantiating it,
 typically in the `__init__` method of your charm (the one which sends telemetry).
 
-The constructor of `COSAgentProvider` has only one required and ten optional parameters:
 
 ```python
     def __init__(
@@ -253,7 +252,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["cosl", "pydantic"]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ cryptography~=43.0.1
 distro==1.9.0
 python-dotenv~=1.0.1
 pycryptodome==3.20.0
-slurmutils~=0.8.0
+slurmutils~=0.9.0
 dbus-fast>=1.90.2
 pyfakefs==5.7.1
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -79,13 +79,16 @@ async def test_build_and_deploy_against_edge(
             num_units=1,
             base=charm_base,
         ),
-        ops_test.model.deploy(
-            ROUTER,
-            application_name=f"{SLURMDBD}-{ROUTER}",
-            channel="dpe/edge",
-            num_units=0,
-            base=charm_base,
-        ),
+        # TODO:
+        #   Re-enable `mysql-router` in the integration tests once `dpe/edge`
+        #   channel supports the `ubuntu@24.04` base.
+        # ops_test.model.deploy(
+        #     ROUTER,
+        #     application_name=f"{SLURMDBD}-{ROUTER}",
+        #     channel="dpe/edge",
+        #     num_units=0,
+        #     base=charm_base,
+        # ),
         ops_test.model.deploy(
             DATABASE,
             application_name=DATABASE,
@@ -98,8 +101,8 @@ async def test_build_and_deploy_against_edge(
     await ops_test.model.integrate(f"{SLURMCTLD}:{SLURMD}", f"{SLURMD}:{SLURMCTLD}")
     await ops_test.model.integrate(f"{SLURMCTLD}:{SLURMDBD}", f"{SLURMDBD}:{SLURMCTLD}")
     await ops_test.model.integrate(f"{SLURMCTLD}:{SLURMRESTD}", f"{SLURMRESTD}:{SLURMCTLD}")
-    await ops_test.model.integrate(f"{SLURMDBD}-{ROUTER}:backend-database", f"{DATABASE}:database")
-    await ops_test.model.integrate(f"{SLURMDBD}:database", f"{SLURMDBD}-{ROUTER}:database")
+    # await ops_test.model.integrate(f"{SLURMDBD}-{ROUTER}:backend-database", f"{DATABASE}:database")
+    await ops_test.model.integrate(f"{SLURMDBD}:database", f"{DATABASE}:database")
     # Reduce the update status frequency to accelerate the triggering of deferred events.
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=SLURM_APPS, status="active", timeout=1000)


### PR DESCRIPTION
This PR upgrades the Slurm charms to Noble from Jammy. We get several benefits from this such as access to a newer base and package versions + more recent hardware support.

BREAKING CHANGES:

1. The Slurm charms no longer use the PPA `ppa:ubuntu-hpc/slurm-wlm-23.02` to install Slurm. Instead Slurm is pulled directly from the Ubuntu Archive. This enables us to use Slurm 23.11. Newer versions of Slurm should be published to the experimental PPA `ppa:ubuntu-hpc/experimental` rather than create a separate PPA for the Slurm packages.
2. Speeds up charm builds by using the `charm-binary-python-paclages` directive in _charmcraft.yaml_. This pulls in pre-built versions of Rust-based packages such as `cryptography` and `pydantic` rather than compile them from source with `rustc`. This should drastically reduce the amount of time it takes to run integration tests.
3. Deactivates `mysql-router` in the integration test suite. The `mysql-router` subordinate charm does not yet support Noble, so instead we integrate directly with the `mysql` charm in the integration tests. `mysql-router` supporting Noble will likely not come until after the 25.04 cycle.
4. _charmcraft.yaml_ now uses the new `base`, `platforms` syntax that was introduced with charmcraft v3 for charms that support `ubuntu@24.04` and greater.