### PR TITLE
feat(ci): add `sackd` to release matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,18 +24,18 @@ jobs:
     uses: ./.github/workflows/ci.yaml
 
   release-to-charmhub:
-    name: Release to CharmHub
+    name: Release to Charmhub
     needs:
       - ci-tests
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: true
       matrix:
-        charm: [slurmctld, slurmd, slurmdbd, slurmrestd]
+        charm: [slurmctld, slurmd, slurmdbd, slurmrestd, sackd]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Select charmhub channel
+      - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.5.0-rc
         id: channel
       - name: Install tox
@@ -46,7 +46,7 @@ jobs:
         uses: canonical/setup-lxd@v0.1.2
         with:
           channel: 5.21/stable
-      - name: Upload charm to charmhub
+      - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"


### PR DESCRIPTION
This PR adds `sackd` to the charm release matrix in the "Release to latest/edge" workflow. This will ensure that `sackd` is published to Charmhub after each PR.

Also, treat `charmhub` as a proper noun in step names. `charmhub` -> `Charmhub`.