### PR TITLE
feat(all): add `base` and `constraints` config options to charm tf modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ version
 _build
 .charmhub.secret
 cover
+.terraform
+.terraform.lock.hcl
+*.tfstate*

--- a/charms/sackd/terraform/README.md
+++ b/charms/sackd/terraform/README.md
@@ -1,0 +1,50 @@
+# Terraform module for sackd
+
+This is a Terraform module facilitating the deployment of the sackd charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name          | Type        | Description                                              | Default      | Required |
+|---------------|-------------|----------------------------------------------------------|--------------|:--------:|
+| `app_name`    | string      | Application name                                         | sackd        |          |
+| `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
+| `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
+| `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
+| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
+| `revision`    | number      | Revision number of charm to deploy                       | null         |          |
+| `units`       | number      | Number of units to deploy                                | 1            |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `provides` | Map of `provides` endpoints |
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```

--- a/charms/sackd/terraform/main.tf
+++ b/charms/sackd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ resource "juju_application" "sackd" {
 
   charm {
     name     = "sackd"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }
 
-  config = var.config
-  units  = var.units
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
 }

--- a/charms/sackd/terraform/variables.tf
+++ b/charms/sackd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,35 +13,49 @@
 # limitations under the License.
 
 variable "app_name" {
-  description = "Name of the sackd application within the Juju model."
+  description = "Application name"
   type        = string
+  default     = "sackd"
+}
+
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
 }
 
 variable "channel" {
-  description = "Channel to deploy the sackd charm from."
+  description = "Charm channel"
   type        = string
   default     = "latest/edge"
 }
 
 variable "config" {
-  description = "Initial configuration for deployed sackd charm."
+  description = "Charm configuration"
   type        = map(string)
   default     = {}
 }
 
+variable "constraints" {
+  description = "Deployment constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
 variable "model_name" {
-  description = "Name of model to deploy sackd charm to."
+  description = "Model name"
   type        = string
 }
 
 variable "revision" {
-  description = "Revision of the sackd charm to deploy."
+  description = "Charm revision"
   type        = number
+  nullable    = true
   default     = null
 }
 
 variable "units" {
-  description = "Number of sackd units to deploy."
+  description = "Number of units"
   type        = number
   default     = 1
 }

--- a/charms/slurmctld/terraform/README.md
+++ b/charms/slurmctld/terraform/README.md
@@ -1,0 +1,50 @@
+# Terraform module for slurmctld
+
+This is a Terraform module facilitating the deployment of the slurmctld charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name          | Type        | Description                                              | Default      | Required |
+|---------------|-------------|----------------------------------------------------------|--------------|:--------:|
+| `app_name`    | string      | Application name                                         | slurmctld    |          |
+| `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
+| `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
+| `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
+| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
+| `revision`    | number      | Revision number of charm to deploy                       | null         |          |
+| `units`       | number      | Number of units to deploy                                | 1            |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `requires` | Map of `requires` endpoints |
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```

--- a/charms/slurmctld/terraform/main.tf
+++ b/charms/slurmctld/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ resource "juju_application" "slurmctld" {
 
   charm {
     name     = "slurmctld"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }
 
-  config = var.config
-  units  = var.units
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
 }

--- a/charms/slurmctld/terraform/variables.tf
+++ b/charms/slurmctld/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,35 +13,49 @@
 # limitations under the License.
 
 variable "app_name" {
-  description = "Name of the slurmctld application within the Juju model."
+  description = "Application name"
   type        = string
+  default = "slurmctld"
+}
+
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
 }
 
 variable "channel" {
-  description = "Channel to deploy the slurmctld charm from."
+  description = "Charm channel"
   type        = string
   default     = "latest/edge"
 }
 
 variable "config" {
-  description = "Initial configuration for deployed slurmctld charm."
+  description = "Charm configuration"
   type        = map(string)
   default     = {}
 }
 
+variable "constraints" {
+  description = "Deployment constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
 variable "model_name" {
-  description = "Name of model to deploy slurmctld charm to."
+  description = "Model name"
   type        = string
 }
 
 variable "revision" {
-  description = "Revision of the slurmctld charm to deploy."
+  description = "Charm revision"
   type        = number
+  nullable    = true
   default     = null
 }
 
 variable "units" {
-  description = "Number of slurmctld units to deploy."
+  description = "Number of units"
   type        = number
   default     = 1
 }

--- a/charms/slurmd/terraform/README.md
+++ b/charms/slurmd/terraform/README.md
@@ -1,0 +1,50 @@
+# Terraform module for slurmd
+
+This is a Terraform module facilitating the deployment of the slurmd charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name          | Type        | Description                                              | Default      | Required |
+|---------------|-------------|----------------------------------------------------------|--------------|:--------:|
+| `app_name`    | string      | Application name                                         | slurmd       |          |
+| `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
+| `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
+| `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
+| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
+| `revision`    | number      | Revision number of charm to deploy                       | null         |          |
+| `units`       | number      | Number of units to deploy                                | 1            |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `provides` | Map of `provides` endpoints |
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```

--- a/charms/slurmd/terraform/main.tf
+++ b/charms/slurmd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ resource "juju_application" "slurmd" {
 
   charm {
     name     = "slurmd"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }
 
-  config = var.config
-  units  = var.units
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
 }

--- a/charms/slurmd/terraform/variables.tf
+++ b/charms/slurmd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,35 +13,49 @@
 # limitations under the License.
 
 variable "app_name" {
-  description = "Name of the slurmd application within the Juju model."
+  description = "Application name"
   type        = string
+  default = "slurmd"
+}
+
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
 }
 
 variable "channel" {
-  description = "Channel to deploy the slurmd charm from."
+  description = "Charm channel"
   type        = string
   default     = "latest/edge"
 }
 
 variable "config" {
-  description = "Initial configuration for deployed slurmd charm."
+  description = "Charm configuration"
   type        = map(string)
   default     = {}
 }
 
+variable "constraints" {
+  description = "Deployment constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
 variable "model_name" {
-  description = "Name of model to deploy slurmd charm to."
+  description = "Model name"
   type        = string
 }
 
 variable "revision" {
-  description = "Revision of the slurmd charm to deploy."
+  description = "Charm revision"
   type        = number
+  nullable    = true
   default     = null
 }
 
 variable "units" {
-  description = "Number of slurmd units to deploy."
+  description = "Number of units"
   type        = number
   default     = 1
 }

--- a/charms/slurmdbd/terraform/README.md
+++ b/charms/slurmdbd/terraform/README.md
@@ -1,0 +1,52 @@
+# Terraform module for slurmdbd
+
+This is a Terraform module facilitating the deployment of the slurmdbd charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name          | Type        | Description                                              | Default      | Required |
+|---------------|-------------|----------------------------------------------------------|--------------|:--------:|
+| `app_name`    | string      | Application name                                         | slurmdbd     |          |
+| `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
+| `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
+| `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
+| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
+| `revision`    | number      | Revision number of charm to deploy                       | null         |          |
+| `units`       | number      | Number of units to deploy                                | 1            |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `provides` | Map of `provides` endpoints |
+| `requires` | Map of `requires` endpoints |
+
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```

--- a/charms/slurmdbd/terraform/main.tf
+++ b/charms/slurmdbd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@ resource "juju_application" "slurmdbd" {
   model = var.model_name
 
   charm {
-    name    = "slurmdbd"
-    channel = var.channel
+    name     = "slurmdbd"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
   }
 
-  config = var.config
-  units  = var.units
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
 }

--- a/charms/slurmdbd/terraform/variables.tf
+++ b/charms/slurmdbd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,35 +13,49 @@
 # limitations under the License.
 
 variable "app_name" {
-  description = "Name of the slurmdbd application within the Juju model."
+  description = "Application name"
   type        = string
+  default = "slurmdbd"
+}
+
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
 }
 
 variable "channel" {
-  description = "Channel to deploy the slurmdbd charm from."
+  description = "Charm channel"
   type        = string
   default     = "latest/edge"
 }
 
 variable "config" {
-  description = "Initial configuration for deployed slurmdbd charm."
+  description = "Charm configuration"
   type        = map(string)
   default     = {}
 }
 
+variable "constraints" {
+  description = "Deployment constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
 variable "model_name" {
-  description = "Name of model to deploy slurmdbd charm to."
+  description = "Model name"
   type        = string
 }
 
 variable "revision" {
-  description = "Revision of the slurmdbd charm to deploy."
+  description = "Charm revision"
   type        = number
+  nullable    = true
   default     = null
 }
 
 variable "units" {
-  description = "Number of slurmdbd units to deploy."
+  description = "Number of units"
   type        = number
   default     = 1
 }

--- a/charms/slurmrestd/terraform/README.md
+++ b/charms/slurmrestd/terraform/README.md
@@ -1,0 +1,50 @@
+# Terraform module for slurmrestd
+
+This is a Terraform module facilitating the deployment of the slurmrestd charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name          | Type        | Description                                              | Default      | Required |
+|---------------|-------------|----------------------------------------------------------|--------------|:--------:|
+| `app_name`    | string      | Application name                                         | slurmrestd   |          |
+| `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
+| `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
+| `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
+| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
+| `revision`    | number      | Revision number of charm to deploy                       | null         |          |
+| `units`       | number      | Number of units to deploy                                | 1            |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `provides` | Map of `provides` endpoints |
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```

--- a/charms/slurmrestd/terraform/main.tf
+++ b/charms/slurmrestd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@ resource "juju_application" "slurmrestd" {
   model = var.model_name
 
   charm {
-    name    = "slurmrestd"
-    channel = var.channel
+    name     = "slurmrestd"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
   }
 
-  config = var.config
-  units  = var.units
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
 }

--- a/charms/slurmrestd/terraform/variables.tf
+++ b/charms/slurmrestd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,35 +13,49 @@
 # limitations under the License.
 
 variable "app_name" {
-  description = "Name of the slurmrestd application within the Juju model"
+  description = "Application name"
   type        = string
+  default = "slurmrestd"
+}
+
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
 }
 
 variable "channel" {
-  description = "Channel to deploy the slurmrestd charm from."
+  description = "Charm channel"
   type        = string
   default     = "latest/edge"
 }
 
 variable "config" {
-  description = "Initial configuration for deployed slurmrestd charm."
+  description = "Charm configuration"
   type        = map(string)
   default     = {}
 }
 
+variable "constraints" {
+  description = "Deployment constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
 variable "model_name" {
-  description = "Name of model to deploy slurmrestd charm to."
+  description = "Model name"
   type        = string
 }
 
 variable "revision" {
-  description = "Revision of the slurmrestd charm to deploy."
+  description = "Charm revision"
   type        = number
+  nullable    = true
   default     = null
 }
 
 variable "units" {
-  description = "Number of slurmrestd units to deploy."
+  description = "Number of units"
   type        = number
   default     = 1
 }


### PR DESCRIPTION
This PR adds the `base` and `constraints` configuration options to the Slurm charm tf modules. This way we can specify different bases, and request specific instance types through OpenTofu/Terraform. This PR also adds READMEs for each of the modules to document both inputs and outputs.