### PR TITLE
Improve unit status reporting in `slurmd` install hook

### DIFF
--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -16,6 +16,7 @@ from ops import (
     CharmBase,
     ConfigChangedEvent,
     InstallEvent,
+    MaintenanceStatus,
     StoredState,
     UpdateStatusEvent,
     WaitingStatus,
@@ -82,13 +83,18 @@ class SlurmdCharm(CharmBase):
         # running kernel pending replacement by a newer version on reboot.
         self._reboot_if_required(now=True)
 
-        self.unit.status = WaitingStatus("installing slurmd")
+        self.unit.status = MaintenanceStatus("installing slurmd")
 
         try:
             self._slurmd.install()
+
+            self.unit.status = MaintenanceStatus("installing nhc")
             nhc.install()
             rdma.install()
+
+            self.unit.status = MaintenanceStatus("auto-detecting GPUs")
             gpu.autoinstall()
+
             self.unit.set_workload_version(self._slurmd.version())
             # TODO: https://github.com/orgs/charmed-hpc/discussions/10 -
             #  Evaluate if we should continue doing the service override here

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -90,6 +90,8 @@ class SlurmdCharm(CharmBase):
 
             self.unit.status = MaintenanceStatus("Installing nhc")
             nhc.install()
+
+            self.unit.status = MaintenanceStatus("Installing RDMA packages")
             rdma.install()
 
             self.unit.status = MaintenanceStatus("Detecting if machine is GPU-equipped")

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -83,21 +83,21 @@ class SlurmdCharm(CharmBase):
         # running kernel pending replacement by a newer version on reboot.
         self._reboot_if_required(now=True)
 
-        self.unit.status = MaintenanceStatus("installing slurmd")
+        self.unit.status = MaintenanceStatus("Installing slurmd")
 
         try:
             self._slurmd.install()
 
-            self.unit.status = MaintenanceStatus("installing nhc")
+            self.unit.status = MaintenanceStatus("Installing nhc")
             nhc.install()
             rdma.install()
 
-            self.unit.status = MaintenanceStatus("detecting if machine is GPU-equipped")
+            self.unit.status = MaintenanceStatus("Detecting if machine is GPU-equipped")
             gpu_enabled = gpu.autoinstall()
             if gpu_enabled:
-                self.unit.status = MaintenanceStatus("successfully installed GPU drivers")
+                self.unit.status = MaintenanceStatus("Successfully installed GPU drivers")
             else:
-                self.unit.status = MaintenanceStatus("no GPUs found. continuing")
+                self.unit.status = MaintenanceStatus("No GPUs found. Continuing")
 
             self.unit.set_workload_version(self._slurmd.version())
             # TODO: https://github.com/orgs/charmed-hpc/discussions/10 -
@@ -321,7 +321,7 @@ class SlurmdCharm(CharmBase):
         - munge key configured and working
         """
         if self._stored.slurm_installed is not True:
-            self.unit.status = BlockedStatus("install failed. see logs for further details")
+            self.unit.status = BlockedStatus("Install failed. See `juju debug-log` for details")
             return False
 
         if self._slurmctld.is_joined is not True:

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -93,8 +93,8 @@ class SlurmdCharm(CharmBase):
             rdma.install()
 
             self.unit.status = MaintenanceStatus("detecting if machine is GPU-equipped")
-            installed_packages = gpu.autoinstall()
-            if len(installed_packages) > 0:
+            gpu_enabled = gpu.autoinstall()
+            if gpu_enabled:
                 self.unit.status = MaintenanceStatus("successfully installed GPU drivers")
             else:
                 self.unit.status = MaintenanceStatus("no GPUs found. continuing")

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -92,7 +92,7 @@ class SlurmdCharm(CharmBase):
             nhc.install()
             rdma.install()
 
-            self.unit.status = MaintenanceStatus("auto-detecting GPUs")
+            self.unit.status = MaintenanceStatus("detecting GPUs, installing drivers as needed")
             gpu.autoinstall()
 
             self.unit.set_workload_version(self._slurmd.version())

--- a/charms/slurmd/src/utils/gpu.py
+++ b/charms/slurmd/src/utils/gpu.py
@@ -77,8 +77,11 @@ class GPUDriverDetector:
         return [p for p in install_packages if p]
 
 
-def autoinstall() -> None:
+def autoinstall() -> list[str]:
     """Autodetect available GPUs and install drivers.
+
+    Returns:
+        The list of driver packages installed.
 
     Raises:
         GPUOpsError: Raised if error is encountered during package install.
@@ -89,13 +92,15 @@ def autoinstall() -> None:
 
     if len(install_packages) == 0:
         _logger.info("no GPU drivers requiring installation")
-        return
+        return install_packages
 
     _logger.info("installing GPU driver packages: %s", install_packages)
     try:
         apt.add_package(install_packages)
     except (apt.PackageNotFoundError, apt.PackageError) as e:
         raise GPUOpsError(f"failed to install packages {install_packages}. reason: {e}")
+
+    return install_packages
 
 
 def get_all_gpu() -> dict[str, list[int]]:

--- a/charms/slurmd/src/utils/gpu.py
+++ b/charms/slurmd/src/utils/gpu.py
@@ -77,11 +77,11 @@ class GPUDriverDetector:
         return [p for p in install_packages if p]
 
 
-def autoinstall() -> list[str]:
+def autoinstall() -> bool:
     """Autodetect available GPUs and install drivers.
 
     Returns:
-        The list of driver packages installed.
+        True if drivers were installed, False otherwise.
 
     Raises:
         GPUOpsError: Raised if error is encountered during package install.
@@ -92,7 +92,7 @@ def autoinstall() -> list[str]:
 
     if len(install_packages) == 0:
         _logger.info("no GPU drivers requiring installation")
-        return install_packages
+        return False
 
     _logger.info("installing GPU driver packages: %s", install_packages)
     try:
@@ -100,7 +100,7 @@ def autoinstall() -> list[str]:
     except (apt.PackageNotFoundError, apt.PackageError) as e:
         raise GPUOpsError(f"failed to install packages {install_packages}. reason: {e}")
 
-    return install_packages
+    return True
 
 
 def get_all_gpu() -> dict[str, list[int]]:

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -91,7 +91,7 @@ class TestCharm(TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            BlockedStatus("install failed. see logs for further details"),
+            BlockedStatus("Install failed. See `juju debug-log` for details"),
         )
         self.assertFalse(self.harness.charm._stored.slurm_installed)
         defer.assert_called()
@@ -185,5 +185,5 @@ class TestCharm(TestCase):
         self.harness.charm.on.update_status.emit()
         self.assertEqual(
             self.harness.charm.unit.status,
-            BlockedStatus("install failed. see logs for further details"),
+            BlockedStatus("Install failed. See `juju debug-log` for details"),
         )

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -91,7 +91,7 @@ class TestCharm(TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            BlockedStatus("failed to install slurmd. see logs for further details"),
+            BlockedStatus("install failed. see logs for further details"),
         )
         self.assertFalse(self.harness.charm._stored.slurm_installed)
         defer.assert_called()
@@ -185,5 +185,5 @@ class TestCharm(TestCase):
         self.harness.charm.on.update_status.emit()
         self.assertEqual(
             self.harness.charm.unit.status,
-            BlockedStatus("failed to install slurmd. see logs for further details"),
+            BlockedStatus("install failed. see logs for further details"),
         )


### PR DESCRIPTION
Adds additional status messages as `slurmd` installs to better inform users of progress.

Changes [`WaitingStatus`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.WaitingStatus) to [`MaintenanceStatus`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.MaintenanceStatus) to follow ops docs recommendations that the former be used for waiting for "activity on related units, not on this unit" and the latter for "when the charm is performing an operation such as `apt install`".

@AshleyCliff thoughts on status messages would be appreciated!