### PR TITLE
feat(slurmd): enable Infiniband RDMA support

### DIFF
--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -23,7 +23,7 @@ from ops import (
 )
 from slurmutils import calculate_rs
 from slurmutils.models.option import NodeOptionSet, PartitionOptionSet
-from utils import gpu, machine, nhc, service
+from utils import gpu, machine, nhc, rdma, service
 
 from charms.hpc_libs.v0.slurm_ops import SlurmdManager, SlurmOpsError
 from charms.operator_libs_linux.v0.juju_systemd_notices import (  # type: ignore[import-untyped]
@@ -87,6 +87,7 @@ class SlurmdCharm(CharmBase):
         try:
             self._slurmd.install()
             nhc.install()
+            rdma.install()
             gpu.autoinstall()
             self.unit.set_workload_version(self._slurmd.version())
             # TODO: https://github.com/orgs/charmed-hpc/discussions/10 -

--- a/charms/slurmd/src/utils/rdma.py
+++ b/charms/slurmd/src/utils/rdma.py
@@ -41,7 +41,7 @@ def _install_rdma() -> None:
         raise RDMAOpsError(f"failed to install packages {install_packages}. reason: {e}")
 
 
-def _override_opmi_conf() -> None:
+def _override_ompi_conf() -> None:
     """Re-enable UCX/UCT transport protocol by overriding system OpenMPI configuration.
 
     Notes:
@@ -89,4 +89,4 @@ def install() -> None:
         RDMAOpsError: Raised if error is encountered during package install.
     """
     _install_rdma()
-    _override_opmi_conf()
+    _override_ompi_conf()

--- a/charms/slurmd/src/utils/rdma.py
+++ b/charms/slurmd/src/utils/rdma.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manage RDMA packages on compute nodes."""
+
+import logging
+
+import charms.operator_libs_linux.v0.apt as apt
+
+_logger = logging.getLogger(__name__)
+
+
+class RDMAOpsError(Exception):
+    """Exception raised when an RDMA package installation operation failed."""
+
+    @property
+    def message(self) -> str:
+        """Return message passed as argument to exception."""
+        return self.args[0]
+
+
+def install() -> None:
+    """Install RDMA packages.
+
+    Raises:
+        RDMAOpsError: Raised if error is encountered during package install.
+    """
+    install_packages = ["rdma-core", "infiniband-diags"]
+    _logger.info("installing RDMA packages: %s", install_packages)
+    try:
+        apt.add_package(install_packages)
+    except (apt.PackageNotFoundError, apt.PackageError) as e:
+        raise RDMAOpsError(f"failed to install packages {install_packages}. reason: {e}")

--- a/charms/slurmd/src/utils/rdma.py
+++ b/charms/slurmd/src/utils/rdma.py
@@ -37,8 +37,50 @@ def install() -> None:
         RDMAOpsError: Raised if error is encountered during package install.
     """
     install_packages = ["rdma-core", "infiniband-diags"]
+
     _logger.info("installing RDMA packages: %s", install_packages)
     try:
         apt.add_package(install_packages)
     except (apt.PackageNotFoundError, apt.PackageError) as e:
         raise RDMAOpsError(f"failed to install packages {install_packages}. reason: {e}")
+
+    # Re-enable UCX/UCT.
+    # The OpenMPI package from archive includes a Debian patch that disables UCX to silence
+    # warnings when running on systems without RDMA hardware. This leads to the less performant
+    # "ob1" method being selected on Infiniband-enabled systems. By default, OpenMPI selects UCX
+    # when Infiniband devices are available. This default functionality is restored here.
+    #
+    # See:
+    # https://sources.debian.org/src/openmpi/4.1.4-3/debian/patches/no-warning-unused.patch/#L24
+    # https://github.com/open-mpi/ompi/issues/8367
+    # https://github.com/open-mpi/ompi/blob/v4.1.x/README#L763
+    path = "/etc/openmpi/openmpi-mca-params.conf"
+    _logger.info("enabling OpenMPI UCX transport in %s", path)
+
+    try:
+        with open(path, "r") as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        _logger.warn("%s not found. skipping OpenMPI UCX enablement", path)
+        return
+
+    # Current patch adds lines:
+    #   btl = ^uct,openib,ofi
+    #   pml = ^ucx
+    #   osc = ^ucx,pt2pt
+    # Remove "uct" and "ucx". Values must still begin with "^", e.g. `btl = ^openib,ofi`, to leave
+    # openib and ofi disabled.
+    new_lines = []
+    for line in lines:
+        if line.startswith(("btl =", "pml =", "osc =")):
+            parts = line.split()
+            values = parts[2].strip().lstrip("^").split(",")
+            values = [v for v in values if v not in ("uct", "ucx")]
+            # Remove line entirely if all values removed, e.g. "pml = ^ucx"
+            if values:
+                new_lines.append(f"{parts[0]} = ^{','.join(values)}\n")
+        else:
+            new_lines.append(line)
+
+    with open(path, "w") as f:
+        f.writelines(new_lines)

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -109,7 +109,7 @@ class TestCharm(TestCase):
         path = "/etc/openmpi/openmpi-mca-params.conf"
         self.fs.create_file(path, contents=initial_contents)
 
-        _override_opmi_conf(path)
+        _override_opmi_conf()
 
         with open(path, "r") as f:
             contents = f.read()

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -25,7 +25,7 @@ from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 from pyfakefs.fake_filesystem_unittest import TestCase
 
-from utils.rdma import _override_opmi_conf
+from utils.rdma import _override_ompi_conf
 
 from charms.hpc_libs.v0.slurm_ops import SlurmOpsError
 
@@ -55,7 +55,7 @@ class TestCharm(TestCase):
         )
         defer.assert_not_called()
 
-    @patch("utils.rdma._override_opmi_conf")
+    @patch("utils.rdma._override_ompi_conf")
     @patch("utils.nhc.install")
     @patch("utils.service.override_service")
     @patch("charms.operator_libs_linux.v0.juju_systemd_notices.SystemdNotices.subscribe")
@@ -96,7 +96,7 @@ class TestCharm(TestCase):
         self.assertFalse(self.harness.charm._stored.slurm_installed)
         defer.assert_called()
 
-    def test_override_opmi_conf(self) -> None:
+    def test_override_ompi_conf(self) -> None:
         """Test OpenMPI configuration file override."""
         initial_contents = (
             "# Comment\nmtl = ^ofi\nbtl = ^uct,openib,ofi\npml = ^ucx\nosc = ^ucx,pt2pt\n"
@@ -109,7 +109,7 @@ class TestCharm(TestCase):
         path = "/etc/openmpi/openmpi-mca-params.conf"
         self.fs.create_file(path, contents=initial_contents)
 
-        _override_opmi_conf()
+        _override_ompi_conf()
 
         with open(path, "r") as f:
             contents = f.read()


### PR DESCRIPTION
This PR enables use of Infiniband in Charmed HPC clusters. Microsoft Azure `Standard_HB120rs_v3` instances equipped with 200 Gb/sec HDR InfiniBand have been used for testing.

Minimally, installing the `rdma-core` package from the Ubuntu repositories is sufficient to enable connectivity as MLNX drivers for ConnectX cards are available out-of-the-box. Here, `infiniband-diags` is also installed to provide diagnostic tools `ibstat`, `ibping`, etc. for cluster administrators.

These changes also re-enable UCX for OpenMPI. The developer-intended default for OpenMPI is to [use the UCX PML when Infiniband devices are available](https://github.com/open-mpi/ompi/blob/v4.1.x/README#L763) however, [a Debian patch](https://sources.debian.org/src/openmpi/4.1.4-3/debian/patches/no-warning-unused.patch/) disables UCX in order to [suppress warnings in the case where RDMA hardware is not available](https://github.com/open-mpi/ompi/issues/8367). Without this change, measured bandwidth is the region of 3Gb/s on test systems, while upwards of 190Gb/s can be seen with the change.

String operations are used to remove `ucx` and `uct` from `/etc/openmpi/openmpi-mca-params.conf`. An alternative we may wish to consider is including our own `openmpi-mca-params.conf` and copying it into place.