### PR TITLE
fix(ci): pin charmcraft to version 3.2.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,6 +87,13 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
+      # TODO: https://github.com/canonical/charmcraft/issues/2125 -
+      #   Remove pin to charmcraft 3.2.3 once `FileExistsError` is fixed
+      #   when accessing the charmcraft build cache in parallel builds.
+      - name: Revert to charmcraft 3.2.3
+        run: |
+          sudo snap refresh charmcraft --revision=5858
+          sudo snap refresh charmcraft --hold
       - name: Run tests
         run: tox run -e integration -- --charm-base=${{ matrix.bases }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,13 @@ jobs:
         uses: canonical/setup-lxd@v0.1.2
         with:
           channel: 5.21/stable
+      # TODO: https://github.com/canonical/charmcraft/issues/2125 -
+      #   Remove pin to charmcraft 3.2.3 once `FileExistsError` is fixed
+      #   when accessing the charmcraft build cache in parallel builds.
+      - name: Install charmcraft 3.2.3
+        run: |
+          sudo snap install charmcraft --classic --revision=5858
+          sudo snap refresh charmcraft --hold
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:


### PR DESCRIPTION
This should fix the CI issues we've been seeing since charmcraft 3.3.2 was released to the `latest/stable` channel. I just modified the CI and Release pipelines to just install and hold the version of charmcraft to 3.2.3. We'll still need to deep dive on what the longer term solution is, but at least we will be able to get the latest batch of PRs through.

Bug opened on the upstream `charmcraft` repository:

* https://github.com/canonical/charmcraft/issues/2125