### PR TITLE
chore: migrate charms to `hpc-libs` charm library

### DIFF
--- a/charms/sackd/charmcraft.yaml
+++ b/charms/sackd/charmcraft.yaml
@@ -32,6 +32,8 @@ platforms:
 
 parts:
   charm:
+    build-packages:
+      - git
     charm-binary-python-packages:
       - cryptography ~= 44.0.0
       - jsonschema ~= 4.23.0

--- a/charms/sackd/pyproject.toml
+++ b/charms/sackd/pyproject.toml
@@ -2,7 +2,6 @@
 name = "sackd"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = ["ops"]
+dependencies = ["ops", "hpc-libs"]
 
 [tool.repository]
-libraries = ["hpc-libs.slurm_ops", "operator-libs-linux.apt"]

--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 
+from hpc_libs.slurm_ops import SackdManager, SlurmOpsError
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent
 from ops import (
     ActiveStatus,
@@ -17,8 +18,6 @@ from ops import (
     WaitingStatus,
     main,
 )
-
-from charms.hpc_libs.v0.slurm_ops import SackdManager, SlurmOpsError
 
 logger = logging.getLogger(__name__)
 

--- a/charms/sackd/tests/unit/test_charm.py
+++ b/charms/sackd/tests/unit/test_charm.py
@@ -19,10 +19,9 @@ from unittest import TestCase
 from unittest.mock import Mock, PropertyMock, patch
 
 from charm import SackdCharm
+from hpc_libs.slurm_ops import SlurmOpsError
 from ops.model import ActiveStatus, BlockedStatus
 from scenario import Context, State
-
-from charms.hpc_libs.v0.slurm_ops import SlurmOpsError
 
 
 class TestCharm(TestCase):

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -54,6 +54,8 @@ platforms:
 
 parts:
   charm:
+    build-packages:
+      - git
     charm-binary-python-packages:
       - cryptography ~= 44.0.0
       - jsonschema ~= 4.23.0

--- a/charms/slurmctld/pyproject.toml
+++ b/charms/slurmctld/pyproject.toml
@@ -2,13 +2,7 @@
 name = "slurmctld"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = ["ops", "slurmutils", "influxdb", "netifaces-plus"]
+dependencies = ["ops", "slurmutils", "influxdb", "netifaces-plus", "hpc-libs"]
 
 [tool.repository]
-libraries = [
-  "hpc-libs.slurm_ops",
-  "hpc-libs.is_container",
-  "operator-libs-linux.apt",
-  "operator-libs-linux.systemd",
-  "grafana-agent.cos_agent",
-]
+libraries = ["grafana-agent.cos_agent"]

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -17,6 +17,8 @@ from constants import (
     PEER_RELATION,
 )
 from exceptions import IngressAddressUnavailableError
+from hpc_libs.is_container import is_container
+from hpc_libs.slurm_ops import SlurmctldManager, SlurmOpsError
 from interface_influxdb import InfluxDB, InfluxDBAvailableEvent, InfluxDBUnavailableEvent
 from interface_sackd import Sackd
 from interface_slurmctld_peer import SlurmctldPeer, SlurmctldPeerError
@@ -46,8 +48,6 @@ from ops import (
 from slurmutils.models import AcctGatherConfig, CgroupConfig, GRESConfig, GRESNode, SlurmConfig
 
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from charms.hpc_libs.v0.is_container import is_container
-from charms.hpc_libs.v0.slurm_ops import SlurmctldManager, SlurmOpsError
 
 logger = logging.getLogger()
 

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -18,12 +18,11 @@
 from unittest.mock import Mock, PropertyMock, patch
 
 from charm import SlurmctldCharm
+from hpc_libs.slurm_ops import SlurmOpsError
 from interface_slurmctld_peer import SlurmctldPeerError
 from ops.model import BlockedStatus
 from ops.testing import Harness
 from pyfakefs.fake_filesystem_unittest import TestCase
-
-from charms.hpc_libs.v0.slurm_ops import SlurmOpsError
 
 
 class TestCharm(TestCase):
@@ -226,7 +225,7 @@ class TestCharm(TestCase):
         self.assertEqual(self.harness.charm._stored.slurmdbd_host, "")
 
     @patch(
-        "charms.hpc_libs.v0.slurm_ops.SlurmctldManager.hostname",
+        "hpc_libs.slurm_ops.SlurmctldManager.hostname",
         new_callable=PropertyMock(return_value="test_hostname"),
     )
     def test_sackd_on_relation_created(self, *_) -> None:

--- a/charms/slurmd/pyproject.toml
+++ b/charms/slurmd/pyproject.toml
@@ -2,11 +2,16 @@
 name = "slurmd"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = ["ops", "slurmutils", "nvidia-ml-py", "ubuntu-drivers-common"]
+dependencies = [
+    "ops",
+    "slurmutils",
+    "nvidia-ml-py",
+    "ubuntu-drivers-common",
+    "hpc-libs",
+]
 
 [tool.repository]
 libraries = [
-    "hpc-libs.slurm_ops",
     "operator-libs-linux.apt",
     "operator-libs-linux.juju_systemd_notices",
     "operator-libs-linux.systemd",

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, cast
 
+from hpc_libs.slurm_ops import SlurmdManager, SlurmOpsError
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent
 from ops import (
     ActionEvent,
@@ -26,7 +27,6 @@ from slurmutils import calculate_rs
 from slurmutils.models.option import NodeOptionSet, PartitionOptionSet
 from utils import gpu, machine, nhc, rdma, service
 
-from charms.hpc_libs.v0.slurm_ops import SlurmdManager, SlurmOpsError
 from charms.operator_libs_linux.v0.juju_systemd_notices import (  # type: ignore[import-untyped]
     ServiceStartedEvent,
     ServiceStoppedEvent,

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -27,7 +27,7 @@ from pyfakefs.fake_filesystem_unittest import TestCase
 
 from utils.rdma import _override_ompi_conf
 
-from charms.hpc_libs.v0.slurm_ops import SlurmOpsError
+from hpc_libs.slurm_ops import SlurmOpsError
 
 
 class TestCharm(TestCase):
@@ -58,7 +58,7 @@ class TestCharm(TestCase):
     @patch("utils.rdma._override_ompi_conf")
     @patch("utils.nhc.install")
     @patch("utils.service.override_service")
-    @patch("charms.hpc_libs.v0.slurm_ops._SystemctlServiceManager.enable")
+    @patch("hpc_libs.slurm_ops._SystemctlServiceManager.enable")
     @patch("charms.operator_libs_linux.v0.juju_systemd_notices.SystemdNotices.subscribe")
     @patch("charms.operator_libs_linux.v0.apt.add_package")
     @patch("ops.framework.EventBase.defer")

--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -32,6 +32,8 @@ platforms:
 
 parts:
   charm:
+    build-packages:
+      - git
     charm-binary-python-packages:
       - cryptography ~= 44.0.0
       - jsonschema ~= 4.23.0

--- a/charms/slurmdbd/pyproject.toml
+++ b/charms/slurmdbd/pyproject.toml
@@ -2,12 +2,7 @@
 name = "slurmdbd"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = ["ops", "slurmutils"]
+dependencies = ["ops", "slurmutils", "hpc-libs"]
 
 [tool.repository]
-libraries = [
-    "hpc-libs.slurm_ops",
-    "operator-libs-linux.apt",
-    "operator-libs-linux.systemd",
-    "data-platform-libs.data_interfaces",
-]
+libraries = ["data-platform-libs.data_interfaces"]

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Union
 from urllib.parse import urlparse
 
 from constants import CHARM_MAINTAINED_PARAMETERS, SLURM_ACCT_DB
+from hpc_libs.slurm_ops import SlurmdbdManager, SlurmOpsError
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent, SlurmctldUnavailableEvent
 from ops import (
     ActiveStatus,
@@ -27,7 +28,6 @@ from ops import (
 from slurmutils.models import SlurmdbdConfig
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseCreatedEvent, DatabaseRequires
-from charms.hpc_libs.v0.slurm_ops import SlurmdbdManager, SlurmOpsError
 
 logger = logging.getLogger(__name__)
 

--- a/charms/slurmdbd/tests/unit/test_charm.py
+++ b/charms/slurmdbd/tests/unit/test_charm.py
@@ -18,11 +18,10 @@
 from unittest.mock import Mock, PropertyMock, patch
 
 from charm import SlurmdbdCharm
+from hpc_libs.slurm_ops import SlurmOpsError
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 from pyfakefs.fake_filesystem_unittest import TestCase
-
-from charms.hpc_libs.v0.slurm_ops import SlurmOpsError
 
 
 class TestCharm(TestCase):
@@ -32,7 +31,7 @@ class TestCharm(TestCase):
         self.setUpPyfakefs()
         self.harness.begin()
 
-    @patch("charms.hpc_libs.v0.slurm_ops._SystemctlServiceManager.enable")
+    @patch("hpc_libs.slurm_ops._SystemctlServiceManager.enable")
     def test_install_success(self, *_) -> None:
         """Test `InstallEvent` hook success."""
         self.harness.set_leader(True)
@@ -121,9 +120,7 @@ class TestCharm(TestCase):
         )
 
     @patch("charm.SlurmdbdCharm._write_config_and_restart_slurmdbd")
-    @patch(
-        "charms.hpc_libs.v0.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock
-    )
+    @patch("hpc_libs.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock)
     def test_on_database_created_socket_endpoints(
         self, mysql_unix_port, _write_config_and_restart_slurmdbd
     ) -> None:
@@ -145,9 +142,7 @@ class TestCharm(TestCase):
         _write_config_and_restart_slurmdbd.assert_called_once_with(event)
 
     @patch("charm.SlurmdbdCharm._write_config_and_restart_slurmdbd")
-    @patch(
-        "charms.hpc_libs.v0.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock
-    )
+    @patch("hpc_libs.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock)
     def test_on_database_created_socket_multiple_endpoints(
         self, mysql_unix_port, _write_config_and_restart_slurmdbd
     ) -> None:
@@ -170,9 +165,7 @@ class TestCharm(TestCase):
         _write_config_and_restart_slurmdbd.assert_called_once_with(event)
 
     @patch("charm.SlurmdbdCharm._write_config_and_restart_slurmdbd")
-    @patch(
-        "charms.hpc_libs.v0.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock
-    )
+    @patch("hpc_libs.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock)
     def test_on_database_created_tcp_endpoint(
         self, mysql_unix_port, _write_config_and_restart_slurmdbd
     ) -> None:
@@ -197,9 +190,7 @@ class TestCharm(TestCase):
         _write_config_and_restart_slurmdbd.assert_called_once_with(event)
 
     @patch("charm.SlurmdbdCharm._write_config_and_restart_slurmdbd")
-    @patch(
-        "charms.hpc_libs.v0.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock
-    )
+    @patch("hpc_libs.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock)
     def test_on_database_created_multiple_tcp_endpoints(
         self, mysql_unix_port, _write_config_and_restart_slurmdbd
     ) -> None:
@@ -225,9 +216,7 @@ class TestCharm(TestCase):
         _write_config_and_restart_slurmdbd.assert_called_once_with(event)
 
     @patch("charm.SlurmdbdCharm._write_config_and_restart_slurmdbd")
-    @patch(
-        "charms.hpc_libs.v0.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock
-    )
+    @patch("hpc_libs.slurm_ops.SlurmdbdManager.mysql_unix_port", new_callable=PropertyMock)
     def test_on_database_created_ipv6_tcp_endpoints(
         self,
         mysql_unix_port,

--- a/charms/slurmrestd/charmcraft.yaml
+++ b/charms/slurmrestd/charmcraft.yaml
@@ -29,6 +29,8 @@ platforms:
 
 parts:
   charm:
+    build-packages:
+      - git
     charm-binary-python-packages:
       - cryptography ~= 44.0.0
       - jsonschema ~= 4.23.0

--- a/charms/slurmrestd/pyproject.toml
+++ b/charms/slurmrestd/pyproject.toml
@@ -2,11 +2,6 @@
 name = "slurmrestd"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = ["ops", "slurmutils"]
+dependencies = ["ops", "slurmutils", "hpc-libs"]
 
 [tool.repository]
-libraries = [
-    "hpc-libs.slurm_ops",
-    "operator-libs-linux.apt",
-    "operator-libs-linux.systemd",
-]

--- a/charms/slurmrestd/src/charm.py
+++ b/charms/slurmrestd/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 
+from hpc_libs.slurm_ops import SlurmOpsError, SlurmrestdManager
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent, SlurmctldUnavailableEvent
 from ops import (
     ActiveStatus,
@@ -18,8 +19,6 @@ from ops import (
     main,
 )
 from slurmutils.models import SlurmConfig
-
-from charms.hpc_libs.v0.slurm_ops import SlurmOpsError, SlurmrestdManager
 
 logger = logging.getLogger()
 

--- a/charms/slurmrestd/tests/unit/test_charm.py
+++ b/charms/slurmrestd/tests/unit/test_charm.py
@@ -18,11 +18,10 @@
 from unittest.mock import Mock, PropertyMock, patch
 
 from charm import SlurmrestdCharm
+from hpc_libs.slurm_ops import SlurmOpsError
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 from pyfakefs.fake_filesystem_unittest import TestCase
-
-from charms.hpc_libs.v0.slurm_ops import SlurmOpsError
 
 
 class TestCharm(TestCase):
@@ -36,8 +35,8 @@ class TestCharm(TestCase):
         "interface_slurmctld.Slurmctld.is_joined",
         new_callable=PropertyMock(return_value=True),
     )
-    @patch("charms.hpc_libs.v0.slurm_ops._SystemctlServiceManager.active", return_value=True)
-    @patch("charms.hpc_libs.v0.slurm_ops._SystemctlServiceManager.enable")
+    @patch("hpc_libs.slurm_ops._SystemctlServiceManager.active", return_value=True)
+    @patch("hpc_libs.slurm_ops._SystemctlServiceManager.enable")
     def test_install_success(self, *_) -> None:
         """Test `InstallEvent` hook success."""
         self.harness.charm._stored.slurmctld_relation_data_available = True
@@ -65,7 +64,7 @@ class TestCharm(TestCase):
         "interface_slurmctld.Slurmctld.is_joined",
         new_callable=PropertyMock(return_value=True),
     )
-    @patch("charms.hpc_libs.v0.slurm_ops._SystemctlServiceManager.active", return_value=True)
+    @patch("hpc_libs.slurm_ops._SystemctlServiceManager.active", return_value=True)
     def test_update_status_success(self, *_) -> None:
         """Test `UpdateStatusEvent` hook success."""
         self.harness.charm._stored.slurmctld_relation_data_available = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,14 @@ dependencies = [
     "influxdb==5.3.2",
     "netifaces-plus==0.12.4",
     "nvidia-ml-py==12.560.30",
+    "hpc-libs",
 ]
 
 [project.optional-dependencies]
 dev = [
     # Tests
     "ops[testing]~=2.19",
-    "cryptography~=43.0.1",
+    "cryptography~=44.0.1",
     "distro==1.9.0",
     "python-dotenv~=1.0.1",
     "pycryptodome==3.20.0",
@@ -38,8 +39,8 @@ dev = [
     # Integration
     "juju ~= 3.3",
     "pytest ~= 7.2",
-    "pytest-operator ~= 0.34",
-    "pytest-order ~= 1.1",
+    "pytest-operator ~= 0.41",
+    "pytest-order ~= 1.3",
     "tenacity ~= 8.2",
 
     # Linting
@@ -63,14 +64,13 @@ members = ["charms/*"]
 
 [tool.uv.sources]
 ubuntu-drivers-common = { git = "https://github.com/canonical/ubuntu-drivers-common", rev = "554b91edfd3699625dbed90f679abb31a897b76e" }
+hpc-libs = { git = "https://github.com/charmed-hpc/hpc-libs", rev = "1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" }
 
 [tool.uv]
 dependency-metadata = [{ name = "ubuntu-drivers-common", version = "0.10.0" }]
 
 [tool.repository]
 external-libraries = [
-    { lib = "hpc-libs.slurm_ops", version = "0.18" },
-    { lib = "hpc-libs.is_container", version = "0.1" },
     { lib = "operator-libs-linux.apt", version = "0.16" },
     { lib = "operator-libs-linux.systemd", version = "1.4" },
     { lib = "operator-libs-linux.juju_systemd_notices", version = "0.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -217,65 +217,71 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.7.0"
+version = "7.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/36/465f5492443265e1278f9a82ffe6aeed3f1db779da0d6e7d4611a5cfb6af/coverage-7.7.0.tar.gz", hash = "sha256:cd879d4646055a573775a1cec863d00c9ff8c55860f8b17f6d8eee9140c06166", size = 809969 }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/bf/3effb7453498de9c14a81ca21e1f92e6723ce7ebdc5402ae30e4dcc490ac/coverage-7.7.1.tar.gz", hash = "sha256:199a1272e642266b90c9f40dec7fd3d307b51bf639fa0d15980dc0b3246c1393", size = 810332 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/47/f7b870caa26082ff8033be074ac61dc175a6b0c965adf7b910f92a6d7cfe/coverage-7.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:056d3017ed67e7ddf266e6f57378ece543755a4c9231e997789ab3bd11392c94", size = 210907 },
-    { url = "https://files.pythonhosted.org/packages/ea/eb/40b39bdc6c1da403257f0fcb2c1b2fd81ff9f66c13abbe3862f42780e1c1/coverage-7.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33c1394d8407e2771547583b66a85d07ed441ff8fae5a4adb4237ad39ece60db", size = 211162 },
-    { url = "https://files.pythonhosted.org/packages/53/08/42a2db41b4646d6261122773e222dd7105e2306526f2d7846de6fee808ec/coverage-7.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fbb7a0c3c21908520149d7751cf5b74eb9b38b54d62997b1e9b3ac19a8ee2fe", size = 245223 },
-    { url = "https://files.pythonhosted.org/packages/78/2a/0ceb328a7e67e8639d5c7800b8161d4b5f489073ac8d5ac33b11eadee218/coverage-7.7.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb356e7ae7c2da13f404bf8f75be90f743c6df8d4607022e759f5d7d89fe83f8", size = 242114 },
-    { url = "https://files.pythonhosted.org/packages/ba/68/42b13b849d40af1581830ff06c60f4ec84649764f4a58d5c6e20ae11cbd4/coverage-7.7.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bce730d484038e97f27ea2dbe5d392ec5c2261f28c319a3bb266f6b213650135", size = 244371 },
-    { url = "https://files.pythonhosted.org/packages/68/66/ab7c3b9fdbeb8bdd322f5b67b1886463834dba2014a534caba60fb0075ea/coverage-7.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aa4dff57fc21a575672176d5ab0ef15a927199e775c5e8a3d75162ab2b0c7705", size = 244134 },
-    { url = "https://files.pythonhosted.org/packages/01/74/b833d299a479681957d6b238e16a0725586e1d56ec1e43658f3184550bb0/coverage-7.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b667b91f4f714b17af2a18e220015c941d1cf8b07c17f2160033dbe1e64149f0", size = 242353 },
-    { url = "https://files.pythonhosted.org/packages/f9/c5/0ed656d65da39bbab8e8fc367dc3d465a7501fea0f2b1caccfb4f6361c9f/coverage-7.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:693d921621a0c8043bfdc61f7d4df5ea6d22165fe8b807cac21eb80dd94e4bbd", size = 243543 },
-    { url = "https://files.pythonhosted.org/packages/87/b5/142bcff3828e4cce5d4c9ddc9222de1664464263acca09638e4eb0dbda7c/coverage-7.7.0-cp312-cp312-win32.whl", hash = "sha256:52fc89602cde411a4196c8c6894afb384f2125f34c031774f82a4f2608c59d7d", size = 213543 },
-    { url = "https://files.pythonhosted.org/packages/29/74/99d226985def03284bad6a9aff27a1079a8881ec7523b5980b00a5260527/coverage-7.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ce8cf59e09d31a4915ff4c3b94c6514af4c84b22c4cc8ad7c3c546a86150a92", size = 214344 },
-    { url = "https://files.pythonhosted.org/packages/2a/ac/60f409a448e5b0e9b8539716f683568aa5848c1be903cdbbc805a552cdf8/coverage-7.7.0-py3-none-any.whl", hash = "sha256:708f0a1105ef2b11c79ed54ed31f17e6325ac936501fc373f24be3e6a578146a", size = 202803 },
+    { url = "https://files.pythonhosted.org/packages/cf/b0/4eaba302a86ec3528231d7cfc954ae1929ec5d42b032eb6f5b5f5a9155d2/coverage-7.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:eff187177d8016ff6addf789dcc421c3db0d014e4946c1cc3fbf697f7852459d", size = 211253 },
+    { url = "https://files.pythonhosted.org/packages/fd/68/21b973e6780a3f2457e31ede1aca6c2f84bda4359457b40da3ae805dcf30/coverage-7.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2444fbe1ba1889e0b29eb4d11931afa88f92dc507b7248f45be372775b3cef4f", size = 211504 },
+    { url = "https://files.pythonhosted.org/packages/d1/b4/c19e9c565407664390254252496292f1e3076c31c5c01701ffacc060e745/coverage-7.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:177d837339883c541f8524683e227adcaea581eca6bb33823a2a1fdae4c988e1", size = 245566 },
+    { url = "https://files.pythonhosted.org/packages/7b/0e/f9829cdd25e5083638559c8c267ff0577c6bab19dacb1a4fcfc1e70e41c0/coverage-7.7.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15d54ecef1582b1d3ec6049b20d3c1a07d5e7f85335d8a3b617c9960b4f807e0", size = 242455 },
+    { url = "https://files.pythonhosted.org/packages/29/57/a3ada2e50a665bf6d9851b5eb3a9a07d7e38f970bdd4d39895f311331d56/coverage-7.7.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c82b27c56478d5e1391f2e7b2e7f588d093157fa40d53fd9453a471b1191f2", size = 244713 },
+    { url = "https://files.pythonhosted.org/packages/0f/d3/f15c7d45682a73eca0611427896016bad4c8f635b0fc13aae13a01f8ed9d/coverage-7.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:315ff74b585110ac3b7ab631e89e769d294f303c6d21302a816b3554ed4c81af", size = 244476 },
+    { url = "https://files.pythonhosted.org/packages/19/3b/64540074e256082b220e8810fd72543eff03286c59dc91976281dc0a559c/coverage-7.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4dd532dac197d68c478480edde74fd4476c6823355987fd31d01ad9aa1e5fb59", size = 242695 },
+    { url = "https://files.pythonhosted.org/packages/8a/c1/9cad25372ead7f9395a91bb42d8ae63e6cefe7408eb79fd38797e2b763eb/coverage-7.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:385618003e3d608001676bb35dc67ae3ad44c75c0395d8de5780af7bb35be6b2", size = 243888 },
+    { url = "https://files.pythonhosted.org/packages/66/c6/c3e6c895bc5b95ccfe4cb5838669dbe5226ee4ad10604c46b778c304d6f9/coverage-7.7.1-cp312-cp312-win32.whl", hash = "sha256:63306486fcb5a827449464f6211d2991f01dfa2965976018c9bab9d5e45a35c8", size = 213744 },
+    { url = "https://files.pythonhosted.org/packages/cc/8a/6df2fcb4c3e38ec6cd7e211ca8391405ada4e3b1295695d00aa07c6ee736/coverage-7.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:37351dc8123c154fa05b7579fdb126b9f8b1cf42fd6f79ddf19121b7bdd4aa04", size = 214546 },
+    { url = "https://files.pythonhosted.org/packages/52/26/9f53293ff4cc1d47d98367ce045ca2e62746d6be74a5c6851a474eabf59b/coverage-7.7.1-py3-none-any.whl", hash = "sha256:822fa99dd1ac686061e1219b67868e25d9757989cf2259f735a4802497d6da31", size = 203006 },
 ]
 
 [[package]]
 name = "cryptography"
-version = "43.0.3"
+version = "44.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz", hash = "sha256:315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805", size = 686989 }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/25/4ce80c78963834b8a9fd1cc1266be5ed8d1840785c0f2e1b73b8d128d505/cryptography-44.0.2.tar.gz", hash = "sha256:c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0", size = 710807 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/f3/01fdf26701a26f4b4dbc337a26883ad5bccaa6f1bbbdd29cd89e22f18a1c/cryptography-43.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf7a1932ac4176486eab36a19ed4c0492da5d97123f1406cf15e41b05e787d2e", size = 6225303 },
-    { url = "https://files.pythonhosted.org/packages/a3/01/4896f3d1b392025d4fcbecf40fdea92d3df8662123f6835d0af828d148fd/cryptography-43.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63efa177ff54aec6e1c0aefaa1a241232dcd37413835a9b674b6e3f0ae2bfd3e", size = 3760905 },
-    { url = "https://files.pythonhosted.org/packages/0a/be/f9a1f673f0ed4b7f6c643164e513dbad28dd4f2dcdf5715004f172ef24b6/cryptography-43.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e1ce50266f4f70bf41a2c6dc4358afadae90e2a1e5342d3c08883df1675374f", size = 3977271 },
-    { url = "https://files.pythonhosted.org/packages/4e/49/80c3a7b5514d1b416d7350830e8c422a4d667b6d9b16a9392ebfd4a5388a/cryptography-43.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:443c4a81bb10daed9a8f334365fe52542771f25aedaf889fd323a853ce7377d6", size = 3746606 },
-    { url = "https://files.pythonhosted.org/packages/0e/16/a28ddf78ac6e7e3f25ebcef69ab15c2c6be5ff9743dd0709a69a4f968472/cryptography-43.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:74f57f24754fe349223792466a709f8e0c093205ff0dca557af51072ff47ab18", size = 3986484 },
-    { url = "https://files.pythonhosted.org/packages/01/f5/69ae8da70c19864a32b0315049866c4d411cce423ec169993d0434218762/cryptography-43.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9762ea51a8fc2a88b70cf2995e5675b38d93bf36bd67d91721c309df184f49bd", size = 3852131 },
-    { url = "https://files.pythonhosted.org/packages/fd/db/e74911d95c040f9afd3612b1f732e52b3e517cb80de8bf183be0b7d413c6/cryptography-43.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:81ef806b1fef6b06dcebad789f988d3b37ccaee225695cf3e07648eee0fc6b73", size = 4075647 },
-    { url = "https://files.pythonhosted.org/packages/56/48/7b6b190f1462818b324e674fa20d1d5ef3e24f2328675b9b16189cbf0b3c/cryptography-43.0.3-cp37-abi3-win32.whl", hash = "sha256:cbeb489927bd7af4aa98d4b261af9a5bc025bd87f0e3547e11584be9e9427be2", size = 2623873 },
-    { url = "https://files.pythonhosted.org/packages/eb/b1/0ebff61a004f7f89e7b65ca95f2f2375679d43d0290672f7713ee3162aff/cryptography-43.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:f46304d6f0c6ab8e52770addfa2fc41e6629495548862279641972b6215451cd", size = 3068039 },
-    { url = "https://files.pythonhosted.org/packages/30/d5/c8b32c047e2e81dd172138f772e81d852c51f0f2ad2ae8a24f1122e9e9a7/cryptography-43.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8ac43ae87929a5982f5948ceda07001ee5e83227fd69cf55b109144938d96984", size = 6222984 },
-    { url = "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5", size = 3762968 },
-    { url = "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4", size = 3977754 },
-    { url = "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7", size = 3749458 },
-    { url = "https://files.pythonhosted.org/packages/ac/25/e715fa0bc24ac2114ed69da33adf451a38abb6f3f24ec207908112e9ba53/cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405", size = 3988220 },
-    { url = "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16", size = 3853898 },
-    { url = "https://files.pythonhosted.org/packages/2a/33/b3682992ab2e9476b9c81fff22f02c8b0a1e6e1d49ee1750a67d85fd7ed2/cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73", size = 4076592 },
-    { url = "https://files.pythonhosted.org/packages/81/1e/ffcc41b3cebd64ca90b28fd58141c5f68c83d48563c88333ab660e002cd3/cryptography-43.0.3-cp39-abi3-win32.whl", hash = "sha256:d56e96520b1020449bbace2b78b603442e7e378a9b3bd68de65c782db1507995", size = 2623145 },
-    { url = "https://files.pythonhosted.org/packages/87/5c/3dab83cc4aba1f4b0e733e3f0c3e7d4386440d660ba5b1e3ff995feb734d/cryptography-43.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:0c580952eef9bf68c4747774cde7ec1d85a6e61de97281f2dba83c7d2c806362", size = 3068026 },
+    { url = "https://files.pythonhosted.org/packages/92/ef/83e632cfa801b221570c5f58c0369db6fa6cef7d9ff859feab1aae1a8a0f/cryptography-44.0.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7", size = 6676361 },
+    { url = "https://files.pythonhosted.org/packages/30/ec/7ea7c1e4c8fc8329506b46c6c4a52e2f20318425d48e0fe597977c71dbce/cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1", size = 3952350 },
+    { url = "https://files.pythonhosted.org/packages/27/61/72e3afdb3c5ac510330feba4fc1faa0fe62e070592d6ad00c40bb69165e5/cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb", size = 4166572 },
+    { url = "https://files.pythonhosted.org/packages/26/e4/ba680f0b35ed4a07d87f9e98f3ebccb05091f3bf6b5a478b943253b3bbd5/cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843", size = 3958124 },
+    { url = "https://files.pythonhosted.org/packages/9c/e8/44ae3e68c8b6d1cbc59040288056df2ad7f7f03bbcaca6b503c737ab8e73/cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5", size = 3678122 },
+    { url = "https://files.pythonhosted.org/packages/27/7b/664ea5e0d1eab511a10e480baf1c5d3e681c7d91718f60e149cec09edf01/cryptography-44.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c", size = 4191831 },
+    { url = "https://files.pythonhosted.org/packages/2a/07/79554a9c40eb11345e1861f46f845fa71c9e25bf66d132e123d9feb8e7f9/cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a", size = 3960583 },
+    { url = "https://files.pythonhosted.org/packages/bb/6d/858e356a49a4f0b591bd6789d821427de18432212e137290b6d8a817e9bf/cryptography-44.0.2-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308", size = 4191753 },
+    { url = "https://files.pythonhosted.org/packages/b2/80/62df41ba4916067fa6b125aa8c14d7e9181773f0d5d0bd4dcef580d8b7c6/cryptography-44.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688", size = 4079550 },
+    { url = "https://files.pythonhosted.org/packages/f3/cd/2558cc08f7b1bb40683f99ff4327f8dcfc7de3affc669e9065e14824511b/cryptography-44.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7", size = 4298367 },
+    { url = "https://files.pythonhosted.org/packages/71/59/94ccc74788945bc3bd4cf355d19867e8057ff5fdbcac781b1ff95b700fb1/cryptography-44.0.2-cp37-abi3-win32.whl", hash = "sha256:51e4de3af4ec3899d6d178a8c005226491c27c4ba84101bfb59c901e10ca9f79", size = 2772843 },
+    { url = "https://files.pythonhosted.org/packages/ca/2c/0d0bbaf61ba05acb32f0841853cfa33ebb7a9ab3d9ed8bb004bd39f2da6a/cryptography-44.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:c505d61b6176aaf982c5717ce04e87da5abc9a36a5b39ac03905c4aafe8de7aa", size = 3209057 },
+    { url = "https://files.pythonhosted.org/packages/9e/be/7a26142e6d0f7683d8a382dd963745e65db895a79a280a30525ec92be890/cryptography-44.0.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3", size = 6677789 },
+    { url = "https://files.pythonhosted.org/packages/06/88/638865be7198a84a7713950b1db7343391c6066a20e614f8fa286eb178ed/cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639", size = 3951919 },
+    { url = "https://files.pythonhosted.org/packages/d7/fc/99fe639bcdf58561dfad1faa8a7369d1dc13f20acd78371bb97a01613585/cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd", size = 4167812 },
+    { url = "https://files.pythonhosted.org/packages/53/7b/aafe60210ec93d5d7f552592a28192e51d3c6b6be449e7fd0a91399b5d07/cryptography-44.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181", size = 3958571 },
+    { url = "https://files.pythonhosted.org/packages/16/32/051f7ce79ad5a6ef5e26a92b37f172ee2d6e1cce09931646eef8de1e9827/cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea", size = 3679832 },
+    { url = "https://files.pythonhosted.org/packages/78/2b/999b2a1e1ba2206f2d3bca267d68f350beb2b048a41ea827e08ce7260098/cryptography-44.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699", size = 4193719 },
+    { url = "https://files.pythonhosted.org/packages/72/97/430e56e39a1356e8e8f10f723211a0e256e11895ef1a135f30d7d40f2540/cryptography-44.0.2-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9", size = 3960852 },
+    { url = "https://files.pythonhosted.org/packages/89/33/c1cf182c152e1d262cac56850939530c05ca6c8d149aa0dcee490b417e99/cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23", size = 4193906 },
+    { url = "https://files.pythonhosted.org/packages/e1/99/87cf26d4f125380dc674233971069bc28d19b07f7755b29861570e513650/cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922", size = 4081572 },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/6a3e0391957cc0c5f84aef9fbdd763035f2b52e998a53f99345e3ac69312/cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4", size = 4298631 },
+    { url = "https://files.pythonhosted.org/packages/e2/a5/5bc097adb4b6d22a24dea53c51f37e480aaec3465285c253098642696423/cryptography-44.0.2-cp39-abi3-win32.whl", hash = "sha256:3dc62975e31617badc19a906481deacdeb80b4bb454394b4098e3f2525a488c5", size = 2773792 },
+    { url = "https://files.pythonhosted.org/packages/33/cf/1f7649b8b9a3543e042d3f348e398a061923ac05b507f3f4d95f11938aa9/cryptography-44.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:5f6f90b72d8ccadb9c6e311c775c8305381db88374c65fa1a68250aa8a9cb3a6", size = 3210957 },
 ]
 
 [[package]]
 name = "dbus-fast"
-version = "2.39.6"
+version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/4f/60e9fe553a55f93869d76b3c68dd358f595e88f40763f918139372ef92bc/dbus_fast-2.39.6.tar.gz", hash = "sha256:fc3349ffea522d137d856f8967129dd4b87394c0bf8b8b1648295c5eb0a457fe", size = 72161 }
+sdist = { url = "https://files.pythonhosted.org/packages/16/42/b37c77b67f1c7aec0c30c75fe69ae94df4e592522c0b9bc206e2b183c4b6/dbus_fast-2.43.0.tar.gz", hash = "sha256:c4968dd6e8c15c27a307a0b3c90347ab1eb7a0787d189e65896d404eb1c0728f", size = 72442 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/da/f0b460f7eff5ccfc921fa48c5ee01beeaa4c4108e95d168a9b0470251a68/dbus_fast-2.39.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9704e2e27444e266d21d83ba4bcbf27e9666bb6274268cf20d8ea4a52404bf38", size = 703913 },
-    { url = "https://files.pythonhosted.org/packages/59/1a/3c18adb49a6ea8969dd463cff8d2b49bd892aff933d9546f3027efd723b0/dbus_fast-2.39.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8abd3d27da0d2d1d863059514efa094b4d488920f9458aa40c655904905150d8", size = 836798 },
-    { url = "https://files.pythonhosted.org/packages/ac/e0/171cbc110a8b6cd27f8302bd4ccc2cddd3bbb41930f4c8bc19bfe1528c81/dbus_fast-2.39.6-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:8dca1ec19826f95838821578d1a6dddb8ff147df46b3640132db080027ab04b1", size = 908070 },
-    { url = "https://files.pythonhosted.org/packages/c9/9e/491acdb45460f5b4f4a40d28f02c663883812c1b879014ec5985fdcd7b46/dbus_fast-2.39.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:809c48eba60c9d593e265ee1b90d307e138c01dca14297838ce1dd9aca231fb4", size = 891083 },
-    { url = "https://files.pythonhosted.org/packages/67/bb/e9054ac880320c19667457c21e9e6910883340e6fbde7da5b5a16a715c08/dbus_fast-2.39.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:930eaf3a8a29a166fa4940a560b5b22d2dae342d43c568cdcffeb699337deeae", size = 850204 },
-    { url = "https://files.pythonhosted.org/packages/a1/4f/52bccc297cd76a604c0eef1b08695b9f5cf6e77c95b9ac3c4899783ad1a4/dbus_fast-2.39.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:587e38c403560986a3495eb4f162efa0690bfb8e3b8fc426976b13ad4d918400", size = 941527 },
-    { url = "https://files.pythonhosted.org/packages/c1/ab/071d315bc67f18c611484ee639e0e74342eade9d4cb3136e526ec22c793a/dbus_fast-2.39.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1fe17820e3956b1719aacc605c19f3235d143b1c92edcf74b0416134171c5e8f", size = 917877 },
+    { url = "https://files.pythonhosted.org/packages/a4/02/ea51d2c0a138707edbca7264ce7204b1e4c9113dbdcaf71539cac2472272/dbus_fast-2.43.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f0e20fb3d908cfc19ed0c8472d5323262a5b0fd96898c6eec5518638c19e8fe", size = 705497 },
+    { url = "https://files.pythonhosted.org/packages/2f/3f/a060f1262532b5335c6697ab252ca56f143e14c0d5de1efdf8eb1f7fbcc8/dbus_fast-2.43.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e94023f7492ac9c0cd401291f9391308817163a32ab20f7962f67be1744d4347", size = 840428 },
+    { url = "https://files.pythonhosted.org/packages/75/bb/ed6284a497d5dae6205bc653c37b338d85d6b5741c51774a63cf9df3c8aa/dbus_fast-2.43.0-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:723573933212e281e7667bfa8944f4e983734bf0aa9340f23f904466646ee4d7", size = 912299 },
+    { url = "https://files.pythonhosted.org/packages/b5/ff/f174bd86364597add6cd7d8bcbd734b5015ca443210d4dc8fa1a40ede408/dbus_fast-2.43.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40473392d29b9c580c2e16471aa868c4477fc5b7c9af88bf08f66b36cf6b3087", size = 895035 },
+    { url = "https://files.pythonhosted.org/packages/54/e2/8e7d2841d7d3a85a09118c1bbffc872c0c72476898a657c2300e3f9e972c/dbus_fast-2.43.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e506846fc8b84588e37f734c7cda3f81a3d83a0ed93974391929fa1510ef3bdf", size = 855343 },
+    { url = "https://files.pythonhosted.org/packages/1b/db/0435399093ad9f1bc93511c9e6de28e8e3bfcbf47f583154aa2b8a7b93cf/dbus_fast-2.43.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:06818da2bdd855120fa0ec65411182ab774f034dfad84ebfa26c576bbb570f44", size = 944288 },
+    { url = "https://files.pythonhosted.org/packages/1f/2e/344dcd530142693030b99a68309bd16ec26a0a34b1785ef64a2f55039bf8/dbus_fast-2.43.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b41abbd5b9c289a5251ef282664c122f420f210199d36e1a3a536e3b814bb551", size = 923510 },
 ]
 
 [[package]]
@@ -352,6 +358,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hpc-libs"
+version = "0.1.0"
+source = { git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba#1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "distro" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "slurmutils" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -418,11 +436,11 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
 ]
 
 [[package]]
@@ -803,11 +821,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.6"
+version = "4.3.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351", size = 21291 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
+    { url = "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94", size = 18499 },
 ]
 
 [[package]]
@@ -988,7 +1006,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "3.3.5"
+version = "3.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -999,9 +1017,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/e7/3616e8caa61f918c4864db075800a6bd7422621618045c188fd45c3f7a2b/pylint-3.3.5.tar.gz", hash = "sha256:38d0f784644ed493d91f76b5333a0e370a1c1bc97c22068a77523b4bf1e82c31", size = 1519168 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/a7/113d02340afb9dcbb0c8b25454e9538cd08f0ebf3e510df4ed916caa1a89/pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a", size = 1519586 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/62/42199570fc199cc0f6825d746ddb0183b30739b334dc6d85edeaa8a2073c/pylint-3.3.5-py3-none-any.whl", hash = "sha256:7cb170929a371238530b2eeea09f5f28236d106b70308c3d46a9c0cf11634633", size = 522215 },
+    { url = "https://files.pythonhosted.org/packages/31/21/9537fc94aee9ec7316a230a49895266cf02d78aa29b0a2efbc39566e0935/pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6", size = 522462 },
 ]
 
 [[package]]
@@ -1242,27 +1260,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.11.0"
+version = "0.11.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/2b/7ca27e854d92df5e681e6527dc0f9254c9dc06c8408317893cf96c851cdd/ruff-0.11.0.tar.gz", hash = "sha256:e55c620690a4a7ee6f1cccb256ec2157dc597d109400ae75bbf944fc9d6462e2", size = 3799407 }
+sdist = { url = "https://files.pythonhosted.org/packages/90/61/fb87430f040e4e577e784e325351186976516faef17d6fcd921fe28edfd7/ruff-0.11.2.tar.gz", hash = "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94", size = 3857511 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/40/3d0340a9e5edc77d37852c0cd98c5985a5a8081fc3befaeb2ae90aaafd2b/ruff-0.11.0-py3-none-linux_armv6l.whl", hash = "sha256:dc67e32bc3b29557513eb7eeabb23efdb25753684b913bebb8a0c62495095acb", size = 10098158 },
-    { url = "https://files.pythonhosted.org/packages/ec/a9/d8f5abb3b87b973b007649ac7bf63665a05b2ae2b2af39217b09f52abbbf/ruff-0.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38c23fd9bdec4eb437b4c1e3595905a0a8edfccd63a790f818b28c78fe345639", size = 10879071 },
-    { url = "https://files.pythonhosted.org/packages/ab/62/aaa198614c6211677913ec480415c5e6509586d7b796356cec73a2f8a3e6/ruff-0.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c8661b0be91a38bd56db593e9331beaf9064a79028adee2d5f392674bbc5e88", size = 10247944 },
-    { url = "https://files.pythonhosted.org/packages/9f/52/59e0a9f2cf1ce5e6cbe336b6dd0144725c8ea3b97cac60688f4e7880bf13/ruff-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c0e8d3d2db7e9f6efd884f44b8dc542d5b6b590fc4bb334fdbc624d93a29a2", size = 10421725 },
-    { url = "https://files.pythonhosted.org/packages/a6/c3/dcd71acc6dff72ce66d13f4be5bca1dbed4db678dff2f0f6f307b04e5c02/ruff-0.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c3156d3f4b42e57247275a0a7e15a851c165a4fc89c5e8fa30ea6da4f7407b8", size = 9954435 },
-    { url = "https://files.pythonhosted.org/packages/a6/9a/342d336c7c52dbd136dee97d4c7797e66c3f92df804f8f3b30da59b92e9c/ruff-0.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:490b1e147c1260545f6d041c4092483e3f6d8eba81dc2875eaebcf9140b53905", size = 11492664 },
-    { url = "https://files.pythonhosted.org/packages/84/35/6e7defd2d7ca95cc385ac1bd9f7f2e4a61b9cc35d60a263aebc8e590c462/ruff-0.11.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1bc09a7419e09662983b1312f6fa5dab829d6ab5d11f18c3760be7ca521c9329", size = 12207856 },
-    { url = "https://files.pythonhosted.org/packages/22/78/da669c8731bacf40001c880ada6d31bcfb81f89cc996230c3b80d319993e/ruff-0.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcfa478daf61ac8002214eb2ca5f3e9365048506a9d52b11bea3ecea822bb844", size = 11645156 },
-    { url = "https://files.pythonhosted.org/packages/ee/47/e27d17d83530a208f4a9ab2e94f758574a04c51e492aa58f91a3ed7cbbcb/ruff-0.11.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6fbb2aed66fe742a6a3a0075ed467a459b7cedc5ae01008340075909d819df1e", size = 13884167 },
-    { url = "https://files.pythonhosted.org/packages/9f/5e/42ffbb0a5d4b07bbc642b7d58357b4e19a0f4774275ca6ca7d1f7b5452cd/ruff-0.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c0c1ff014351c0b0cdfdb1e35fa83b780f1e065667167bb9502d47ca41e6db", size = 11348311 },
-    { url = "https://files.pythonhosted.org/packages/c8/51/dc3ce0c5ce1a586727a3444a32f98b83ba99599bb1ebca29d9302886e87f/ruff-0.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e4fd5ff5de5f83e0458a138e8a869c7c5e907541aec32b707f57cf9a5e124445", size = 10305039 },
-    { url = "https://files.pythonhosted.org/packages/60/e0/475f0c2f26280f46f2d6d1df1ba96b3399e0234cf368cc4c88e6ad10dcd9/ruff-0.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:96bc89a5c5fd21a04939773f9e0e276308be0935de06845110f43fd5c2e4ead7", size = 9937939 },
-    { url = "https://files.pythonhosted.org/packages/e2/d3/3e61b7fd3e9cdd1e5b8c7ac188bec12975c824e51c5cd3d64caf81b0331e/ruff-0.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a9352b9d767889ec5df1483f94870564e8102d4d7e99da52ebf564b882cdc2c7", size = 10923259 },
-    { url = "https://files.pythonhosted.org/packages/30/32/cd74149ebb40b62ddd14bd2d1842149aeb7f74191fb0f49bd45c76909ff2/ruff-0.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:049a191969a10897fe052ef9cc7491b3ef6de79acd7790af7d7897b7a9bfbcb6", size = 11406212 },
-    { url = "https://files.pythonhosted.org/packages/00/ef/033022a6b104be32e899b00de704d7c6d1723a54d4c9e09d147368f14b62/ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2", size = 10310905 },
-    { url = "https://files.pythonhosted.org/packages/ed/8a/163f2e78c37757d035bd56cd60c8d96312904ca4a6deeab8442d7b3cbf89/ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21", size = 11411730 },
-    { url = "https://files.pythonhosted.org/packages/4e/f7/096f6efabe69b49d7ca61052fc70289c05d8d35735c137ef5ba5ef423662/ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657", size = 10538956 },
+    { url = "https://files.pythonhosted.org/packages/62/99/102578506f0f5fa29fd7e0df0a273864f79af044757aef73d1cae0afe6ad/ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477", size = 10113146 },
+    { url = "https://files.pythonhosted.org/packages/74/ad/5cd4ba58ab602a579997a8494b96f10f316e874d7c435bcc1a92e6da1b12/ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272", size = 10867092 },
+    { url = "https://files.pythonhosted.org/packages/fc/3e/d3f13619e1d152c7b600a38c1a035e833e794c6625c9a6cea6f63dbf3af4/ruff-0.11.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9", size = 10224082 },
+    { url = "https://files.pythonhosted.org/packages/90/06/f77b3d790d24a93f38e3806216f263974909888fd1e826717c3ec956bbcd/ruff-0.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb", size = 10394818 },
+    { url = "https://files.pythonhosted.org/packages/99/7f/78aa431d3ddebfc2418cd95b786642557ba8b3cb578c075239da9ce97ff9/ruff-0.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3", size = 9952251 },
+    { url = "https://files.pythonhosted.org/packages/30/3e/f11186d1ddfaca438c3bbff73c6a2fdb5b60e6450cc466129c694b0ab7a2/ruff-0.11.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74", size = 11563566 },
+    { url = "https://files.pythonhosted.org/packages/22/6c/6ca91befbc0a6539ee133d9a9ce60b1a354db12c3c5d11cfdbf77140f851/ruff-0.11.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608", size = 12208721 },
+    { url = "https://files.pythonhosted.org/packages/19/b0/24516a3b850d55b17c03fc399b681c6a549d06ce665915721dc5d6458a5c/ruff-0.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f", size = 11662274 },
+    { url = "https://files.pythonhosted.org/packages/d7/65/76be06d28ecb7c6070280cef2bcb20c98fbf99ff60b1c57d2fb9b8771348/ruff-0.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147", size = 13792284 },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/4ceed7147e05852876f3b5f3fdc23f878ce2b7e0b90dd6e698bda3d20787/ruff-0.11.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b", size = 11327861 },
+    { url = "https://files.pythonhosted.org/packages/c4/78/4935ecba13706fd60ebe0e3dc50371f2bdc3d9bc80e68adc32ff93914534/ruff-0.11.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9", size = 10276560 },
+    { url = "https://files.pythonhosted.org/packages/81/7f/1b2435c3f5245d410bb5dc80f13ec796454c21fbda12b77d7588d5cf4e29/ruff-0.11.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab", size = 9945091 },
+    { url = "https://files.pythonhosted.org/packages/39/c4/692284c07e6bf2b31d82bb8c32f8840f9d0627d92983edaac991a2b66c0a/ruff-0.11.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630", size = 10977133 },
+    { url = "https://files.pythonhosted.org/packages/94/cf/8ab81cb7dd7a3b0a3960c2769825038f3adcd75faf46dd6376086df8b128/ruff-0.11.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f", size = 11378514 },
+    { url = "https://files.pythonhosted.org/packages/d9/3a/a647fa4f316482dacf2fd68e8a386327a33d6eabd8eb2f9a0c3d291ec549/ruff-0.11.2-py3-none-win32.whl", hash = "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc", size = 10319835 },
+    { url = "https://files.pythonhosted.org/packages/86/54/3c12d3af58012a5e2cd7ebdbe9983f4834af3f8cbea0e8a8c74fa1e23b2b/ruff-0.11.2-py3-none-win_amd64.whl", hash = "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080", size = 11373713 },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/dd813703af8a1e2ac33bf3feb27e8a5ad514c9f219df80c64d69807e7f71/ruff-0.11.2-py3-none-win_arm64.whl", hash = "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4", size = 10441990 },
 ]
 
 [[package]]
@@ -1270,11 +1288,15 @@ name = "sackd"
 version = "0.0"
 source = { virtual = "charms/sackd" }
 dependencies = [
+    { name = "hpc-libs" },
     { name = "ops" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "ops" }]
+requires-dist = [
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" },
+    { name = "ops" },
+]
 
 [[package]]
 name = "six"
@@ -1290,6 +1312,7 @@ name = "slurm-charms"
 version = "0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "hpc-libs" },
     { name = "influxdb" },
     { name = "netifaces-plus" },
     { name = "nvidia-ml-py" },
@@ -1327,10 +1350,11 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'" },
     { name = "cosl", marker = "extra == 'dev'" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
-    { name = "cryptography", marker = "extra == 'dev'", specifier = "~=43.0.1" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = "~=44.0.1" },
     { name = "dbus-fast", marker = "extra == 'dev'", specifier = ">=1.90.2" },
     { name = "distro", marker = "extra == 'dev'", specifier = "==1.9.0" },
     { name = "flake8", marker = "extra == 'dev'" },
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" },
     { name = "influxdb", specifier = "==5.3.2" },
     { name = "juju", marker = "extra == 'dev'", specifier = "~=3.3" },
     { name = "netifaces-plus", specifier = "==0.12.4" },
@@ -1344,8 +1368,8 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "~=7.2" },
-    { name = "pytest-operator", marker = "extra == 'dev'", specifier = "~=0.34" },
-    { name = "pytest-order", marker = "extra == 'dev'", specifier = "~=1.1" },
+    { name = "pytest-operator", marker = "extra == 'dev'", specifier = "~=0.41" },
+    { name = "pytest-order", marker = "extra == 'dev'", specifier = "~=1.3" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = "~=1.0.1" },
     { name = "pyyaml", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -1359,6 +1383,7 @@ name = "slurmctld"
 version = "0.0"
 source = { virtual = "charms/slurmctld" }
 dependencies = [
+    { name = "hpc-libs" },
     { name = "influxdb" },
     { name = "netifaces-plus" },
     { name = "ops" },
@@ -1367,6 +1392,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" },
     { name = "influxdb" },
     { name = "netifaces-plus" },
     { name = "ops" },
@@ -1378,6 +1404,7 @@ name = "slurmd"
 version = "0.0"
 source = { virtual = "charms/slurmd" }
 dependencies = [
+    { name = "hpc-libs" },
     { name = "nvidia-ml-py" },
     { name = "ops" },
     { name = "slurmutils" },
@@ -1386,6 +1413,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" },
     { name = "nvidia-ml-py" },
     { name = "ops" },
     { name = "slurmutils" },
@@ -1397,12 +1425,14 @@ name = "slurmdbd"
 version = "0.0"
 source = { virtual = "charms/slurmdbd" }
 dependencies = [
+    { name = "hpc-libs" },
     { name = "ops" },
     { name = "slurmutils" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" },
     { name = "ops" },
     { name = "slurmutils" },
 ]
@@ -1412,12 +1442,14 @@ name = "slurmrestd"
 version = "0.0"
 source = { virtual = "charms/slurmrestd" }
 dependencies = [
+    { name = "hpc-libs" },
     { name = "ops" },
     { name = "slurmutils" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" },
     { name = "ops" },
     { name = "slurmutils" },
 ]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Migrates all our charms from using the charm libraries from `hpc-libs` to use the `hpc-libs` python package.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Change is entirely internal, so it doesn't need documentation changes.
