### PR TITLE
fix: set MemSpecLimit to always be less than RealMemory

### DIFF
--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -378,10 +378,12 @@ class SlurmdCharm(CharmBase):
                     f"gpu:{model}:{len(devices)}"
                 ]
 
+        real_memory = int(cast(str, slurmd_info["RealMemory"]))
+
         node = {
             "node_parameters": {
                 **slurmd_info,
-                "MemSpecLimit": "1024",
+                "MemSpecLimit": str(min(1024, real_memory // 2)),
                 **self._user_supplied_node_parameters,
             },
             "new_node": self._new_node,


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes
~Depends on #91~

Fixes a bug where nodes would always return 1024 as their `MemSpecLimit`, even if they had less than 1024 MB of memory.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Internal change.

