### PR TITLE
feat: automatically manage binary packages from repository.py

### DIFF
--- a/charms/sackd/charmcraft.yaml
+++ b/charms/sackd/charmcraft.yaml
@@ -34,9 +34,6 @@ parts:
   charm:
     build-packages:
       - git
-    charm-binary-python-packages:
-      - cryptography ~= 44.0.0
-      - rpds-py ~= 0.23.1
 
 provides:
   slurmctld:

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -56,10 +56,6 @@ parts:
   charm:
     build-packages:
       - git
-    charm-binary-python-packages:
-      - cryptography ~= 44.0.0
-      - rpds-py ~= 0.23.1
-      - pydantic-core ~= 2.33.0
 
 config:
   options:

--- a/charms/slurmctld/pyproject.toml
+++ b/charms/slurmctld/pyproject.toml
@@ -2,7 +2,7 @@
 name = "slurmctld"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = ["ops", "slurmutils", "influxdb", "netifaces-plus", "hpc-libs"]
+dependencies = ["ops", "slurmutils", "influxdb", "netifaces-plus", "hpc-libs", "cosl"]
 
 [tool.repository]
 libraries = ["grafana-agent.cos_agent"]

--- a/charms/slurmd/charmcraft.yaml
+++ b/charms/slurmd/charmcraft.yaml
@@ -36,9 +36,6 @@ parts:
       - libkmod-dev
       - libpci-dev
       - pkgconf
-    charm-binary-python-packages:
-      - cryptography ~= 44.0.0
-      - rpds-py ~= 0.23.1
   nhc:
     plugin: nil
     build-packages:

--- a/charms/slurmrestd/charmcraft.yaml
+++ b/charms/slurmrestd/charmcraft.yaml
@@ -31,9 +31,6 @@ parts:
   charm:
     build-packages:
       - git
-    charm-binary-python-packages:
-      - cryptography ~= 44.0.0
-      - rpds-py ~= 0.23.1
 
 provides:
   slurmctld:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "netifaces-plus==0.12.4",
     "nvidia-ml-py==12.560.30",
     "rpds-py ~= 0.23.1",
+    "cosl >= 0.0.50",
     "hpc-libs",
 ]
 
@@ -49,11 +50,6 @@ dev = [
     "codespell",
     "pyright",
 
-    # `cos` dependencies
-    "cosl>=0.0.50",
-    "pydantic-core ~= 2.33.0",
-    "pydantic",
-
     # TiCS scan dependencies
     "flake8",
     "pylint",
@@ -78,6 +74,11 @@ external-libraries = [
     { lib = "operator-libs-linux.juju_systemd_notices", version = "0.2" },
     { lib = "data-platform-libs.data_interfaces", version = "0.41" },
     { lib = "grafana-agent.cos_agent", version = "0.20" },
+]
+binary-packages = [
+    "pydantic-core",
+    "rpds-py",
+    "cryptography"
 ]
 
 # Testing tools configuration

--- a/uv.lock
+++ b/uv.lock
@@ -1313,6 +1313,7 @@ name = "slurm-charms"
 version = "0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "cosl" },
     { name = "hpc-libs" },
     { name = "influxdb" },
     { name = "netifaces-plus" },
@@ -1325,7 +1326,6 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "codespell" },
-    { name = "cosl" },
     { name = "coverage" },
     { name = "cryptography" },
     { name = "dbus-fast" },
@@ -1334,8 +1334,6 @@ dev = [
     { name = "juju" },
     { name = "ops", extra = ["testing"] },
     { name = "pycryptodome" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
     { name = "pyfakefs" },
     { name = "pylint" },
     { name = "pyright" },
@@ -1351,7 +1349,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "codespell", marker = "extra == 'dev'" },
-    { name = "cosl", marker = "extra == 'dev'", specifier = ">=0.0.50" },
+    { name = "cosl", specifier = ">=0.0.50" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = "~=44.0.1" },
     { name = "dbus-fast", marker = "extra == 'dev'", specifier = ">=1.90.2" },
@@ -1365,8 +1363,6 @@ requires-dist = [
     { name = "ops", specifier = "~=2.19" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'", specifier = "~=2.19" },
     { name = "pycryptodome", marker = "extra == 'dev'", specifier = "==3.20.0" },
-    { name = "pydantic", marker = "extra == 'dev'" },
-    { name = "pydantic-core", marker = "extra == 'dev'", specifier = "~=2.33.0" },
     { name = "pyfakefs", marker = "extra == 'dev'", specifier = "==5.7.1" },
     { name = "pylint", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
@@ -1388,6 +1384,7 @@ name = "slurmctld"
 version = "0.0"
 source = { virtual = "charms/slurmctld" }
 dependencies = [
+    { name = "cosl" },
     { name = "hpc-libs" },
     { name = "influxdb" },
     { name = "netifaces-plus" },
@@ -1397,6 +1394,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cosl" },
     { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1c1fd91bcc7de71fd9da7bc077f88757c81d14ba" },
     { name = "influxdb" },
     { name = "netifaces-plus" },


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Adds functionality on `repository.py` to inject the required binary packages onto the `charmcraft.yaml` files instead of having to manually manage them.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Internal tooling improvement, which doesn't require documentation.

