### PR TITLE
fix: replace deprecated logger `warn` method

### DIFF
--- a/charms/slurmd/src/utils/rdma.py
+++ b/charms/slurmd/src/utils/rdma.py
@@ -65,7 +65,7 @@ def _override_ompi_conf() -> None:
 
     file = Path(conf)
     if not file.exists():
-        _logger.warn("%s not found. skipping OpenMPI UCX enablement", file)
+        _logger.warning("%s not found. skipping OpenMPI UCX enablement", file)
         return
 
     content = file.read_text().splitlines()


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Single line fix to replace a logging `warn` call with `warning` as the former [is deprecated](https://docs.python.org/3/library/logging.html#logging.Logger.warning).

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)



## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

