### PR TITLE
chore: bump juju terraform provider version

### DIFF
--- a/charms/sackd/terraform/versions.tf
+++ b/charms/sackd/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.13.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/charms/slurmctld/terraform/versions.tf
+++ b/charms/slurmctld/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.13.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/charms/slurmd/terraform/versions.tf
+++ b/charms/slurmd/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.13.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/charms/slurmdbd/terraform/versions.tf
+++ b/charms/slurmdbd/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.13.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/charms/slurmrestd/terraform/versions.tf
+++ b/charms/slurmrestd/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.13.0"
+      version = ">= 0.19.0"
     }
   }
 }


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Bumps the Juju terraform provider version to 0.19.0.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Just an internal change.

