### PR TITLE
ci: install charmcraft before running the TiCS scan

### DIFF
--- a/.github/workflows/nightly-TICS.yaml
+++ b/.github/workflows/nightly-TICS.yaml
@@ -24,6 +24,9 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: 0.5.8
+
+      - name: Install Charmcraft
+        run: sudo snap install charmcraft --classic --channel latest/stable
       
       - name: Run coverage tests
         run: just repo unit


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Fixes our CI for the TiCS scan by installing charmcraft before running the unit tests.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Just a CI fix.