### PR TITLE
(feat): open slurm service ports

### DIFF
--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 
+from constants import SACKD_PORT
 from hpc_libs.slurm_ops import SackdManager, SlurmOpsError
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent
 from ops import (
@@ -67,6 +68,7 @@ class SackdCharm(CharmBase):
             logger.error(e.message)
             event.defer()
 
+        self.unit.open_port("tcp", SACKD_PORT)
         self._check_status()
 
     def _on_update_status(self, _: UpdateStatusEvent) -> None:

--- a/charms/sackd/src/constants.py
+++ b/charms/sackd/src/constants.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Vantage Compute Corporation
+# See LICENSE file for licensing details.
+
+"""Constants."""
+
+SACKD_PORT = 6818

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -14,8 +14,8 @@ from constants import (
     CHARM_MAINTAINED_CGROUP_CONF_PARAMETERS,
     CHARM_MAINTAINED_SLURM_CONF_PARAMETERS,
     CLUSTER_NAME_PREFIX,
-    EXPORTER_PORT,
     PEER_RELATION,
+    PROMETHEUS_EXPORTER_PORT,
     SLURMCTLD_PORT,
 )
 from exceptions import IngressAddressUnavailableError
@@ -150,7 +150,7 @@ class SlurmctldCharm(CharmBase):
             event.defer()
 
         self.unit.open_port("tcp", SLURMCTLD_PORT)
-        self.unit.open_port("tcp", EXPORTER_PORT)
+        self.unit.open_port("tcp", PROMETHEUS_EXPORTER_PORT)
 
     def _on_start(self, event: StartEvent) -> None:
         """Set cluster_name and write slurm.conf.

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -16,6 +16,7 @@ from constants import (
     CLUSTER_NAME_PREFIX,
     PEER_RELATION,
     SLURMCTLD_PORT,
+    EXPORTER_PORT,
 )
 from exceptions import IngressAddressUnavailableError
 from hpc_libs.is_container import is_container
@@ -149,6 +150,7 @@ class SlurmctldCharm(CharmBase):
             event.defer()
 
         self.unit.open_port("tcp", SLURMCTLD_PORT)
+        self.unit.open_port("tcp", EXPORTER_PORT)
 
     def _on_start(self, event: StartEvent) -> None:
         """Set cluster_name and write slurm.conf.

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -14,9 +14,9 @@ from constants import (
     CHARM_MAINTAINED_CGROUP_CONF_PARAMETERS,
     CHARM_MAINTAINED_SLURM_CONF_PARAMETERS,
     CLUSTER_NAME_PREFIX,
+    EXPORTER_PORT,
     PEER_RELATION,
     SLURMCTLD_PORT,
-    EXPORTER_PORT,
 )
 from exceptions import IngressAddressUnavailableError
 from hpc_libs.is_container import is_container

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -15,6 +15,7 @@ from constants import (
     CHARM_MAINTAINED_SLURM_CONF_PARAMETERS,
     CLUSTER_NAME_PREFIX,
     PEER_RELATION,
+    SLURMCTLD_PORT,
 )
 from exceptions import IngressAddressUnavailableError
 from hpc_libs.is_container import is_container
@@ -146,6 +147,8 @@ class SlurmctldCharm(CharmBase):
         except SlurmOpsError as e:
             logger.error(e.message)
             event.defer()
+
+        self.unit.open_port("tcp", SLURMCTLD_PORT)
 
     def _on_start(self, event: StartEvent) -> None:
         """Set cluster_name and write slurm.conf.

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -4,7 +4,7 @@
 """This module provides constants for the slurmctld-operator charm."""
 
 SLURMCTLD_PORT = 6817
-EXPORTER_PORT = 9092
+PROMETHEUS_EXPORTER_PORT = 9092
 
 PEER_RELATION = "slurmctld-peer"
 

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -3,6 +3,8 @@
 
 """This module provides constants for the slurmctld-operator charm."""
 
+SLURMCTLD_PORT = 6817
+
 PEER_RELATION = "slurmctld-peer"
 
 CLUSTER_NAME_PREFIX = "charmed-hpc"
@@ -28,7 +30,7 @@ CHARM_MAINTAINED_SLURM_CONF_PARAMETERS = {
     "PlugStackConfig": "/etc/slurm/plugstack.conf.d/plugstack.conf",
     "SelectType": "select/cons_tres",
     "SelectTypeParameters": "CR_CPU_Memory",
-    "SlurmctldPort": "6817",
+    "SlurmctldPort": SLURMCTLD_PORT,
     "SlurmdPort": "6818",
     "StateSaveLocation": "/var/lib/slurm/checkpoint",
     "SlurmdSpoolDir": "/var/lib/slurm/slurmd",

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -31,7 +31,7 @@ CHARM_MAINTAINED_SLURM_CONF_PARAMETERS = {
     "PlugStackConfig": "/etc/slurm/plugstack.conf.d/plugstack.conf",
     "SelectType": "select/cons_tres",
     "SelectTypeParameters": "CR_CPU_Memory",
-    "SlurmctldPort": SLURMCTLD_PORT,
+    "SlurmctldPort": f"{SLURMCTLD_PORT}",
     "SlurmdPort": "6818",
     "StateSaveLocation": "/var/lib/slurm/checkpoint",
     "SlurmdSpoolDir": "/var/lib/slurm/slurmd",

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -4,6 +4,7 @@
 """This module provides constants for the slurmctld-operator charm."""
 
 SLURMCTLD_PORT = 6817
+EXPORTER_PORT = 9092
 
 PEER_RELATION = "slurmctld-peer"
 

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, cast
 
+from constants import SLURMD_PORT
 from hpc_libs.slurm_ops import SlurmdManager, SlurmOpsError
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent
 from ops import (
@@ -116,6 +117,8 @@ class SlurmdCharm(CharmBase):
         except (SlurmOpsError, gpu.GPUOpsError) as e:
             logger.error(e.message)
             event.defer()
+
+        self.unit.open_port("tcp", SLURMD_PORT)
 
         self._check_status()
         self._reboot_if_required()

--- a/charms/slurmd/src/constants.py
+++ b/charms/slurmd/src/constants.py
@@ -14,6 +14,8 @@
 
 """Slurmd Charm Constants."""
 
+SLURMD_PORT = 6818
+
 NHC_CONFIG = """
 # Enforce short hostnames to match the node names as tracked by slurm.
 * || HOSTNAME="$HOSTNAME_S"

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -11,7 +11,7 @@ from time import sleep
 from typing import Any, Dict, Union
 from urllib.parse import urlparse
 
-from constants import CHARM_MAINTAINED_PARAMETERS, SLURM_ACCT_DB
+from constants import CHARM_MAINTAINED_PARAMETERS, SLURM_ACCT_DB, SLURMDBD_PORT
 from hpc_libs.slurm_ops import SlurmdbdManager, SlurmOpsError
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent, SlurmctldUnavailableEvent
 from ops import (
@@ -82,6 +82,7 @@ class SlurmdbdCharm(CharmBase):
             logger.error(e.message)
             event.defer()
 
+        self.unit.open_port("tcp", SLURMDBD_PORT)
         self._check_status()
 
     def _on_update_status(self, _: UpdateStatusEvent) -> None:

--- a/charms/slurmdbd/src/constants.py
+++ b/charms/slurmdbd/src/constants.py
@@ -7,7 +7,7 @@ SLURMDBD_PORT = 6819
 
 SLURM_ACCT_DB = "slurm_acct_db"
 CHARM_MAINTAINED_PARAMETERS = {
-    "DbdPort": SLURMDBD_PORT,
+    "DbdPort": f"{SLURMDBD_PORT}",
     "AuthType": "auth/slurm",
     "SlurmUser": "slurm",
     "PluginDir": ["/usr/lib/x86_64-linux-gnu/slurm-wlm"],

--- a/charms/slurmdbd/src/constants.py
+++ b/charms/slurmdbd/src/constants.py
@@ -3,9 +3,11 @@
 
 """Constants."""
 
+SLURMDBD_PORT = 6819
+
 SLURM_ACCT_DB = "slurm_acct_db"
 CHARM_MAINTAINED_PARAMETERS = {
-    "DbdPort": "6819",
+    "DbdPort": SLURMDBD_PORT,
     "AuthType": "auth/slurm",
     "SlurmUser": "slurm",
     "PluginDir": ["/usr/lib/x86_64-linux-gnu/slurm-wlm"],

--- a/charms/slurmrestd/src/charm.py
+++ b/charms/slurmrestd/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 
+from constants import SLURMRESTD_PORT
 from hpc_libs.slurm_ops import SlurmOpsError, SlurmrestdManager
 from interface_slurmctld import Slurmctld, SlurmctldAvailableEvent, SlurmctldUnavailableEvent
 from ops import (
@@ -60,6 +61,7 @@ class SlurmrestdCharm(CharmBase):
             logger.error(e.message)
             event.defer()
 
+        self.unit.open_port("tcp", SLURMRESTD_PORT)
         self._check_status()
 
     def _on_update_status(self, _: UpdateStatusEvent) -> None:

--- a/charms/slurmrestd/src/constants.py
+++ b/charms/slurmrestd/src/constants.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Vantage Compute Corporation
+# See LICENSE file for licensing details.
+
+"""Constants."""
+
+SLURMRESTD_PORT = 6820


### PR DESCRIPTION
These changes add the open_port() to the end of the install hook for each of; slurmctld, slurmd, slurmdbd, slurmrestd, sackd.

These changes are needed to facilitate the charm creating security group rules that will allow traffic to the slurm services.

Fixes: https://github.com/charmed-hpc/slurm-charms/issues/103

# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)



#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)



## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

