### PR TITLE
fix: merge slurm_conf before calling SlurmConfig

### DIFF
--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -533,8 +533,8 @@ class SlurmctldCharm(CharmBase):
             profiling_parameters = self._assemble_profiling_params()
             logger.debug(f"## profiling_params: {profiling_parameters}")
 
-        slurm_conf = SlurmConfig(
-            **{
+        slurm_conf = SlurmConfig.from_dict(
+            {
                 "ClusterName": self.cluster_name,
                 "SlurmctldAddr": self._ingress_address,
                 "SlurmctldHost": [self._slurmctld.hostname],

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -503,7 +503,6 @@ class SlurmctldCharm(CharmBase):
     def _assemble_slurm_conf(self) -> SlurmConfig:
         """Return the slurm.conf parameters."""
         user_supplied_parameters = self._get_user_supplied_parameters()
-
         slurmd_parameters = self._slurmd.get_new_nodes_and_nodes_and_partitions()
 
         def _assemble_slurmctld_parameters() -> dict[str, Any]:
@@ -535,19 +534,22 @@ class SlurmctldCharm(CharmBase):
             logger.debug(f"## profiling_params: {profiling_parameters}")
 
         slurm_conf = SlurmConfig(
-            ClusterName=self.cluster_name,
-            SlurmctldAddr=self._ingress_address,
-            SlurmctldHost=[self._slurmctld.hostname],
-            SlurmctldParameters=_assemble_slurmctld_parameters(),
-            ProctrackType="proctrack/linuxproc" if is_container() else "proctrack/cgroup",
-            TaskPlugin=["task/affinity"] if is_container() else ["task/cgroup", "task/affinity"],
-            **profiling_parameters,
-            **accounting_params,
-            **CHARM_MAINTAINED_SLURM_CONF_PARAMETERS,
-            **slurmd_parameters,
-            **user_supplied_parameters,
+            **{
+                "ClusterName": self.cluster_name,
+                "SlurmctldAddr": self._ingress_address,
+                "SlurmctldHost": [self._slurmctld.hostname],
+                "SlurmctldParameters": _assemble_slurmctld_parameters(),
+                "ProctrackType": "proctrack/linuxproc" if is_container() else "proctrack/cgroup",
+                "TaskPlugin": (
+                    ["task/affinity"] if is_container() else ["task/cgroup", "task/affinity"]
+                ),
+                **profiling_parameters,
+                **accounting_params,
+                **CHARM_MAINTAINED_SLURM_CONF_PARAMETERS,
+                **slurmd_parameters,
+                **user_supplied_parameters,
+            }
         )
-
         logger.debug(f"slurm.conf: {slurm_conf.dict()}")
         return slurm_conf
 

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -253,12 +253,27 @@ class TestCharm(TestCase):
         """Test that user supplied parameters are parsed correctly."""
         self.harness.add_relation("slurmd", "slurmd")
         self.harness.add_relation("slurmctld-peer", self.harness.charm.app.name)
-        self.harness.update_config(
-            {"slurm-conf-parameters": "JobAcctGatherFrequency=task=30,network=40"}
+
+        select_type_parameters_val = "CR_Core_Memory"
+        job_acct_gather_frequency_val = "task=30,network=40"
+
+        select_type_parameters = f"SelectTypeParameters={select_type_parameters_val}"
+        job_acct_gather_frequency = f"JobAcctGatherFrequency={job_acct_gather_frequency_val}"
+
+        user_supplied_slurm_config = "\n".join([select_type_parameters, job_acct_gather_frequency])
+
+        # Set user suppled slurm config already defined by the charm in
+        # CHARM_MAINTAINED_SLURM_CONF_PARAMETERS so that we test overriding predefined
+        # key,val with user supplied config in addition to setting slurm config that doesn't
+        # override any predefined slurm configuration.
+        self.harness.update_config({"slurm-conf-parameters": user_supplied_slurm_config})
+        self.assertEqual(
+            self.harness.charm._assemble_slurm_conf().select_type_parameters,
+            select_type_parameters_val,
         )
         self.assertEqual(
             self.harness.charm._assemble_slurm_conf().job_acct_gather_frequency,
-            "task=30,network=40",
+            job_acct_gather_frequency_val,
         )
 
     def test_resume_nodes_valid_input(self) -> None:


### PR DESCRIPTION
These changes merge the values of the slurm config dict prior to passing it as input to SlurmConfig and add a test for setting user supplied slurm config that overrides slurm config set by the charm.

Fixes: #106

# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)



#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)



## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

