### PR TITLE
fix(slurmdbd): user supplied configuration

### DIFF
--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -38,6 +38,10 @@ parts:
       - cryptography ~= 44.0.0
       - rpds-py ~= 0.23.1
 
+peers:
+  slurmdbd-peer:
+    interface: slurmdbd-peer
+
 requires:
   database:
     interface: mysql_client
@@ -48,3 +52,14 @@ provides:
   cos-agent:
     interface: cos_agent
     limit: 1
+
+config:
+  options:
+    slurmdbd-conf-parameters:
+      type: string
+      default: ""
+      description: |
+        User supplied Slurmdbd configuration as a multiline string.
+
+        Example usage:
+        $ juju config slurmdbd slurmdbd-conf-parameters="$(cat additional.conf)"

--- a/charms/slurmdbd/src/exceptions.py
+++ b/charms/slurmdbd/src/exceptions.py
@@ -1,5 +1,4 @@
-# Copyright 2024 Omnivector, LLC
-# Copyright 2025 Vantage Compute Corporation
+# Copyright (c) 2025 Vantage Compute Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Slurmdbd Charm Constants."""
+"""Custom exceptions for the slurmdbd operator."""
 
 
-PEER_RELATION = "slurmdbd-peer"
+class IngressAddressUnavailableError(Exception):
+    """Exception raised when a slurm operation failed."""
 
-SLURMDBD_PORT = 6819
-
-SLURM_ACCT_DB = "slurm_acct_db"
-CHARM_MAINTAINED_PARAMETERS = {
-    "DbdPort": f"{SLURMDBD_PORT}",
-    "AuthType": "auth/slurm",
-    "SlurmUser": "slurm",
-    "PluginDir": ["/usr/lib/x86_64-linux-gnu/slurm-wlm"],
-    "PidFile": "/var/run/slurmdbd/slurmdbd.pid",
-    "LogFile": "/var/log/slurm/slurmdbd.log",
-    "StorageType": "accounting_storage/mysql",
-}
+    @property
+    def message(self) -> str:
+        """Return message passed as argument to exception."""
+        return self.args[0]


### PR DESCRIPTION
These changes fix #114 and #115 by a) adding the
missing slurmdbd-conf-parameters config option in slurmdbd (#114), and b) fix the dict merging error (#115).

Notes:
 - The slurmdbd-peer relation was added to facilitate getting the ingress-address.

# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)



#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)



## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

