### PR TITLE
feat(slurmdbd): Add user supplied db-uri

### DIFF
--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -55,6 +55,11 @@ provides:
 
 config:
   options:
+    db-uri-secret-id:
+      default:
+      type: secret
+      description: |
+        The secret-id for db-uri. E.g. "secret:XXXXXXXXXXX" 
     slurmdbd-conf-parameters:
       type: string
       default: ""

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -28,6 +28,7 @@ from ops import (
     main,
 )
 from slurmutils.models import SlurmdbdConfig
+from utils import parse_user_supplied_parameters
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseCreatedEvent, DatabaseRequires
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider

--- a/charms/slurmdbd/src/constants.py
+++ b/charms/slurmdbd/src/constants.py
@@ -15,6 +15,7 @@
 
 """Slurmdbd Charm Constants."""
 
+DB_URI_SECRET_LABEL = "db-uri"
 
 PEER_RELATION = "slurmdbd-peer"
 

--- a/charms/slurmdbd/src/exceptions.py
+++ b/charms/slurmdbd/src/exceptions.py
@@ -15,6 +15,15 @@
 """Custom exceptions for the slurmdbd operator."""
 
 
+class DBURISecretAccessError(RuntimeError):
+    """Exception raised when the db-uri secret cannot be accessed."""
+
+    @property
+    def message(self) -> str:
+        """Return message passed as argument to exception."""
+        return self.args[0]
+
+
 class IngressAddressUnavailableError(Exception):
     """Exception raised when a slurm operation failed."""
 
@@ -22,3 +31,7 @@ class IngressAddressUnavailableError(Exception):
     def message(self) -> str:
         """Return message passed as argument to exception."""
         return self.args[0]
+
+
+class InvalidDBURIError(ValueError):
+    """Raised when a database URI is malformed or missing required components."""

--- a/charms/slurmdbd/src/utils.py
+++ b/charms/slurmdbd/src/utils.py
@@ -3,28 +3,40 @@
 # See LICENSE file for licensing details.
 
 """utils.py."""
+from typing import Dict
+from urllib.parse import urlparse
 
-import logging
-from typing import Any, Dict
-
-logger = logging.getLogger(__name__)
+from exceptions import InvalidDBURIError
 
 
-def parse_user_supplied_parameters(custom_config: str) -> Dict[Any, Any]:
-    """Parse the user supplied parameters."""
-    user_supplied_parameters = {}
+def convert_db_uri_to_dict(db_uri: str) -> Dict[str, str]:
+    """Convert db_uri to a dictionary of database connection parameters."""
+    parsed = urlparse(db_uri)
 
-    try:
-        for line in str(custom_config).splitlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" not in line:
-                raise IndexError(f"Malformed config line (missing '='): {line}")
-            key, value = line.split("=", 1)
-            user_supplied_parameters[key.strip()] = value.strip()
-    except IndexError as e:
-        logger.error(f"Could not parse user supplied parameters: {e}.")
-        raise e
+    missing = []
+    if not parsed.username:
+        missing.append("username")
+    if not parsed.password:
+        missing.append("password")
+    if not parsed.hostname:
+        missing.append("hostname")
+    if not parsed.port:
+        missing.append("port")
+    if not parsed.path or parsed.path == "/":
+        missing.append("database (path)")
 
-    return user_supplied_parameters
+    if missing:
+        raise InvalidDBURIError(f"Missing required component(s) in db-uri: {', '.join(missing)}")
+
+    if parsed.scheme != "mysql":
+        raise InvalidDBURIError(
+            f"Invalid scheme: {parsed.scheme}. Only mysql scheme is supported."
+        )
+
+    return {
+        "StorageUser": str(parsed.username),
+        "StoragePass": str(parsed.password),
+        "StorageHost": str(parsed.hostname),
+        "StoragePort": str(parsed.port),
+        "StorageLoc": parsed.path.lstrip("/"),
+    }

--- a/charms/slurmdbd/src/utils.py
+++ b/charms/slurmdbd/src/utils.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Vantage Compute Corporation
+# See LICENSE file for licensing details.
+
+"""utils.py."""
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def parse_user_supplied_parameters(custom_config: str) -> Dict[Any, Any]:
+    """Parse the user supplied parameters."""
+    user_supplied_parameters = {}
+
+    try:
+        for line in str(custom_config).splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                raise IndexError(f"Malformed config line (missing '='): {line}")
+            key, value = line.split("=", 1)
+            user_supplied_parameters[key.strip()] = value.strip()
+    except IndexError as e:
+        logger.error(f"Could not parse user supplied parameters: {e}.")
+        raise e
+
+    return user_supplied_parameters

--- a/charms/slurmdbd/tests/unit/test_utils.py
+++ b/charms/slurmdbd/tests/unit/test_utils.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Vantage Compute Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test functions in utils.py."""
+
+# test_utils.py
+# test_utils.py
+
+import textwrap
+from unittest.mock import patch
+
+import pytest
+from utils import parse_user_supplied_parameters
+
+
+def test_parse_valid_config():
+    config = textwrap.dedent(
+        """
+        StorageType=accounting_storage/slurmdbd
+        LogFile=/var/log/slurm/slurmdbd.log
+        """
+    )
+    expected = {
+        "StorageType": "accounting_storage/slurmdbd",
+        "LogFile": "/var/log/slurm/slurmdbd.log",
+    }
+    result = parse_user_supplied_parameters(config)
+    assert result == expected
+
+
+def test_parse_with_comments_and_blank_lines():
+    config = textwrap.dedent(
+        """
+        # This is a comment
+        StorageType=accounting_storage/slurmdbd
+
+        LogFile=/var/log/slurm/slurmdbd.log
+        # Another comment
+        """
+    )
+    expected = {
+        "StorageType": "accounting_storage/slurmdbd",
+        "LogFile": "/var/log/slurm/slurmdbd.log",
+    }
+    result = parse_user_supplied_parameters(config)
+    assert result == expected
+
+
+def test_parse_empty_config():
+    config = ""
+    result = parse_user_supplied_parameters(config)
+    assert result == {}
+
+
+def test_parse_malformed_line_raises_index_error():
+    config = textwrap.dedent(
+        """
+        ValidKey=ValidValue
+        MalformedLineWithoutEquals
+        """
+    )
+
+    with patch("utils.logger") as mock_logger:
+        with pytest.raises(IndexError):
+            parse_user_supplied_parameters(config)
+        assert mock_logger.error.called
+        assert "Could not parse user supplied parameters" in mock_logger.error.call_args[0][0]
+
+
+def test_parse_handles_only_malformed_line():
+    config = "BadLineWithoutEquals"
+    with patch("utils.logger") as mock_logger:
+        with pytest.raises(IndexError):
+            parse_user_supplied_parameters(config)
+        assert mock_logger.error.called


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

These changes add support for user supplied mysql database via juju secrets.

### Example Configuration Using Docker

#### 1) Create a mysql database
```bash
docker run --name mysql-slurmdbd \
    -e MYSQL_USER=testuser \
    -e MYSQL_PASSWORD=testpassword \
    -e MYSQL_DATABASE=slurm_acct_db \
    -e MYSQL_ALLOW_EMPTY_PASSWORD=true \
    -p 3306:3306 \
    -d mysql:8.4
```
#### 2) Build the slurmdbd charm
```bash
just repo build slurmdbd
```
#### 3) Add juju infrastructure
```
ip=`hostname -i`

juju add-model mysql-testing

secret_id=`juju add-secret db-uri db-uri="mysql://testuser:testpassword@$ip:3306/slurm_acct_db"`

juju deploy ./_build/slurmdbd.charm --config db-uri-secret-id=$secret_id
juju deploy slurmctld --channel edge
juju deploy slurmd --channel edge

juju grant-secret db-uri slurmdbd

juju relate slurmctld slurmdbd
juju relate slurmctld slurmd
```

#### Related Issues, PRs, and Discussions
#109 


## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [ ] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

