### PR TITLE
feat(slurmctld): implement high availability (HA) for `slurmctld`

### DIFF
--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -36,7 +36,7 @@ class SackdCharm(CharmBase):
             auth_key=str(),
             sackd_installed=False,
             slurmctld_available=False,
-            slurmctld_host=str(),
+            slurmctld_hosts=str(),
         )
 
         self._sackd = SackdManager(snap=False)
@@ -81,13 +81,14 @@ class SackdCharm(CharmBase):
             event.defer()
             return
 
-        if (slurmctld_host := event.slurmctld_host) != self._stored.slurmctld_host:
-            if slurmctld_host is not None:
-                self._sackd.config_server = f"{slurmctld_host}:6817"
-                self._stored.slurmctld_host = slurmctld_host
-                logger.debug(f"slurmctld_host={slurmctld_host}")
+        if (slurmctld_hosts := event.slurmctld_hosts) != self._stored.slurmctld_hosts:
+            if slurmctld_hosts is not None:
+                # Create comma-separated list of slurmctld hosts with port number appended
+                self._sackd.config_server = ",".join(f"{host}:6817" for host in slurmctld_hosts)
+                self._stored.slurmctld_hosts = slurmctld_hosts
+                logger.debug(f"slurmctld_hosts={slurmctld_hosts}")
             else:
-                logger.debug("'slurmctld_host' not in event data.")
+                logger.debug("'slurmctld_hosts' not in event data.")
                 return
 
         if (auth_key := event.auth_key) != self._stored.auth_key:
@@ -117,7 +118,7 @@ class SackdCharm(CharmBase):
         logger.debug("## Slurmctld unavailable")
         self._stored.slurmctld_available = False
         self._stored.auth_key = ""
-        self._stored.slurmctld_host = ""
+        self._stored.slurmctld_hosts = ""
         self._sackd.service.disable()
         self._check_status()
 

--- a/charms/sackd/src/interface_slurmctld.py
+++ b/charms/sackd/src/interface_slurmctld.py
@@ -2,14 +2,12 @@
 
 import json
 import logging
-from typing import Union
 
 from ops import (
     EventBase,
     EventSource,
     Object,
     ObjectEvents,
-    Relation,
     RelationBrokenEvent,
     RelationChangedEvent,
 )
@@ -24,24 +22,24 @@ class SlurmctldAvailableEvent(EventBase):
         self,
         handle,
         auth_key,
-        slurmctld_host,
+        slurmctld_hosts,
     ):
         super().__init__(handle)
 
         self.auth_key = auth_key
-        self.slurmctld_host = slurmctld_host
+        self.slurmctld_hosts = slurmctld_hosts
 
     def snapshot(self):
         """Snapshot the event data."""
         return {
             "auth_key": self.auth_key,
-            "slurmctld_host": self.slurmctld_host,
+            "slurmctld_hosts": self.slurmctld_hosts,
         }
 
     def restore(self, snapshot):
         """Restore the snapshot of the event data."""
         self.auth_key = snapshot.get("auth_key")
-        self.slurmctld_host = snapshot.get("slurmctld_host")
+        self.slurmctld_hosts = snapshot.get("slurmctld_hosts")
 
 
 class SlurmctldUnavailableEvent(EventBase):
@@ -114,11 +112,6 @@ class Slurmctld(Object):
         self.on.slurmctld_unavailable.emit()
 
     @property
-    def _relation(self) -> Union[Relation, None]:
-        """Return the relation."""
-        return self.model.get_relation(self._relation_name)
-
-    @property
     def is_joined(self) -> bool:
-        """Return True if relation is joined."""
-        return True if self.model.relations.get(self._relation_name) else False
+        """Return True if relation(s) are joined."""
+        return all(self.model.relations.get(self._relation_name, ()))

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -68,6 +68,24 @@ config:
         This is important if a single database is used to record information from
         multiple Slurm-managed clusters.
 
+    use-network-state:
+      type: boolean
+      default: false
+      description: |
+        Use an external network file system for holding the Slurm configuration files
+        and controller state, i.e. its `StateSaveLocation` data`. If `false`, the
+        local root disk is used.
+
+        The network file system must be provided by another mechanism, such as the
+        `filesystem-client` charm. Deployment will block until a file system is
+        mounted at `/var/lib/slurm/checkpoint`.
+
+        NOTE: To use `slurmctld` High Availability, this configuration value must have
+        been `true` at charm deployment time.
+
+        This configuration can be set only at charm deployment. Migration from a local
+        disk to a network file system is not supported.
+
     default-partition:
       type: string
       default: ""

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -4,16 +4,18 @@
 
 """SlurmctldCharm."""
 
+import json
 import logging
-import secrets
 import shlex
+import shutil
 import subprocess
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from constants import (
     CHARM_MAINTAINED_CGROUP_CONF_PARAMETERS,
     CHARM_MAINTAINED_SLURM_CONF_PARAMETERS,
-    CLUSTER_NAME_PREFIX,
     PEER_RELATION,
     PROMETHEUS_EXPORTER_PORT,
     SLURMCTLD_PORT,
@@ -23,7 +25,11 @@ from hpc_libs.is_container import is_container
 from hpc_libs.slurm_ops import SlurmctldManager, SlurmOpsError
 from interface_influxdb import InfluxDB, InfluxDBAvailableEvent, InfluxDBUnavailableEvent
 from interface_sackd import Sackd
-from interface_slurmctld_peer import SlurmctldPeer, SlurmctldPeerError
+from interface_slurmctld_peer import (
+    SlurmctldAvailableEvent,
+    SlurmctldDepartedEvent,
+    SlurmctldPeer,
+)
 from interface_slurmd import (
     PartitionAvailableEvent,
     PartitionUnavailableEvent,
@@ -65,10 +71,9 @@ class SlurmctldCharm(CharmBase):
 
         self._stored.set_default(
             default_partition=str(),
-            jwt_key=str(),
-            auth_key=str(),
             new_nodes=[],
             nhc_params=str(),
+            save_state_location=str(),
             slurm_installed=False,
             slurmdbd_host=str(),
             user_supplied_slurm_conf_params=str(),
@@ -96,6 +101,8 @@ class SlurmctldCharm(CharmBase):
             self.on.start: self._on_start,
             self.on.update_status: self._on_update_status,
             self.on.config_changed: self._on_config_changed,
+            self._slurmctld_peer.on.slurmctld_available: self._on_slurmctld_changed,
+            self._slurmctld_peer.on.slurmctld_departed: self._on_slurmctld_changed,
             self._slurmdbd.on.slurmdbd_available: self._on_slurmdbd_available,
             self._slurmdbd.on.slurmdbd_unavailable: self._on_slurmdbd_unavailable,
             self._slurmd.on.partition_available: self._on_write_slurm_conf,
@@ -116,38 +123,18 @@ class SlurmctldCharm(CharmBase):
         """Perform installation operations for slurmctld."""
         self.unit.status = WaitingStatus("installing slurmctld")
         try:
-            if self.unit.is_leader():
-                self._slurmctld.install()
+            self._slurmctld.install()
+            self._slurmctld.exporter.args = [
+                "-slurm.collect-diags",
+                "-slurm.collect-limits",
+            ]
 
-                # TODO: https://github.com/charmed-hpc/slurm-charms/issues/38 -
-                #  Use Juju Secrets instead of StoredState for exchanging keys between units.
-                self._slurmctld.jwt.generate()
-                self._stored.jwt_rsa = self._slurmctld.jwt.get()
-
-                self._slurmctld.key.generate()
-                self._stored.auth_key = self._slurmctld.key.get()
-
-                self._slurmctld.service.enable()
-
-                self._slurmctld.exporter.args = [
-                    "-slurm.collect-diags",
-                    "-slurm.collect-limits",
-                ]
-                self._slurmctld.exporter.service.enable()
-                self._slurmctld.exporter.service.restart()
-
-                self.unit.set_workload_version(self._slurmctld.version())
-
-                self.slurm_installed = True
-            else:
-                self.unit.status = BlockedStatus("slurmctld high-availability not supported")
-                logger.warning(
-                    "slurmctld high-availability is not supported yet. please scale down application."
-                )
-                event.defer()
+            self.unit.set_workload_version(self._slurmctld.version())
+            self.slurm_installed = True
         except SlurmOpsError as e:
             logger.error(e.message)
             event.defer()
+            return
 
         self.unit.open_port("tcp", SLURMCTLD_PORT)
         self.unit.open_port("tcp", PROMETHEUS_EXPORTER_PORT)
@@ -157,38 +144,121 @@ class SlurmctldCharm(CharmBase):
 
         Notes:
             - The start hook can execute multiple times in a charms lifecycle,
-              for example, after a reboot of the underlying instance. This code safeguards
-              against the potentiality of changing the cluster_name in subsequent start hook
-              executions by applying logic that ensures the cluster_name is only set on the
-              first execution of this hook, we log and return on any subsequent start hook
-              event executions.
+              for example, after a reboot of the underlying instance.
         """
+        if self.config.get("use-network-state"):
+            state_save_location = Path(CHARM_MAINTAINED_SLURM_CONF_PARAMETERS["StateSaveLocation"])
+            if not state_save_location.is_mount():
+                self.unit.status = BlockedStatus(
+                    f"waiting for {state_save_location} to be mounted"
+                )
+                event.defer()
+                return
+            shutil.chown(state_save_location, "slurm", "slurm")
+
+            # Move config data to network storage
+            etc_source = Path("/etc/slurm")
+            etc_target = state_save_location / "etc-slurm"
+            try:
+                self._migrate_etc_data(etc_source, etc_target)
+            except Exception:
+                logger.exception(
+                    "failed to migrate slurm configuration from %s to %s. deferring event",
+                    etc_source,
+                    etc_target,
+                )
+                event.defer()
+                return
+
         if self.unit.is_leader():
-            if self._slurmctld_peer.cluster_name is None:
-                if (charm_config_cluster_name := str(self.config.get("cluster-name", ""))) != "":
-                    cluster_name = charm_config_cluster_name
-                else:
-                    cluster_name = f"{CLUSTER_NAME_PREFIX}-{secrets.token_urlsafe(3)}"
+            if not self._slurmctld.jwt.path.exists():
+                self._slurmctld.jwt.generate()
+            if not self._slurmctld.key.path.exists():
+                self._slurmctld.key.generate()
 
-                logger.debug(f"Cluster Name: {cluster_name}")
-
-                try:
-                    self._slurmctld_peer.cluster_name = cluster_name
-                except SlurmctldPeerError as e:
-                    self.unit.status = BlockedStatus(e.message)
-                    logger.error(e.message)
-                    event.defer()
-                    return
-
-                self._on_write_slurm_conf(event)
-
-            else:
-                logger.debug("Cluster name already created - skipping creation.")
+            self._on_write_slurm_conf(event)
+            if event.deferred:
+                logger.debug("attempt to write slurm.conf deferred start event")
+                return
         else:
-            msg = "High availability of slurmctld is not supported at this time."
+            # In an HA setup, peers defer until leader writes out keys and configuration files.
+            if not self._peer_ready():
+                logger.debug("peer not ready. deferring event", self._slurmctld.config.path)
+                event.defer()
+                return
+
+        try:
+            self._slurmctld.service.enable()
+            self._slurmctld.service.restart()
+            self._slurmctld.exporter.service.enable()
+            self._slurmctld.exporter.service.restart()
+            self._check_status()
+        except SlurmOpsError as e:
+            logger.error(e.message)
+            event.defer()
+
+    def _migrate_etc_data(self, etc_source: Path, etc_target: Path) -> None:
+        """Migrate the given source directory to the given target.
+
+        The charm leader recursively copies the source directory to the target.
+        All units then replace the source with a symlink to the target.
+
+        This is necessary in a high availability (HA) deployment as all slurmctld units require access to identical conf files.
+        For this reason, the target must be located on shared storage mounted on all slurmctld units.
+
+        To avoid data loss, the existing configuration is backed up to a directory suffixed by the current date and time before migration.
+        For example, `/etc/slurm_20250620_161437`.
+        """
+        # Nothing to do if target already correctly symlinked
+        if etc_source.is_symlink() and etc_source.resolve() == etc_target:
+            logger.debug("%s -> %s sylink already exists", etc_source, etc_target)
+            return
+
+        if self.unit.is_leader() and etc_source.is_dir() and not etc_target.exists():
+            logger.debug("leader copying %s to %s", etc_source, etc_target)
+            shutil.copytree(etc_source, etc_target)
+
+        if etc_source.exists():
+            # Timestamp to avoid overwriting any existing backup
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            backup_target = Path(f"{etc_source}_{timestamp}")
+            logger.debug("backing up %s to %s", etc_source, backup_target)
+            shutil.move(etc_source, backup_target)
+        else:
+            logger.warning("%s not found. unable to backup existing slurm data", etc_source)
+
+        logger.debug("symlinking %s to %s", etc_source, etc_target)
+        etc_source.symlink_to(etc_target)
+
+    def _peer_ready(self) -> bool:
+        """Return True if all conditions are met to allow this peer to start. False otherwise."""
+        if self.unit.is_leader():
+            return True
+
+        if not self.config.get("use-network-state"):
+            msg = "High availability requires slurmctld to have been deployed with `use-network-state` enabled."
             self.unit.status = BlockedStatus(msg)
             logger.warning(msg)
-            event.defer()
+            return False
+
+        if not self._slurmctld.config.path.exists():
+            logger.debug("%s not found", self._slurmctld.config.path)
+            return False
+
+        config = self._slurmctld.config.load()
+        if self.hostname not in config.slurmctld_host:  # type: ignore
+            logger.debug("%s not in %s.", self.hostname, self._slurmctld.config.path)
+            return False
+
+        if not self._slurmctld.key.path.exists():
+            logger.debug("auth key %s not found", self._slurmctld.key.path)
+            return False
+
+        if not self._slurmctld.jwt.path.exists():
+            logger.debug("JWT key %s not found", self._slurmctld.jwt.path)
+            return False
+
+        return True
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         """Perform config-changed operations."""
@@ -227,6 +297,24 @@ class SlurmctldCharm(CharmBase):
     def _on_show_current_config_action(self, event: ActionEvent) -> None:
         """Show current slurm.conf."""
         event.set_results({"slurm.conf": str(self._slurmctld.config.load())})
+
+    def _on_slurmctld_changed(
+        self, event: Union[SlurmctldAvailableEvent, SlurmctldDepartedEvent]
+    ) -> None:
+        """Update slurmctld configuration and list of controllers on all Slurm services."""
+        # self.all_units_observed() check not needed as event is not emitted unless this is true
+
+        if not self._check_status():
+            logger.debug(
+                "attempted slurmctld relation change while unit is not ready. deferring event"
+            )
+            event.defer()
+            return
+
+        # Only slurm.conf update needed. New slurmctld controllers joining or leaving do not change any other conf file.
+        self._on_write_slurm_conf(event)
+        self._sackd.update_controllers()
+        self._slurmd.update_controllers()
 
     def _on_slurmrestd_available(self, event: SlurmrestdAvailableEvent) -> None:
         """Check that we have slurm_config when slurmrestd available otherwise defer the event."""
@@ -331,6 +419,14 @@ class SlurmctldCharm(CharmBase):
             Lack of map between departing unit and NodeName complicates removal of node from gres.conf.
             Instead, rewrite full gres.conf with data from remaining units.
         """
+        if not self.unit.is_leader():
+            return
+
+        if not self._check_status():
+            logger.debug("slurmd departing while unit is not ready. deferring event")
+            event.defer()
+            return
+
         # Reconcile the new_nodes.
         new_nodes = self.new_nodes
         logger.debug(f"New nodes from stored state: {new_nodes}")
@@ -413,6 +509,8 @@ class SlurmctldCharm(CharmBase):
             InfluxDBAvailableEvent,
             InfluxDBUnavailableEvent,
             StartEvent,
+            SlurmctldAvailableEvent,
+            SlurmctldDepartedEvent,
             SlurmdbdAvailableEvent,
             SlurmdbdUnavailableEvent,
             SlurmdDepartedEvent,
@@ -428,8 +526,13 @@ class SlurmctldCharm(CharmBase):
         if not self.unit.is_leader():
             return
 
-        # If slurmctld isn't installed and we don't have a cluster_name, defer.
         if not self._check_status():
+            logger.debug("unit not ready. deferring event")
+            event.defer()
+            return
+
+        if not self.all_units_observed():
+            logger.debug("not observed all other units in the peer relation. deferring event")
             event.defer()
             return
 
@@ -536,8 +639,7 @@ class SlurmctldCharm(CharmBase):
         slurm_conf = SlurmConfig.from_dict(
             {
                 "ClusterName": self.cluster_name,
-                "SlurmctldAddr": self._ingress_address,
-                "SlurmctldHost": [self._slurmctld.hostname],
+                "SlurmctldHost": self.get_controllers(),
                 "SlurmctldParameters": _assemble_slurmctld_parameters(),
                 "ProctrackType": "proctrack/linuxproc" if is_container() else "proctrack/cgroup",
                 "TaskPlugin": (
@@ -592,7 +694,17 @@ class SlurmctldCharm(CharmBase):
 
         This charm needs these conditions to be satisfied in order to be ready:
         - Slurmctld component installed
+        - Cluster name set
+        - If using network storage, it is mounted
         """
+        if self.config.get("use-network-state"):
+            state_save_location = Path(CHARM_MAINTAINED_SLURM_CONF_PARAMETERS["StateSaveLocation"])
+            if not state_save_location.is_mount():
+                self.unit.status = BlockedStatus(
+                    f"waiting for {state_save_location} to be mounted"
+                )
+                return False
+
         if self.slurm_installed is not True:
             self.unit.status = BlockedStatus(
                 "failed to install slurmctld. see logs for further details"
@@ -603,20 +715,94 @@ class SlurmctldCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for cluster_name....")
             return False
 
-        self.unit.status = ActiveStatus("")
+        try:
+            status = self.get_controller_status(self.hostname)
+        except Exception as e:
+            logger.warning("failed to query controller active status. reason: %s", e)
+            status = ""
+
+        self.unit.status = ActiveStatus(status)
         return True
 
+    def get_controllers(self) -> list[str]:
+        """Get hostnames for all controllers."""
+        # Read the current list of controllers from the slurm.conf file and compare with the controllers currently in the peer relation.
+        # File ordering must be preserved as it dictates which slurmctld instance is the primary and which are backups.
+        from_file = []
+        if self._slurmctld.config.path.exists():
+            config = self._slurmctld.config.load()
+            if config.slurmctld_host:  # type: ignore
+                from_file = config.slurmctld_host  # type: ignore
+        from_peer = self._slurmctld_peer.controllers
+
+        logger.debug(
+            "controllers from slurm.conf: %s, from peer relation: %s", from_file, from_peer
+        )
+
+        # Controllers in the file but not the peer relation have departed.
+        # Controllers in the peer relation but not the file are newly added.
+        from_peer_set = set(from_peer)
+        from_file_set = set(from_file)
+        current_controllers = [c for c in from_file if c in from_peer_set] + [
+            c for c in from_peer if c not in from_file_set
+        ]
+
+        logger.debug("current controllers: %s", current_controllers)
+        return current_controllers
+
     def get_auth_key(self) -> Optional[str]:
-        """Get the stored auth key."""
-        return str(self._stored.auth_key)
+        """Get the current auth key."""
+        try:
+            return self._slurmctld.key.get()
+        except FileNotFoundError:
+            return None
 
     def get_jwt_rsa(self) -> Optional[str]:
-        """Get the stored jwt_rsa key."""
-        return str(self._stored.jwt_rsa)
+        """Get the current jwt_rsa key."""
+        try:
+            return self._slurmctld.jwt.get()
+        except FileNotFoundError:
+            return None
+
+    def get_controller_status(self, hostname: str) -> str:
+        """Return the status of the given controller instance, e.g. 'primary - UP'."""
+        # Example snippet of ping output:
+        #   "pings": [
+        #     {
+        #       "hostname": "juju-829e74-84",
+        #       "pinged": "DOWN",
+        #       "latency": 123,
+        #       "mode": "primary"
+        #     },
+        #     {
+        #       "hostname": "juju-829e74-85",
+        #       "pinged": "UP",
+        #       "latency": 456,
+        #       "mode": "backup1"
+        #     },
+        #     {
+        #       "hostname": "juju-829e74-86",
+        #       "pinged": "UP",
+        #       "latency": 789,
+        #       "mode": "backup2"
+        #     }
+        #   ],
+        ping_output = json.loads(self._slurmctld.scontrol("ping", "--json"))
+        logger.debug("scontrol ping output: %s", ping_output)
+
+        for ping in ping_output["pings"]:
+            if ping["hostname"] == hostname:
+                return f"{ping['mode']} - {ping['pinged']}"
+
+        return ""
 
     def _resume_nodes(self, nodelist: List[str]) -> None:
         """Run scontrol to resume the specified node list."""
         self._slurmctld.scontrol("update", f"nodename={','.join(nodelist)}", "state=resume")
+
+    def all_units_observed(self):
+        """Return True if this unit has observed all other units in the peer relation. False otherwise."""
+        return self._slurmctld_peer.all_units_observed()
 
     @property
     def cluster_name(self) -> Optional[str]:

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -73,7 +73,6 @@ class SlurmctldCharm(CharmBase):
             default_partition=str(),
             new_nodes=[],
             nhc_params=str(),
-            save_state_location=str(),
             slurm_installed=False,
             slurmdbd_host=str(),
             user_supplied_slurm_conf_params=str(),

--- a/charms/slurmctld/src/interface_sackd.py
+++ b/charms/slurmctld/src/interface_sackd.py
@@ -29,15 +29,23 @@ class Sackd(Object):
 
     def _on_relation_created(self, event: RelationCreatedEvent) -> None:
         """Set our data on the relation."""
-        # Need to wait until the charm has installed slurm before we can proceed.
-        if not self._charm.slurm_installed:
+        if not self.framework.model.unit.is_leader():
+            return
+
+        if not (auth_key := self._charm.get_auth_key()):
+            logger.debug("auth key not yet available. deferring event")
+            event.defer()
+            return
+
+        if not self._charm.all_units_observed():
+            logger.debug("not observed all other controller units. deferring event")
             event.defer()
             return
 
         event.relation.data[self.model.app]["cluster_info"] = json.dumps(
             {
-                "auth_key": self._charm.get_auth_key(),
-                "slurmctld_host": self._charm.hostname,
+                "auth_key": auth_key,
+                "slurmctld_hosts": self._charm.get_controllers(),
             }
         )
 
@@ -45,3 +53,12 @@ class Sackd(Object):
         """Clear the cluster info if the relation is broken."""
         if self.framework.model.unit.is_leader():
             event.relation.data[self.model.app]["cluster_info"] = ""
+
+    def update_controllers(self) -> None:
+        """Synchronize the current set of slurmctld controllers with data on the relation."""
+        for rel in self.model.relations.get(self._relation_name, ()):
+            if rel and "cluster_info" in rel.data[self.model.app]:
+                cluster_info = json.loads(rel.data[self.model.app]["cluster_info"])
+                cluster_info["slurmctld_hosts"] = self._charm.get_controllers()
+                rel.data[self.model.app]["cluster_info"] = json.dumps(cluster_info)
+                logger.debug("sackd cluster_info set to %s", cluster_info)

--- a/charms/slurmctld/src/interface_slurmctld_peer.py
+++ b/charms/slurmctld/src/interface_slurmctld_peer.py
@@ -4,9 +4,19 @@
 """SlurmctldPeer."""
 
 import logging
+import secrets
 from typing import Optional
 
-from ops import Object
+from constants import CLUSTER_NAME_PREFIX
+from ops import (
+    EventBase,
+    EventSource,
+    Object,
+    ObjectEvents,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    RelationDepartedEvent,
+)
 
 logger = logging.getLogger()
 
@@ -20,8 +30,25 @@ class SlurmctldPeerError(Exception):
         return self.args[0]
 
 
+class SlurmctldAvailableEvent(EventBase):
+    """Emitted when a new controller instance joins."""
+
+
+class SlurmctldDepartedEvent(EventBase):
+    """Emitted when a controller leaves."""
+
+
+class Events(ObjectEvents):
+    """Interface events."""
+
+    slurmctld_available = EventSource(SlurmctldAvailableEvent)
+    slurmctld_departed = EventSource(SlurmctldDepartedEvent)
+
+
 class SlurmctldPeer(Object):
     """SlurmctldPeer Interface."""
+
+    on = Events()  # pyright: ignore [reportIncompatibleMethodOverride, reportAssignmentType]
 
     def __init__(self, charm, relation_name):
         """Initialize the interface."""
@@ -29,22 +56,88 @@ class SlurmctldPeer(Object):
         self._charm = charm
         self._relation_name = relation_name
 
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_created,
+            self._on_relation_created,
+        )
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_changed,
+            self._on_relation_changed,
+        )
+        self.framework.observe(
+            self._charm.on[self._relation_name].relation_departed,
+            self._on_relation_departed,
+        )
+
     @property
     def _relation(self):
         """Slurmctld peer relation."""
-        return self.framework.model.get_relation(self._relation_name)
+        if relation := self.framework.model.get_relation(self._relation_name):
+            return relation
+        raise SlurmctldPeerError("attempted to access peer relation before it was established")
+
+    def _on_relation_created(self, event: RelationCreatedEvent) -> None:
+        self._relation.data[self._charm.unit]["hostname"] = self._charm.hostname
+        if not self._charm.unit.is_leader():
+            return
+
+        if self.cluster_name is None:
+            if (charm_config_cluster_name := self._charm.config.get("cluster-name", "")) != "":
+                cluster_name = charm_config_cluster_name
+            else:
+                cluster_name = f"{CLUSTER_NAME_PREFIX}-{secrets.token_urlsafe(3)}"
+
+            logger.debug(f"Cluster Name: {cluster_name}")
+            self.cluster_name = cluster_name
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        # Fire only once the leader unit has completed relation-joined for all units
+        if self._charm.unit.is_leader() and self.all_units_observed():
+            self.on.slurmctld_available.emit()
+            return
+
+    def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
+        """Handle hook when a unit departs."""
+        # Fire only once the leader unit has seen the last departing unit leave
+        if self._charm.unit.is_leader() and self.all_units_observed():
+            self.on.slurmctld_departed.emit()
+
+    def all_units_observed(self) -> bool:
+        """Return True if this unit has observed all other units in the peer relation. False otherwise."""
+        try:
+            seen_units = len(self._relation.units)
+        except SlurmctldPeerError:
+            seen_units = 0
+
+        planned_units = self.model.app.planned_units() - 1  # -1 as includes self
+        logger.debug("seen %s other slurmctld unit(s) of planned %s", seen_units, planned_units)
+        return seen_units == planned_units
+
+    @property
+    def controllers(self) -> list:
+        """Return the list of controllers."""
+        try:
+            logger.debug(
+                "gathering controller hostnames from peer relation: %s", self._relation.data
+            )
+            return [
+                data["hostname"] for data in self._relation.data.values() if "hostname" in data
+            ]
+        except SlurmctldPeerError:
+            # If the peer relation hasn't been established yet, the only hostname we know is our own
+            return [self._charm.hostname]
 
     @property
     def cluster_name(self) -> Optional[str]:
         """Return the cluster_name from app relation data."""
         cluster_name = None
-        if self._relation:
+        try:
             if cluster_name_from_relation := self._relation.data[self.model.app].get(
                 "cluster_name"
             ):
                 cluster_name = cluster_name_from_relation
             logger.debug(f"## `slurmctld-peer` relation available. cluster_name: {cluster_name}.")
-        else:
+        except SlurmctldPeerError:
             logger.debug(
                 "## `slurmctld-peer` relation not available yet, cannot get cluster_name."
             )
@@ -57,9 +150,8 @@ class SlurmctldPeer(Object):
             logger.debug("only leader can set the Slurm cluster name")
             return
 
-        if not self._relation:
-            raise SlurmctldPeerError(
-                "`slurmctld-peer` relation not available yet, cannot set cluster_name."
-            )
-
-        self._relation.data[self.model.app]["cluster_name"] = name
+        try:
+            self._relation.data[self.model.app]["cluster_name"] = name
+        except SlurmctldPeerError as e:
+            e.add_note("cannot set cluster_name")
+            raise

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -54,7 +54,7 @@ class SlurmdCharm(CharmBase):
             nhc_params=str(),
             slurm_installed=False,
             slurmctld_available=False,
-            slurmctld_host=str(),
+            slurmctld_hosts=str(),
             user_supplied_node_parameters={},
             user_supplied_partition_parameters={},
         )
@@ -170,13 +170,14 @@ class SlurmdCharm(CharmBase):
             event.defer()
             return
 
-        if (slurmctld_host := event.slurmctld_host) != self._stored.slurmctld_host:
-            if slurmctld_host is not None:
-                self._slurmd.config_server = f"{slurmctld_host}:6817"
-                self._stored.slurmctld_host = slurmctld_host
-                logger.debug(f"slurmctld_host={slurmctld_host}")
+        if (slurmctld_hosts := event.slurmctld_hosts) != self._stored.slurmctld_hosts:
+            if slurmctld_hosts is not None:
+                # Create comma-separated list of slurmctld hosts with port number appended
+                self._slurmd.config_server = ",".join(f"{host}:6817" for host in slurmctld_hosts)
+                self._stored.slurmctld_hosts = slurmctld_hosts
+                logger.debug(f"slurmctld_hosts={slurmctld_hosts}")
             else:
-                logger.debug("'slurmctld_host' not in event data.")
+                logger.debug("'slurmctld_hosts' not in event data.")
                 return
 
         if (auth_key := event.auth_key) != self._stored.auth_key:
@@ -213,7 +214,7 @@ class SlurmdCharm(CharmBase):
         self._stored.slurmctld_available = False
         self._stored.nhc_params = ""
         self._stored.auth_key = ""
-        self._stored.slurmctld_host = ""
+        self._stored.slurmctld_hosts = ""
         self._slurmd.service.stop()
         self._check_status()
 


### PR DESCRIPTION
> Draft PR as following are outstanding:
> * Integration tests for `slurmctld` scaling and failover.
> * Additional unit tests.
> * Documentation.
> * Reconsidering use of `get_controller_status()`.
>   * Currently called every `_check_status()` to update the `ActiveStatus` with primary/backup info. Performs an `scontrol ping` each time - a slow network operation. The `_check_status()` method is used often within charm hooks and this will affect responsiveness.
> * Consider merging `_peer_ready()` into `_check_status()` given potential overlap in functionality.

# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

### Overview
This PR implements high availability (HA) support for `slurmctld`, allowing for scaling up of the application to multiple units such that a backup unit takes over if the primary unit fails. HA support in `slurmctld` uses an active-passive setup with one active primary and zero or more passive backups on standby. Scaling up the unit count for the application does not allow for more requests to be served. The Slurm documentation on HA is available at:

* https://slurm.schedmd.com/quickstart_admin.html#HA
* https://slurm.schedmd.com/slurm.conf.html#OPT_SlurmctldHost
* https://slurm.schedmd.com/quickstart_admin.html#Config

### Implementation

#### Shared Storage

As stated in the documentation, HA requires that "all hosts should mount a common file system containing the state information", i.e. the controller `StateSaveLocation` data.  Additionally:

> "If using a backup host, the StateSaveLocation should reside on a file system shared by the two hosts. We do not recommend using NFS to make the directory accessible to both hosts, but do recommend a shared mount that is accessible to the two controllers and allows low-latency reads and writes to the disk."

To allow for flexibility in the shared file system, support for the [`filesystem-client` charm](https://github.com/charmed-hpc/filesystem-charms) has been implemented. This enables the user to integrate with the file system of their choice, e.g. their own CephFS deployment, a cloud-specific managed file system, or another that meets their latency requirements.

Using the local disk for `StateSaveLocation` data, without the `filesystem-client`, continues to be supported via the new `use-network-state` configuration option for `slurmctld`. The default is `False`, which results in the `slurmctld` charm functioning as it does now: `StateSaveLocation` data is stored locally at `/var/lib/slurm/checkpoint` and the application cannot scale to support HA.

The `use-network-state` option must be set to `True` at `slurmctld` deployment time for HA to function. When set to `True`, the charm blocks until `/var/lib/slurm/checkpoint` is mounted (specifically until [`Path.is_mount`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_mount) returns `True`). The charm leader then generates the JWT key, the auth key, and all configuration files while peers defer until these files appear in the shared storage.

The JWT key is already stored in `/var/lib/slurm/checkpoint` in the latest release of `slurmctld`. This PR adds the auth key and configuration files (`slurm.conf`, `gres.conf`, `acct_gather.conf`, etc.) to this location by relocating `/etc/slurm/` to the shared storage. The original `/etc/slurm/` is replaced with a symlink to `/var/lib/slurm/checkpoint/etc-slurm` so all `slurmctld` instances have a coherent view of all necessary files.

To avoid data loss, any existing `/etc/slurm/` is backed up to `/etc/slurm_[timestamp]` on the unit. To prevent peers from reading partially written configuration files, the latest version of `slurmutils` now makes atomic updates.

#### `slurmctld` Charm Changes

The `Install` hook no longer generates keys or start services; it only performs package install operations. Key generation and service starts have been moved to the `Start` hook both to allow for the `filesystem-client` mount to be in place and for a more logical separation of concerns. The setting of the `cluster_name` has been moved to the peer `relation-creation` event to simplify `Start`.

Also added to the peer `relation-creation` event is every controller unit writing its hostname into its unit databag. This allows for a mapping between the unit name, e.g. `slurmctld/1` and its hostname, e.g. `juju-9cf56a-3`. This mapping is necessary as Slurm requires all `SlurmctldHost` entries to use the controller hostname.

A `get_controllers()` method has been added to gather the hostnames of all controller units. The order this function returns the controllers is the same as is written to `SlurmctldHost` lines in `slurm.conf`. This specifies the failover order for high availability: the first `SlurmctldHost` entry is the primary controller, and the remaining entries are backup controllers, used in the order they appear.

Controllers are sorted by join order, with the most recently added unit being the lowest priority backup. This order is maintained by retrieving the list of existing controllers from `slurm.conf` and comparing with the set of controllers in the peer relation. Controllers in the file but not the peer relation have departed, while controllers in the peer relation but not the file are newly added. This ensures that scaling the application does not switch which units are the primary/backups.

An `all_units_observed()` method has been added which returns `True` if the unit has observed all other units in the peer relation and false otherwise, i.e. `len(self._relation.units) == self.model.app.planned_units()-1`. This guards uses of `get_controllers()` and the new `update_controllers()` to prevent partial updates of controller hostnames to the `slurm.conf` and `sackd`/`slurmd` relation data.

There is risk of a partial update when a new unit is elected leader as it joins an existing `slurmctld` application (such as when all other units are inaccessible). The `all_units_observed()` check prevents the new leader from attempting a controller update before it has seen the `relation-joined` events for all other controllers. This should allow for recoverability of a severely degraded cluster where all controller units have failed through simply `juju add-unit slurmctld`. However, this scenario was not in scope for this PR and has not been extensively tested.

A `get_controller_status()` method has been added which performs an `scontrol ping --json` and returns the current unit's status, e.g. `primary - DOWN`, `backup1 - UP`. This is called in `_check_status()` to update the unit `ActiveStatus` and give insight into controller state when the user runs `juju status`.

The `auth_key` and `jwt_key` are no longer part of the charm stored state. Each access now goes through the `hpclibs` interface which retrieves the key value from the file on disk. This ensures a consistent key is returned across all `slurmctld` units.

#### Other Charm Changes

The `sackd` and `slurmd` interfaces in `slurmctld` have been updated to support multiple controller hostnames and their main charm code now constructs a comma-separated list of hostnames with port ":6817" appended. Updates to controller data for these charms are guarded with `if not self._charm.all_units_observed():` checks to prevent partial updates.

New `if not self.framework.model.unit.is_leader():` guards have been placed around method calls in the interfaces for  `sackd`, `slurmd`, `slurmrestd`, and `slurmdbd` where previously a single controller unit was assumed.

The `if not self._charm.slurm_installed:` guards have been removed as keys are now generated in the `Start` hook rather than `Install`. They have been replaced with checks for `auth_key` and `jwt_rsa`.

#### Alternatives Considered

I believe the solution proposed in this PR is robust and provides good resilience against disasters affecting the Slurm controller. Given Slurm requires a shared file system for HA, I believe the user experience of the `filesystem-charm` and `use-network-state` config is reasonable and builds on existing knowledge (i.e. we expect a Charmed HPC user to be already making use of the `filesystem-charm` for their compute node file system). We have also explored several other options and found them lacking in comparison.

Several file synchronization solutions were considered prior to the `filesystem-client` integration. That is, `rsync`, `csync2`, `DRBD`, or another utility would replicate the `StateSaveLocation` data from the primary to all backups, rather than a shared file system be used as a central store. The motivation being this would allow for scaling of `slurmctld` without the need for a subordinate charm or new config option.

Proofs of concept were developed in my own fork using [`rsync`](https://github.com/dsloanm/slurm-charms/tree/slurm-ha-rsync) and [`csync2`](https://github.com/dsloanm/slurm-charms/tree/slurm-ha-csync2) but were not pursued further due to challenges in certain availability scenarios. For example, recovering in the event of a partially successful sync.

Another proof of concept revolved around [building MicroCeph into the `slurmctld` charm](https://github.com/dsloanm/slurm-charms/tree/slurm-ha-microceph) to automatically deploy a shared file system behind-the-scenes. This was to address the challenges faced with the synchronization solutions in addition to not needing a subordinate charm or new config option.

However, this was not pursued further due to the complexity of managing a clustered file system within the controller charm (we could not reasonably replicate the dedicated [MicroCeph Charm](https://charmhub.io/microceph)) and requirements around maintaining cluster quorum (a minimum of three `slurmctld` instances would be required to maintain quorum and would give resilience against only one instance failure). It also locked the user to the Ceph file system.

Additionally, use of peer relation to store configuration data, as in `slurmrestd`, was considered but abandoned in favour of the shared file system due to challenges around:

* the number of configuration files needing stored (`slurmrestd` requires only `slurm.conf` but each controller instance would require copies of every conf file: `slurm.conf`, `gres.conf`, `acct_gather.conf`, `oci.conf`, etc.)
* ensuring data in the relation remains in sync with the configuration files on disk.
* timing issues ensuring all peers have written the latest configuration data before the leader issues an `scontrol reconfigure`

### Usage

The `slurmctld` charm must be deployed with `--config use-network-state=true` then integrated with the `filesystem-client` charm proving a mount point of `/var/lib/slurm/checkpoint`.

The following script deploys a single unit Ceph cluster with CephFS and associated `filesystem-client`, then mounts on a basic `ubuntu` test client.

<details>

<summary>Script for setting up CephFS & filesystem-client</summary>

```bash
#!/bin/bash
set -e
MODEL=charmed-hpc
MOUNTPOINT=/var/lib/slurm/checkpoint
CEPH_UNITS=1

# Build the model
juju add-model $MODEL
juju model-config logging-config="<root>=DEBUG;unit=DEBUG"

# Deploy and wait for microceph cluster
juju deploy -n $CEPH_UNITS microceph --constraints="virt-type=virtual-machine cores=2 mem=4G"
while true; do
  echo "Waiting for all model applications to become active..."
  all_active=$(juju status --format=json | jq -r '[.applications | to_entries[] | .value["application-status"].current == "active"] | all')
  [[ "$all_active" == "false" ]] || break
  sleep 5
done

# Add storage
INSTANCES=$(juju status --format=json | jq -r '.applications.microceph.units | keys | join(" ")')
for instance in $INSTANCES; do
  juju add-storage $instance osd-standalone='loop,1G,3'
done

# Set up CephFS
juju exec --unit microceph/leader -- microceph.ceph osd pool create cephfs_data
juju exec --unit microceph/leader -- microceph.ceph osd pool create cephfs_metadata
juju exec --unit microceph/leader -- microceph.ceph fs new cephfs cephfs_metadata cephfs_data
juju exec --unit microceph/leader -- microceph.ceph fs authorize cephfs client.fs-client / rw

# Gather info needed for the cephfs proxy
CEPH_HOSTS=$(juju status --format=json | jq -r '.applications.microceph.units | to_entries | map(.value["public-address"] + ":6789") | join(" ")')
FSID=$(juju exec --unit microceph/leader -- microceph.ceph -s -f json | jq -r '.fsid')
CLIENT_KEY=$(juju exec --unit microceph/leader -- microceph.ceph auth print-key client.fs-client)

# Deploy filesystem charms
juju deploy cephfs-server-proxy --channel latest/edge \
  --config fsid=$FSID \
  --config sharepoint=cephfs:/ \
  --config monitor-hosts="$CEPH_HOSTS" \
  --config auth-info=fs-client:$CLIENT_KEY
juju deploy filesystem-client checkpoint --channel latest/edge --config mountpoint="$MOUNTPOINT"
juju integrate checkpoint:filesystem cephfs-server-proxy:filesystem

# Deploy a basic ubuntu test client
juju deploy ubuntu --base ubuntu@24.04 --constraints virt-type=virtual-machine
juju integrate checkpoint:juju-info ubuntu:juju-info
```

</details>

Two `slurmctld` instance can then be deployed in an HA configuration with:

```bash
# Clear any existing StateSaveLocation data
juju exec --unit ubuntu/leader -- "rm -rf /var/lib/slurm/checkpoint/*"

# Build slurmctld locally and deploy in an HA configuration
just repo build slurmctld
juju deploy ./_build/slurmctld.charm --constraints="virt-type=virtual-machine" -n 2 --config use-network-state=true
juju integrate checkpoint:juju-info slurmctld:juju-info
```

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

From the [`slurmctld` documentation](https://slurm.schedmd.com/slurmctld.html):

> "slurmctld is the central management daemon of Slurm. It monitors all other Slurm daemons and resources, accepts work (jobs), and allocates resources to those jobs. Given the critical functionality of slurmctld, there may be a backup server to assume these functions in the event that the primary server fails."

At present, the `slurmctld` charm in Charmed HPC does not support backup instances, allowing only a single `slurmctld` controller unit to be operational at any one time. This creates a single point of failure for a cluster deployment. To address this, the charms must be extended with HA support.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [ ] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Documentation will be required for this PR before it can be moved out of draft status.
