### PR TITLE
feat: add support for internal Python packages in repository.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,32 @@ The following guidelines must be adhered to if you are writing code to be merged
   * We only need one extensive set of documentation rather than individual
     sets scoped per Slurm charm.
 
+#### Adding new internal packages
+
+If you want to add a new internal Python package to the monorepo, you can run:
+
+```bash
+uv init --lib pkgs/pkg-name
+```
+
+This will create all the scaffolding for a new package. Then, to use the
+package as a common dependency, modify the `sources` section of the
+`pyproject.toml` file with the name of the new package.
+
+```toml
+[tool.uv.sources]
+pkg-name = { workspace = true }
+```
+
+After doing this, the package will be available as a normal dependency, so you can
+add it to the `dependencies` section in the `pyproject.toml` file of any charm:
+
+```toml
+[project]
+# ...
+dependencies = ["ops", "pkg-name"]
+```
+
 ### Juju and charmed operators
 
 * Adhere to the operator development best practices outlined in the [operator development styleguide](https://juju.is/docs/sdk/styleguide).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
 ]
 
 [tool.uv.workspace]
-members = ["charms/*"]
+members = ["charms/*", "packages/*"]
 
 [tool.uv.sources]
 ubuntu-drivers-common = { git = "https://github.com/canonical/ubuntu-drivers-common", rev = "554b91edfd3699625dbed90f679abb31a897b76e" }


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

This PR adds support for internal Python packages in the monorepo, which makes it really simple to share common code between all the charms.

## Docs

* [x] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

NOTE: There really wasn't a good place to put "internal" maintainer documentation, so I put the guide on how to create a new internal library into `CONTRIBUTING.md`. Let me know if you have a better place to put that.

