### PR TITLE
feat(slurmctld): add `slurm-oci-runtime` integration

### DIFF
--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -34,6 +34,8 @@ requires:
     interface: sackd
   influxdb:
     interface: influxdb-api
+  oci-runtime:
+    interface: slurm-oci-runtime
 
 provides:
   cos-agent:

--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -17,6 +17,7 @@
 
 from hpc_libs.is_container import is_container
 
+OCI_RUNTIME_INTEGRATION_NAME = "oci-runtime"
 PEER_INTEGRATION_NAME = "slurmctld-peer"
 SACKD_INTEGRATION_NAME = "login-node"
 SLURMD_INTEGRATION_NAME = "slurmd"

--- a/charms/slurmctld/tests/unit/conftest.py
+++ b/charms/slurmctld/tests/unit/conftest.py
@@ -12,14 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Configure unit tests for the `slurmctld` charm."""
+"""Configure unit tests for the `slurmctld` charmed operator."""
 
 import pytest
 from charm import SlurmctldCharm
 from ops import testing
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture(scope="function")
-def mock_charm() -> testing.Context[SlurmctldCharm]:
-    """Mock `SlurmctldCharm`."""
+def mock_ctx() -> testing.Context[SlurmctldCharm]:
+    """Mock `SlurmctldCharm` context."""
     return testing.Context(SlurmctldCharm)
+
+
+@pytest.fixture(scope="function")
+def mock_charm(
+    mock_ctx, fs: FakeFilesystem, mocker: MockerFixture
+) -> testing.Context[SlurmctldCharm]:
+    """Mock `SlurmctldCharm` context with fake filesystem."""
+    fs.create_file("/etc/slurm/slurm.key", create_missing_dirs=True)
+    mocker.patch("shutil.chown")  # User/group `slurm` doesn't exist on host.
+    mocker.patch("subprocess.run")
+    return mock_ctx

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -13,21 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the `slurmctld` charm."""
+"""Unit tests for the `slurmctld` charmed operator."""
 
 import pytest
-from constants import CLUSTER_NAME_PREFIX, PEER_INTEGRATION_NAME
+from constants import CLUSTER_NAME_PREFIX, OCI_RUNTIME_INTEGRATION_NAME, PEER_INTEGRATION_NAME
+from hpc_libs.interfaces import OCIRuntimeDisconnectedEvent, OCIRuntimeReadyEvent
 from ops import testing
 from pytest_mock import MockerFixture
+from slurmutils import OCIConfig
 
-
-@pytest.mark.parametrize(
-    "cluster_name",
-    (
-        pytest.param("polaris", id="cluster name configured"),
-        pytest.param("", id="no cluster name configured"),
-    ),
+EXAMPLE_OCI_CONFIG = OCIConfig(
+    ignorefileconfigjson=False,
+    envexclude="^(SLURM_CONF|SLURM_CONF_SERVER)=",
+    runtimeenvexclude="^(SLURM_CONF|SLURM_CONF_SERVER)=",
+    runtimerun="apptainer exec --userns %r %@",
+    runtimekill="kill -s SIGTERM %p",
+    runtimedelete="kill -s SIGKILL %p",
 )
+
+
 @pytest.mark.parametrize(
     "leader",
     (
@@ -35,34 +39,112 @@ from pytest_mock import MockerFixture
         pytest.param(False, id="not leader"),
     ),
 )
-def test_on_slurmctld_peer_connected(
-    mocker: MockerFixture, mock_charm, leader, cluster_name
-) -> None:
-    """Test the `_on_slurmctld_peer_connected` event handler."""
-    # Patch `secrets.token_urlsafe(...)` to have predictable output.
-    slug = "xyz1"
-    mocker.patch("secrets.token_urlsafe", return_value=slug)
+class TestSlurmctldCharm:
+    """Unit tests for the `slurmctld` charmed operator."""
 
-    peer_integration_id = 1
-    peer_integration = testing.PeerRelation(
-        endpoint=PEER_INTEGRATION_NAME,
-        interface="slurmctld-peer",
-        id=peer_integration_id,
-    )
-
-    state = mock_charm.run(
-        mock_charm.on.relation_created(peer_integration),
-        testing.State(
-            leader=leader, relations={peer_integration}, config={"cluster-name": cluster_name}
+    @pytest.mark.parametrize(
+        "cluster_name",
+        (
+            pytest.param("polaris", id="cluster name configured"),
+            pytest.param("", id="no cluster name configured"),
         ),
     )
+    def test_on_slurmctld_peer_connected(
+        self, mocker: MockerFixture, mock_charm, leader, cluster_name
+    ) -> None:
+        """Test the `_on_slurmctld_peer_connected` event handler."""
+        # Patch `secrets.token_urlsafe(...)` to have predictable output.
+        slug = "xyz1"
+        mocker.patch("secrets.token_urlsafe", return_value=slug)
 
-    integration = state.get_relation(peer_integration_id)
-    if leader:
-        assert "cluster_name" in integration.local_app_data
-        if cluster_name:
-            assert integration.local_app_data["cluster_name"] == '"polaris"'
+        peer_integration_id = 1
+        peer_integration = testing.PeerRelation(
+            endpoint=PEER_INTEGRATION_NAME,
+            interface="slurmctld-peer",
+            id=peer_integration_id,
+        )
+
+        state = mock_charm.run(
+            mock_charm.on.relation_created(peer_integration),
+            testing.State(
+                leader=leader, relations={peer_integration}, config={"cluster-name": cluster_name}
+            ),
+        )
+
+        integration = state.get_relation(peer_integration_id)
+        if leader:
+            assert "cluster_name" in integration.local_app_data
+            if cluster_name:
+                assert integration.local_app_data["cluster_name"] == '"polaris"'
+            else:
+                assert (
+                    integration.local_app_data["cluster_name"] == f'"{CLUSTER_NAME_PREFIX}-{slug}"'
+                )
         else:
-            assert integration.local_app_data["cluster_name"] == f'"{CLUSTER_NAME_PREFIX}-{slug}"'
-    else:
-        assert "cluster_name" not in integration.local_app_data
+            assert "cluster_name" not in integration.local_app_data
+
+    @pytest.mark.parametrize(
+        "ready",
+        (
+            pytest.param(True, id="ready"),
+            pytest.param(False, id="not ready"),
+        ),
+    )
+    def test_on_oci_runtime_ready(self, mock_charm, mocker: MockerFixture, ready, leader) -> None:
+        """Test the `_on_oci_runtime_ready` event handler."""
+        integration_id = 1
+        integration = testing.Relation(
+            endpoint=OCI_RUNTIME_INTEGRATION_NAME,
+            interface="slurm-oci-runtime",
+            id=integration_id,
+            remote_app_name="apptainer",
+            remote_app_data={"ociconfig": EXAMPLE_OCI_CONFIG.json()} if ready else {},
+        )
+
+        with mock_charm(
+            mock_charm.on.relation_changed(integration),
+            testing.State(leader=leader, relations={integration}),
+        ) as manager:
+            slurmctld = manager.charm.slurmctld
+            mocker.patch.object(slurmctld, "is_installed", return_value=True)
+
+            manager.run()
+
+        if ready and leader:
+            assert slurmctld.oci.path.exists()
+            assert slurmctld.oci.load().dict() == EXAMPLE_OCI_CONFIG.dict()
+        else:
+            assert not slurmctld.oci.path.exists()
+            # Assert that `OCIRuntimeReadyEvent` is never emitted on non-leader units or
+            # on the leader unit if `remote_app_data` is empty.
+            assert not any(
+                isinstance(event, OCIRuntimeReadyEvent) for event in mock_charm.emitted_events
+            )
+
+    def test_on_oci_runtime_disconnected(self, mock_charm, mocker: MockerFixture, leader) -> None:
+        """Test the `_on_oci_runtime_disconnected` event handler."""
+        integration_id = 1
+        integration = testing.Relation(
+            endpoint=OCI_RUNTIME_INTEGRATION_NAME,
+            interface="slurm-oci-runtime",
+            id=integration_id,
+            remote_app_name="apptainer",
+        )
+
+        with mock_charm(
+            mock_charm.on.relation_broken(integration),
+            testing.State(leader=leader, relations={integration}),
+        ) as manager:
+            slurmctld = manager.charm.slurmctld
+            mocker.patch.object(slurmctld, "is_installed", return_value=True)
+
+            manager.run()
+
+        if leader:
+            assert not slurmctld.oci.path.exists()
+        else:
+            # Assert that `OCIRuntimeDisconnectedEvent` is only handled by the `slurmctld` leader.
+            assert not any(
+                isinstance(event, OCIRuntimeDisconnectedEvent)
+                for event in mock_charm.emitted_events
+            )

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -31,3 +31,4 @@ SLURM_APPS = {
 
 MYSQL_APP_NAME = "mysql"
 INFLUXDB_APP_NAME = "influxdb"
+APPTAINER_APP_NAME = "apptainer"

--- a/tests/integration/test_oci_runtime.py
+++ b/tests/integration/test_oci_runtime.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`oci-runtime` integration tests for the Slurm charms."""
+
+import logging
+from io import StringIO
+from time import sleep
+
+import jubilant
+import pytest
+from constants import APPTAINER_APP_NAME, SACKD_APP_NAME, SLURMCTLD_APP_NAME, SLURMD_APP_NAME
+from dotenv import dotenv_values
+
+logger = logging.getLogger(__name__)
+
+
+def setup_apptainer(juju: jubilant.Juju) -> None:
+    """Deploy and integrate `apptainer` with `slurmctld` and `slurmd`.
+
+    Notes:
+        - Sleep for five seconds after the `apptainer` app reaches active status
+          to give the cluster enough time to reconfigure.
+    """
+    logger.info("deploy '%s'", APPTAINER_APP_NAME)
+    juju.deploy(APPTAINER_APP_NAME, channel="latest/edge")
+
+    logger.info(
+        "integration '%s' application with '%s' application",
+        APPTAINER_APP_NAME,
+        SLURMCTLD_APP_NAME,
+    )
+    juju.integrate(APPTAINER_APP_NAME, SLURMCTLD_APP_NAME)
+    logger.info(
+        "integration '%s' application with '%s' application",
+        APPTAINER_APP_NAME,
+        SLURMD_APP_NAME,
+    )
+    juju.integrate(APPTAINER_APP_NAME, SLURMD_APP_NAME)
+
+    juju.wait(lambda status: jubilant.all_active(status, APPTAINER_APP_NAME))
+    sleep(5)
+
+
+@pytest.mark.order(11)
+def test_apptainer_oci_scheduling(juju: jubilant.Juju) -> None:
+    """Test that Slurm can schedule jobs using Apptainer."""
+    if APPTAINER_APP_NAME not in juju.status().apps:
+        setup_apptainer(juju)
+
+    sackd_unit = f"{SACKD_APP_NAME}/0"
+    slurmd_unit = f"{SLURMD_APP_NAME}/0"
+
+    logger.info("testing that '%s' is running jobs within OCI images", APPTAINER_APP_NAME)
+    juju.exec("apptainer pull /tmp/jammy.sif docker://ubuntu:jammy", unit=slurmd_unit)
+    result = juju.exec(
+        f"srun -p {SLURMD_APP_NAME} --container=/tmp/jammy.sif cat /etc/os-release",
+        unit=sackd_unit,
+    ).stdout.strip()
+    env = dotenv_values(stream=StringIO(result))
+
+    assert env["VERSION_CODENAME"] == "jammy"
+    assert env["VERSION_ID"] == "22.04"


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds OCI runtime to support to the Slurm charms. Now that we have the interface changes merged, it was straightforward to integrate the `slurm-oci-runtime` interface implementation into the charms. To test these changes without running the full integration test suite:

```
# Using this feature branch
just repo build sackd slurmctld slurmd
juju deploy ./_build/sackd.charm
juju deploy ./_build/slurmctld.charm
juju deploy ./_build/slurmd.charm
juju deploy apptainer --channel latest/edge
juju integrate slurmctld sackd
juju integrate slurmctld slurmd
juju integrate apptainer slurmd

# Now run a example job using `apptainer`
juju exec -u slurmd/0 -- apptainer pull /tmp/jammy.sif docker://ubuntu:jammy
juju exec -u sackd/0 -- srun -p slurmd --container=/tmp/jammy.sif cat /etc/os-release
# See `jammy` /etc/os-release contents
```

### Future work

In the future, we'll want to think about adding support for a prologue script that will inject key `apptainer` environment variables into jobs, but I associate this with "self-service workflows".

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is PR is related to our epic to integrate Apptainer with the Slurm charms to enable OCI workload scheduling.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Docs are not required currently since this PR is against the experimental branch to demonstrate how easy it is to add new features using the new charm structure, but will be required before merging into the `main` branch. _I'm working on the docs this week while we finish the updates to the HA PR_. 