### PR TITLE
fix(slurmctld): add `slurmctld_is_active` condition to prevent premature `sackd` service start

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,8 +117,20 @@ jobs:
     steps:
       - name: Remove unnecessary files
         run: |
-          sudo rm -rf /usr/share/dotnet
+          # Remove Java SDKs
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove Haskell toolchain
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove unnecessary runner tools
           sudo rm -rf /usr/local/share/boost
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Checkout

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -71,7 +71,13 @@ from slurmutils import (
     NodeSet,
     SlurmConfig,
 )
-from state import check_slurmctld, cluster_name_set, config_ready, slurmctld_installed
+from state import (
+    check_slurmctld,
+    cluster_name_set,
+    config_ready,
+    slurmctld_installed,
+    slurmctld_is_active,
+)
 
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 
@@ -230,6 +236,7 @@ class SlurmctldCharm(ops.CharmBase):
         )
 
     @refresh
+    @wait_unless(slurmctld_is_active)
     @block_unless(slurmctld_installed)
     def _on_sackd_connected(self, event: SackdConnectedEvent) -> None:
         """Handle when a new `sackd` application is connected."""
@@ -243,7 +250,7 @@ class SlurmctldCharm(ops.CharmBase):
 
     @refresh
     @reconfigure
-    @wait_unless(cluster_name_set, partition_ready)
+    @wait_unless(partition_ready, slurmctld_is_active)
     @block_unless(slurmctld_installed)
     def _on_slurmd_ready(self, event: SlurmdReadyEvent) -> None:
         """Handle when partition data is ready from a `slurmd` application."""
@@ -345,7 +352,7 @@ class SlurmctldCharm(ops.CharmBase):
             pass
 
     @refresh
-    @wait_unless(database_ready, config_ready)
+    @wait_unless(config_ready, database_ready, slurmctld_is_active)
     @block_unless(slurmctld_installed)
     def _on_slurmrestd_connected(self, event: SlurmrestdConnectedEvent) -> None:
         """Handle when a new `slurmrestd` application is connected."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ members = [
 [tool.uv.sources]
 slurm-ops = { workspace = true }
 ubuntu-drivers-common = { git = "https://github.com/canonical/ubuntu-drivers-common", rev = "554b91edfd3699625dbed90f679abb31a897b76e" }
-hpc-libs = { git = "https://github.com/charmed-hpc/hpc-libs", rev = "1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" }
+hpc-libs = { git = "https://github.com/charmed-hpc/hpc-libs", rev = "d11f93a471246b82572e84522becaec192570578" }
 
 [tool.uv]
 dependency-metadata = [{ name = "ubuntu-drivers-common", version = "0.10.0" }]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,6 +46,17 @@ def juju(request: pytest.FixtureRequest) -> Iterator[jubilant.Juju]:
             print(log, end="")
 
 
+@pytest.fixture(scope="function")
+def fast_forward(juju: jubilant.Juju) -> Iterator[None]:
+    """Temporarily increase the rate of `update-status` event fires to 10s."""
+    old_interval = juju.model_config()["update-status-hook-interval"]
+    juju.model_config({"update-status-hook-interval": "10s"})
+
+    yield
+
+    juju.model_config({"update-status-hook-interval": old_interval})
+
+
 @pytest.fixture(scope="module")
 def base(request: pytest.FixtureRequest) -> str:
     """Get the base to deploy the Slurm charms on."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,7 +37,7 @@ def juju(request: pytest.FixtureRequest) -> Iterator[jubilant.Juju]:
     keep_models = bool(request.config.getoption("--keep-models"))
 
     with jubilant.temp_model(keep=keep_models) as juju:
-        juju.wait_timeout = 20 * 60
+        juju.wait_timeout = 60 * 60  # Timeout after 1 hour.
 
         yield juju
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -35,7 +35,9 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.order(1)
-def test_deploy(juju: jubilant.Juju, base, sackd, slurmctld, slurmd, slurmdbd, slurmrestd) -> None:
+def test_deploy(
+    juju: jubilant.Juju, base, sackd, slurmctld, slurmd, slurmdbd, slurmrestd, fast_forward
+) -> None:
     """Test if the Slurm charms can successfully reach active status."""
     # Deploy Slurm and auxiliary services.
     juju.deploy(
@@ -78,7 +80,7 @@ def test_deploy(juju: jubilant.Juju, base, sackd, slurmctld, slurmd, slurmdbd, s
     juju.integrate(MYSQL_APP_NAME, SLURMDBD_APP_NAME)
 
     # Wait for Slurm applications to reach active status.
-    juju.wait(lambda status: jubilant.all_active(status, *SLURM_APPS))
+    juju.wait(lambda status: jubilant.all_active(status, *SLURM_APPS), error=jubilant.any_error)
 
 
 @pytest.mark.order(2)

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 [[package]]
 name = "hpc-libs"
 version = "0.1.0"
-source = { git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4#1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" }
+source = { git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578#d11f93a471246b82572e84522becaec192570578" }
 
 [package.optional-dependencies]
 all = [
@@ -901,7 +901,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" },
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578" },
     { name = "ops" },
     { name = "slurm-ops", editable = "pkgs/slurm-ops" },
 ]
@@ -965,7 +965,7 @@ requires-dist = [
     { name = "dbus-fast", marker = "extra == 'dev'", specifier = ">=1.90.2" },
     { name = "distro", marker = "extra == 'dev'", specifier = "==1.9.0" },
     { name = "flake8", marker = "extra == 'dev'" },
-    { name = "hpc-libs", extras = ["all"], git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" },
+    { name = "hpc-libs", extras = ["all"], git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578" },
     { name = "influxdb", specifier = "==5.3.2" },
     { name = "jubilant", marker = "extra == 'dev'", specifier = "~=1.0" },
     { name = "netifaces-plus", specifier = "==0.12.4" },
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hpc-libs", extras = ["machine"], git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" },
+    { name = "hpc-libs", extras = ["machine"], git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578" },
     { name = "slurmutils" },
 ]
 
@@ -1022,7 +1022,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cosl" },
-    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" },
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578" },
     { name = "influxdb" },
     { name = "netifaces-plus" },
     { name = "ops" },
@@ -1047,7 +1047,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cosl" },
-    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" },
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578" },
     { name = "nvidia-ml-py" },
     { name = "ops" },
     { name = "slurm-ops", editable = "pkgs/slurm-ops" },
@@ -1070,7 +1070,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cosl" },
-    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" },
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578" },
     { name = "ops" },
     { name = "slurm-ops", editable = "pkgs/slurm-ops" },
     { name = "slurmutils" },
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=1e44e39bbf8d4aa4fd1a0aaff913d13b38052bf4" },
+    { name = "hpc-libs", git = "https://github.com/charmed-hpc/hpc-libs?rev=d11f93a471246b82572e84522becaec192570578" },
     { name = "ops" },
     { name = "slurm-ops", editable = "pkgs/slurm-ops" },
     { name = "slurmutils" },


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR fixes a race condition between `slurmctld` and `sackd` where `sackd` receives the _slurm.key_ secret and controllers list before the `slurmctld` service has started. This causes `sackd` units to fail because they will fail to retrieve the relevant configuration files from `slurmctld`.

To get around this issue, I introduced the `slurmctld_is_active` condition that defers the `SackdConnectedEvent` and `SlurmdConnectedEvent` events until the `_on_start` hook has run. This wasn't something we noticed in our integration tests because our machines are faster than the free GitHub runners, but this would likely be a problem on "slower clouds" where the integration data for communication with `slurmctld` is set before `slurmctld` is ready to start accepting connections from clients. There's just enough latency in the GitHub runner that we're noticeably affected by `relation-changed-*` events being emitted before the `_on_start` hook is called.

### Other changes 

- Added a new `fast_forward` fixture to help speed up integration tests by increasing the rate at which `update-status` is triggered. _Works through deferred events more quickly_.
- Increases the integration test timeout to 1 hour. I thought this was a possible fix, but it's still useful since the HA tests take a good chunk of time to complete.
- Removes more extraneous items from our runner instance. The default GitHub runners come with several language toolchains, so I cleared out a couple such as Haskell, Swift, and Java.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to our ongoing work to integrate dynamic nodes/HA into the Slurm charms.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This PR is a non-user facing change focused on addressing issues within our CI.
