### PR TITLE
ci: add action to backport PRs to branches

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,39 @@
+name: Pull Request Backporting using Git Backporting
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+    branches:
+      - main
+
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+
+jobs:
+  backporting:
+    name: "Backporting"
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && contains(github.event.pull_request.labels.*.name, 'backport')
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backporting
+        uses: kiegroup/git-backporting@8c412dcb1fe477d5d362fa447e5fb7864d3de271 # main
+        with:
+          target-branch: experimental
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ secrets.GITHUB_TOKEN }}
+          enable-err-notification: true
+          auto-no-squash: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,23 @@ just repo unit
 just repo integration
 ```
 
+## Maintenance information
+
+This repository uses Github Actions to handle some tasks related to the maintenance of the repository.
+
+### Backporting commits
+
+You can backport the commits of a PR into our list of maintained branches by adding the `backport`
+label to a currently opened or already merged PR. This will automatically try to rebase the commits
+into the branches by opening a PR against every maintained branch. Only merged PRs can be backported,
+which means adding the `backport` label to an open PR will only trigger the backport when the PR
+gets merged. The action will also make a comment on the original PR if the backport failed to be
+applied, which will require manual intervention to resolve the merge conflict.
+
+The list of maintained branches is defined in the [backport action][action].
+
+[action]: .github/workflows/backport.yaml
+
 ## License information
 
 By contributing to `slurm-charms`, you agree to license your contribution under
@@ -118,4 +135,3 @@ and you make changes to that file in 2025, update the copyright year in the file
 ```text
 Copyright 2023-2025 Canonical Ltd.
 ```
-


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Adds a new Github action that backports the commits on PRs with the `backport` label. This automatically opens a PR with the changes to ensure every backport passes CI before merging it into maintained branches. 

## Docs

* [x] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

Added maintainer documentation on how to use the new label.
