### PR TITLE
feat(slurmctld): enable `signalchildprocesses` by default

### DIFF
--- a/charms/slurmctld/src/constants.py
+++ b/charms/slurmctld/src/constants.py
@@ -34,6 +34,7 @@ DEFAULT_CGROUP_CONFIG = {
     "constraindevices": True,
     "constrainramspace": True,
     "constrainswapspace": True,
+    "signalchildrenprocesses": True,
 }
 
 ACCOUNTING_CONFIG_FILE = "slurm.conf.accounting"


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR enables `signalchildprocesses` by default in the _cgroup.conf_ configuration file so that child processes left behind by a completed job on a compute will be reapered by Slurm. This is an outstanding feature request that was blocked all the way back in 2024 because the apt charm library did not support Noble and this option was added in Slurm 23.02, but now, since it does, we can enable this configuration option by default in the charms.

CC @jamesbeedy 👀

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Resolves #37

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change in the charms, but we might eventually want some explanation document to explain how Charmed HPC cleans up compute nodes after a job completes.