### PR TITLE
feat(all): add `version` file containing Git revision

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -364,6 +364,22 @@ def stage_charm(
         except OSError:
             raise RepositoryError(f"Failed to write file `{charm.build_path / CHARMCRAFT_FILE}`")
 
+        # Create a version file and pack it into the charm. This is dynamically generated to ensure
+        # that the git revision of the charm is always recorded in this version file.
+        git_hash = subprocess.check_output(
+            [
+                "git",
+                "-C",
+                str(charm.path),
+                "describe",
+                "--always",
+                "--dirty",
+            ],
+            stderr=subprocess.STDOUT
+        ).strip().decode("utf-8")
+        version_file = Path(charm.build_path / "version")
+        version_file.write_text(git_hash)
+
     for lib in charm.libraries:
         src = LIBS_CHARM_PATH / "lib" / "charms" / lib.path
         dest = charm.build_path / "lib" / "charms" / lib.path


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR modifies repository.py so that a `version` file containing the current Git revision number (e.g. `fe5f4df`) is included in each charm's `_build` directory when staged.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is to facilitate the Git revision being included in releases to Charmhub, in line with our planned [release policy](https://hackmd.io/jP6H01xsR6a_kAZBr1-0RA?view#Release-channels).

The [process the mysql-proxy-operator charm](https://github.com/charmed-hpc/mysql-proxy-operator/blob/dc74f70/charmcraft.yaml#L34) uses to create a `version` file cannot be used here due to the way the charms are staged by repository.py. Step `VERSION=$(git -C $CRAFT_PART_SRC/../../charm/src describe --always)` causes charm packing to fail as the `.git` directory cannot be found.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a change to our repository tooling. No user documentation updates are required.