### PR TITLE
feat: update terraform module to juju provider ~> 1.0

### DIFF
--- a/charms/sackd/terraform/README.md
+++ b/charms/sackd/terraform/README.md
@@ -23,7 +23,7 @@ This module offers the following configurable units:
 | `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
 | `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
 | `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
-| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `constraints` | string      | Constraints for the charm deployment                     | ""           |          |
 | `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
 | `revision`    | number      | Revision number of charm to deploy                       | null         |          |
 | `units`       | number      | Number of units to deploy                                | 1            |          |
@@ -46,5 +46,5 @@ To deploy this module with its required dependency, you can run
 the following command:
 
 ```shell
-terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
 ```

--- a/charms/sackd/terraform/main.tf
+++ b/charms/sackd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "juju_application" "sackd" {
-  name  = var.app_name
-  model = var.model_name
+  name       = var.app_name
+  model_uuid = var.model_uuid
 
   charm {
     name     = "sackd"

--- a/charms/sackd/terraform/outputs.tf
+++ b/charms/sackd/terraform/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charms/sackd/terraform/variables.tf
+++ b/charms/sackd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ variable "config" {
 variable "constraints" {
   description = "Deployment constraints"
   type        = string
-  default     = "arch=amd64"
+  default     = ""
 }
 
-variable "model_name" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/charms/sackd/terraform/versions.tf
+++ b/charms/sackd/terraform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.19.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/charms/slurmctld/terraform/README.md
+++ b/charms/slurmctld/terraform/README.md
@@ -23,7 +23,7 @@ This module offers the following configurable units:
 | `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
 | `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
 | `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
-| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `constraints` | string      | Constraints for the charm deployment                     | ""           |          |
 | `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
 | `revision`    | number      | Revision number of charm to deploy                       | null         |          |
 | `units`       | number      | Number of units to deploy                                | 1            |          |
@@ -47,5 +47,5 @@ To deploy this module with its required dependency, you can run
 the following command:
 
 ```shell
-terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
 ```

--- a/charms/slurmctld/terraform/main.tf
+++ b/charms/slurmctld/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "juju_application" "slurmctld" {
-  name  = var.app_name
-  model = var.model_name
+  name       = var.app_name
+  model_uuid = var.model_uuid
 
   charm {
     name     = "slurmctld"

--- a/charms/slurmctld/terraform/outputs.tf
+++ b/charms/slurmctld/terraform/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charms/slurmctld/terraform/variables.tf
+++ b/charms/slurmctld/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ variable "config" {
 variable "constraints" {
   description = "Deployment constraints"
   type        = string
-  default     = "arch=amd64"
+  default     = ""
 }
 
-variable "model_name" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/charms/slurmctld/terraform/versions.tf
+++ b/charms/slurmctld/terraform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.19.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/charms/slurmd/terraform/README.md
+++ b/charms/slurmd/terraform/README.md
@@ -23,7 +23,7 @@ This module offers the following configurable units:
 | `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
 | `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
 | `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
-| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `constraints` | string      | Constraints for the charm deployment                     | ""           |          |
 | `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
 | `revision`    | number      | Revision number of charm to deploy                       | null         |          |
 | `units`       | number      | Number of units to deploy                                | 1            |          |
@@ -46,5 +46,5 @@ To deploy this module with its required dependency, you can run
 the following command:
 
 ```shell
-terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
 ```

--- a/charms/slurmd/terraform/main.tf
+++ b/charms/slurmd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "juju_application" "slurmd" {
-  name  = var.app_name
-  model = var.model_name
+  name       = var.app_name
+  model_uuid = var.model_uuid
 
   charm {
     name     = "slurmd"

--- a/charms/slurmd/terraform/outputs.tf
+++ b/charms/slurmd/terraform/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charms/slurmd/terraform/variables.tf
+++ b/charms/slurmd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ variable "config" {
 variable "constraints" {
   description = "Deployment constraints"
   type        = string
-  default     = "arch=amd64"
+  default     = ""
 }
 
-variable "model_name" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/charms/slurmd/terraform/versions.tf
+++ b/charms/slurmd/terraform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.19.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/charms/slurmdbd/terraform/README.md
+++ b/charms/slurmdbd/terraform/README.md
@@ -23,7 +23,7 @@ This module offers the following configurable units:
 | `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
 | `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
 | `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
-| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `constraints` | string      | Constraints for the charm deployment                     | ""           |          |
 | `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
 | `revision`    | number      | Revision number of charm to deploy                       | null         |          |
 | `units`       | number      | Number of units to deploy                                | 1            |          |
@@ -47,5 +47,5 @@ To deploy this module with its required dependency, you can run
 the following command:
 
 ```shell
-terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
 ```

--- a/charms/slurmdbd/terraform/main.tf
+++ b/charms/slurmdbd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "juju_application" "slurmdbd" {
-  name  = var.app_name
-  model = var.model_name
+  name       = var.app_name
+  model_uuid = var.model_uuid
 
   charm {
     name     = "slurmdbd"

--- a/charms/slurmdbd/terraform/outputs.tf
+++ b/charms/slurmdbd/terraform/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charms/slurmdbd/terraform/variables.tf
+++ b/charms/slurmdbd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ variable "config" {
 variable "constraints" {
   description = "Deployment constraints"
   type        = string
-  default     = "arch=amd64"
+  default     = ""
 }
 
-variable "model_name" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/charms/slurmdbd/terraform/versions.tf
+++ b/charms/slurmdbd/terraform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.19.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/charms/slurmrestd/terraform/README.md
+++ b/charms/slurmrestd/terraform/README.md
@@ -23,7 +23,7 @@ This module offers the following configurable units:
 | `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
 | `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
 | `config`      | map(string) | Map of charm configuration options to pass at deployment | {}           |          |
-| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `constraints` | string      | Constraints for the charm deployment                     | ""           |          |
 | `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
 | `revision`    | number      | Revision number of charm to deploy                       | null         |          |
 | `units`       | number      | Number of units to deploy                                | 1            |          |
@@ -46,5 +46,5 @@ To deploy this module with its required dependency, you can run
 the following command:
 
 ```shell
-terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
 ```

--- a/charms/slurmrestd/terraform/main.tf
+++ b/charms/slurmrestd/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "juju_application" "slurmrestd" {
-  name  = var.app_name
-  model = var.model_name
+  name       = var.app_name
+  model_uuid = var.model_uuid
 
   charm {
     name     = "slurmrestd"

--- a/charms/slurmrestd/terraform/outputs.tf
+++ b/charms/slurmrestd/terraform/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charms/slurmrestd/terraform/variables.tf
+++ b/charms/slurmrestd/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ variable "config" {
 variable "constraints" {
   description = "Deployment constraints"
   type        = string
-  default     = "arch=amd64"
+  default     = ""
 }
 
-variable "model_name" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/charms/slurmrestd/terraform/versions.tf
+++ b/charms/slurmrestd/terraform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.19.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the Slurm charm modules to use v1 of the Juju Terraform provider. The most noticeable change is that the `juju_application` resource now expects the `model_uuid` parameter rather than the model name. Another, less noticeable change is that the default value for the `constraints` parameter no longer needs to be `arch=amd64`. It can just be an empty string.

Let me know if you have any questions!

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to my ongoing work to add new identity-related documentation to Charmed HPC's documentation.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Documentation changes will be included as a bulk fix to https://github.com/charmed-hpc/docs/issues/107