### PR TITLE
fix: update Just and uv versions in TICS workflow

### DIFF
--- a/.github/workflows/nightly-TICS.yaml
+++ b/.github/workflows/nightly-TICS.yaml
@@ -18,12 +18,12 @@ jobs:
       - name: Install Just
         uses: extractions/setup-just@v2
         with:
-          just-version: 1.38.0
+          just-version: 1.46.0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.8
+          version: 0.9.25
 
       - name: Install Charmcraft
         run: sudo snap install charmcraft --classic --channel latest/stable


### PR DESCRIPTION
Fixes weekly scan failures due to outdated Just version

# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

The weekly TICS scan is currently failing with:

```
error: Call to unknown function `require`
  ——▶ justfile:15:7
   │
15 │ uv := require("uv")
   │       ^^^^^^^
Error: Process completed with exit code 1.
```

This is due to the `require()` function being an addition to Just v1.39.0 and we currently install v1.38.0.

This PR addresses this by upgrading to the latest Just v1.46.0. It also takes the opportunity to upgrade `uv` to v0.9.25 from v0.5.8.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is necessary to re-enable the weekly TICS scanning of our code. However, it may not be sufficient as the scans have been failing for a protracted period and may require a regeneration of `secrets.TICS_AUTH_TOKEN`. If so, further PRs will be required.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a CI update with no user-facing changes.