### PR TITLE
feat(slurmd): add `set-node-config` action

### DIFF
--- a/charms/slurmd/charmcraft.yaml
+++ b/charms/slurmd/charmcraft.yaml
@@ -75,22 +75,49 @@ actions:
   node-configured:
     description: Remove a node from DownNodes when the reason is `New node`.
 
-  node-config:
-    description: >
-      Set or return node configuration parameters.
+  set-node-config:
+    description: |
+      Set a custom configuration for the node.
 
-      To get the current node configuration for this unit:
-      ``bash
-      $ juju run slurmd/0 node-parameters
+      For example, to set a custom weight for the node, run:
+
+      ```shell
+      juju run slurmd/0 set-node-config parameters="weight=200"
       ```
 
-      To set node level configuration parameters for the unit `slurmd/0`:
-      ``bash
-      $ juju run slurmd/0 node-config parameters="Weight=200 Gres=gpu:tesla:1,gpu:kepler:1,bandwidth:lustre:no_consume:4G"
-      ```
+      To reset the applied custom configuration, run:
 
+      ```shell
+      juju run slurmd/0 set-node-config reset=true
+      ```
     params:
       parameters:
         type: string
-        description: >
-          Node configuration parameter as defined [here](https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION).
+        description: |
+          Node configuration parameters.
+
+          See the "Node configuration" of the slurm.conf manpage for a full
+          description of each option: https://slurm.schedmd.com/slurm.conf.html#SECTION_NODE-CONFIGURATION
+
+          The following charm-managed parameters cannot be set using this action:
+
+          - NodeName
+          - NodeAddr
+          - NodeHostname
+          - State
+          - Reason
+          - Port
+        default: ""
+
+      reset:
+        type: boolean
+        description: |
+          If true, reset the node to its base configuration set by `slurmd -C`.
+
+          This parameter can be used with the `parameters` parameter to replace the existing
+          custom node configuration with a new custom configuration:
+
+          ```shell
+          juju run slurmd/0 set-node-config parameters="weight=100" reset=true
+          ```
+        default: false

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -181,6 +181,24 @@ def test_node_configured_action(juju: jubilant.Juju) -> None:
 
 
 @pytest.mark.order(8)
+def test_set_node_config_action(juju: jubilant.Juju) -> None:
+    """Test that a compute node's configuration can be successfully updated."""
+    slurmd_unit = f"{SLURMD_APP_NAME}/0"
+    name = slurmd_unit.replace("/", "-")
+
+    logger.info("testing that we can update the configuration of a single compute node")
+    juju.run(slurmd_unit, "set-node-config", params={"parameters": "weight=100"})
+    # Check that the weight of the compute node is 100.
+    result = json.loads(juju.exec(f"scontrol --json show node {name}", unit=slurmd_unit).stdout)
+    assert result["nodes"][0]["weight"] == 100
+
+    # Reset compute node to its default configuration.
+    juju.run(slurmd_unit, "set-node-config", params={"reset": True})
+    result = json.loads(juju.exec(f"scontrol --json show node {name}", unit=slurmd_unit).stdout)
+    assert result["nodes"][0]["weight"] == 1
+
+
+@pytest.mark.order(9)
 def test_set_node_state(juju: jubilant.Juju) -> None:
     """Test that the `set-node-state` action updates the state of registered compute nodes."""
     slurmctld_unit = f"{SLURMCTLD_APP_NAME}/0"


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds the `set-node-config` action, replacing the `node-config` action. It's functionally similar to the `node-config` action, but it does three things differently:

1. It guards "charm-managed" attributes and fails if an administrator attempts to override them. For example, the action will fail if a cluster administrator attempts to set a new NodeName for the compute node.
2. It adds a "reset" parameter that can be used to unset the custom applied configuration.
3. It does not double as an action for showing the current node configuration.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Partially addresses #169. @dsloanm and I had an interesting conversation about whether the slurmd charm should have a `show-node-config` action at all. The justification against having a `show-node-config` action is that it is effectively a clone of just running `scontrol show node <nodename>`, and `scontrol` provides the exact node configuration where as `show-node-config` would have to pull from multiple sources on disk and from Slurm. Because of this, we thought it might be best to not have a `show-node-config` action, and instead direct folks towards using `scontrol` instead. Thoughts @jamesbeedy?

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This action will be documented as part of a larger contribution to document the ways that the Slurm charms can be used to manage Slurm.