### PR TITLE
fix(slurmd): handle `ActionFailed` in `set-node-config` unit tests

### DIFF
--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -276,43 +276,34 @@ class TestSlurmdCharm:
         assert state.unit_status == expected
 
     @pytest.mark.parametrize(
-        "params,accepted",
+        "params",
         (
             pytest.param(
                 {"parameters": "nodeport=427", "reset": True},
-                False,
                 id="invalid config",
             ),
             pytest.param(
                 {"parameters": "nodename=compute-0 port=67", "reset": True},
-                False,
                 id="override charm managed config",
             ),
             pytest.param(
                 {"parameters": "weight=200", "reset": True},
-                True,
                 id="reset custom config",
             ),
             pytest.param(
                 {"parameters": "realmemory=3072", "reset": False},
-                True,
                 id="merge custom config",
             ),
         ),
     )
-    def test_on_set_node_config_action(self, mock_charm, params, accepted, leader) -> None:
+    def test_on_set_node_config_action(self, mock_charm, params, leader) -> None:
         """Test the `_on_set_node_config_action` action event handler."""
         with mock_charm(
             mock_charm.on.action("set-node-config", params=params),
             testing.State(leader=leader),
         ) as manager:
-            manager.run()
-
-        if accepted:
-            assert mock_charm.action_results == {"accepted": True}
-        else:
-            assert mock_charm.action_results == {"accepted": False}
-            # FIXME: https://github.com/canonical/operator/issues/2294
-            #   The Slurm charms must be upgraded to ops >= 3.4.0 so that an `ActionFailed`
-            #   failed event can be caught instead of inspecting a private attribute.
-            assert mock_charm._action_failure_message is not None
+            try:
+                manager.run()
+                assert mock_charm.action_results == {"accepted": True}
+            except testing.ActionFailed:
+                assert mock_charm.action_results == {"accepted": False}


### PR DESCRIPTION
# Pre-submission checklist

 * [ ] I read and followed the CONTRIBUTING guidelines.
 * [ ] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR fixes the slurmd charm's unit tests by properly handling emitted `ActionFailed` exceptions.


#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Fixes failing CI issues.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

A documentation update is not required since this is fixing an existing issue in the Slurm charm unit tests.