### PR TITLE
feat: add failed nodes alert rule

### DIFF
--- a/charms/slurmctld/src/cos/alert_rules/prometheus/failed_nodes.rule
+++ b/charms/slurmctld/src/cos/alert_rules/prometheus/failed_nodes.rule
@@ -1,0 +1,17 @@
+alert: SlurmComputeNodesFailing
+expr: slurm_nodes_fail{%%juju_topology%%} > 0
+for: 5m
+labels:
+  severity: critical
+annotations:
+  summary: Compute node(s) are failing or have failed
+  description: >
+    Slurm controller {{ $labels.juju_model }}:{{ $labels.juju_unit }} has {{ $value }}
+    compute node(s) reporting as 'FAIL' for more than 5 minutes. Nodes enter the FAIL state
+    when Slurm detects that they are expected to fail soon due to hardware or configuration issues.
+    These nodes will be drained and removed from the scheduling pool to prevent job failures.
+    Immediate investigation is recommended to identify and resolve the underlying cause.
+
+    The reason for the compute node(s) being in the 'FAIL' state can be viewed with:
+
+    `sinfo --list-reasons`


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds an alert rule for if compute nodes have been in the failing state for longer the 5 minutes.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to building out our set of compute node-specific alerts.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

