### PR TITLE
feat: add unknown nodes alert rule

### DIFF
--- a/charms/slurmctld/src/cos/alert_rules/prometheus/unknown_nodes.rule
+++ b/charms/slurmctld/src/cos/alert_rules/prometheus/unknown_nodes.rule
@@ -1,0 +1,12 @@
+alert: SlurmComputeNodesUnknown
+expr: slurm_nodes_unknown{%%juju_topology%%} > 0
+for: 5m
+labels:
+  severity: critical
+annotations:
+  summary: Compute node(s) state is unknown
+  description: >
+    Slurm controller {{ $labels.juju_model }}:{{ $labels.juju_unit }} has {{ $value }}
+    node(s) reporting as 'UNKNOWN' for more than 5 minutes. Nodes in this state have
+    not yet reported their status to the Slurm controller. This may indicate a
+    communication issue between the node and the Slurm controller's `slurmctld` service.


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds an alert rule for if the state of a compute node is unknown for more than 5 minutes.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to building out our set of compute node-specific alerts.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

