### PR TITLE
feat: add nodes draining too long alert rule

### DIFF
--- a/charms/slurmctld/src/cos/alert_rules/prometheus/draining_nodes.rule
+++ b/charms/slurmctld/src/cos/alert_rules/prometheus/draining_nodes.rule
@@ -1,0 +1,20 @@
+alert: SlurmComputeNodesDrainingTooLong
+expr: slurm_nodes_drain{%%juju_topology%%} > 0
+for: 3h
+labels:
+  severity: warning
+annotations:
+  summary: Compute node(s) have been draining for more than 3 hours
+  description: >
+    Slurm controller {{ $labels.juju_model }}:{{ $labels.juju_unit }} has {{ $value }}
+    compute node(s) that have been draining for more than 3 hours. This may indicate that
+    the nodes either need to be returned to service, or there are long-running jobs assigned
+    to these nodes that still need to complete.
+
+    The reason for the compute node(s) being in the 'DRAIN' state can be viewed with:
+
+    `sinfo --list-reasons`
+
+    The compute node(s) can be returned to service with:
+
+    `juju run <slurm-controller>/leader set-node-state nodes=<draining-nodes> state=idle`


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds an alert that fires if a compute node(s) have been draining for longer than 3 hours. This alert is a warning since it's not necessarily a bad thing if nodes are in the drain state, but it could imply that the cluster administrator either forgot to return the affected node(s) to service or that a long-running job is holding up the node.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to building out our existing set of compute node-specific alerts.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

