### PR TITLE
ci: run commitlint unconditionally

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR changes the CI workflow to unconditionally run commitlint rather than only on a pull request. This is necessary as the integration tests require commitlint to have run successfully or they are skipped, meaning the integration tests are currently being skipped in [the new nightly runs](https://github.com/charmed-hpc/slurm-charms/actions/runs/23178916463) and in [our Charmhub release action](https://github.com/charmed-hpc/slurm-charms/actions/runs/23163929119).

This approach was chosen over removing the `needs: - commitlint` requirement from the integration tests to ensure a commitlint failure in a PR will continue to gate the integration tests. There will now be superfluous commitlint runs but the typical execution time for this check is only 10-20 seconds. 

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is necessary to enable integration tests during our nightly CI runs and release workflow.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a CI change with no user documentation updates required.