### PR TITLE
ci: return commitlint to running only on PRs and remove integration test dependencies on commitlint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -120,7 +121,6 @@ jobs:
       - lint
       - unit-test
       - type-check
-      - commitlint
     steps:
       - name: Remove unnecessary files
         run: |


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Undoes the change in https://github.com/charmed-hpc/slurm-charms/pull/189 as it caused commitlint failures from checking all commits across the repo history.

Removes the `needs: - commitlint` dependency from the integration tests so they run nightly and in the release workflow. Note, the consequence of this is PRs that fail the commitlint check will now run the integration tests and take 30+ minutes to report failure rather than 1-2 minutes.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Necessary to restore CI functionality.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a CI change with no user documentation updates required.