### PR TITLE
feat: update slurmdbd alert rule to use new queue size metric

### DIFF
--- a/charms/slurmctld/src/cos/alert_rules/prometheus/unreachable_slurm_database.rule
+++ b/charms/slurmctld/src/cos/alert_rules/prometheus/unreachable_slurm_database.rule
@@ -1,0 +1,11 @@
+alert: SlurmTooManyFailedDbdMessages
+expr: max_over_time(slurm_slurmdbd_queue_size{%%juju_topology%%}[1m]) > 5000
+for: 1s
+labels:
+  severity: critical
+annotations:
+  summary: Slurm controller {{ $labels.juju_model }}:{{ $labels.juju_unit }} cannot reach the Slurm database
+  description: >
+    The maximum amount of pending messages from the Slurm controller {{ $labels.juju_model }}:{{ $labels.juju_unit }}
+    to the Slurm database exceeded 5000 in the past minute. This may indicate that the Slurm controller
+    cannot contact the Slurm database service `slurmdbd` or its backing database.


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the slurmdbd alert rule which fires if the slurmdbd message queue becomes larger than half of the default value 10,000. It's recommended to investigate the health of the slurmdbd service once the queue size crosses the halfway point as generally this is a smell that something is wrong.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to building out the current set of alerts we have for Charmed HPC.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

All documentation will be updated at once.