### PR TITLE
fix(slurmdbd): banish the `reconfigure` decorator

### DIFF
--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -1,14 +1,21 @@
-# Copyright 2020-2024 Omnivector, LLC.
-# See LICENSE file for licensing details.
+# Copyright 2025-2026 Vantage Compute Corporation
+# Copyright 2020-2024 Omnivector, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: slurmdbd
-
-assumes:
-  - juju
-
 summary: |
   Slurm DBD accounting daemon.
-
 description: |
   This charm provides slurmdbd and the bindings to other utilities
   that make lifecycle operations a breeze.
@@ -18,12 +25,28 @@ description: |
 
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
-
   issues:
     - https://github.com/charmed-hpc/slurm-charms/issues
-
   source:
     - https://github.com/charmed-hpc/slurm-charms
+
+requires:
+  database:
+    interface: mysql_client
+
+provides:
+  slurmctld:
+    interface: slurmdbd
+  cos-agent:
+    interface: cos_agent
+    limit: 1
+
+peers:
+  slurmdbd-peer:
+    interface: slurmdbd-peer
+
+assumes:
+  - juju
 
 type: charm
 base: ubuntu@24.04
@@ -38,20 +61,6 @@ parts:
       - cryptography ~= 44.0.0
       - rpds-py ~= 0.23.1
 
-peers:
-  slurmdbd-peer:
-    interface: slurmdbd-peer
-
-requires:
-  database:
-    interface: mysql_client
-
-provides:
-  slurmctld:
-    interface: slurmdbd
-  cos-agent:
-    interface: cos_agent
-    limit: 1
 
 config:
   options:

--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -37,9 +37,6 @@ requires:
 provides:
   slurmctld:
     interface: slurmdbd
-  cos-agent:
-    interface: cos_agent
-    limit: 1
 
 peers:
   slurmdbd-peer:

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -16,42 +16,35 @@
 
 """Charmed operator for `slurmdbd`, Slurm's database service."""
 
-# pyright: reportAttributeAccessIssue=false
-
 import logging
-from typing import Any
 from urllib.parse import urlparse
 
 import ops
 from charms.data_platform_libs.v0.data_interfaces import DatabaseCreatedEvent, DatabaseRequires
-from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from config import (
-    init_config,
-    reconfigure_slurmdbd,
-    update_overrides,
-    update_storage,
-)
+from config import ConfigManager
 from constants import (
     DATABASE_INTEGRATION_NAME,
+    PEER_INTEGRATION_NAME,
     SLURM_ACCT_DATABASE_NAME,
     SLURMDBD_INTEGRATION_NAME,
     SLURMDBD_PORT,
 )
 from hpc_libs.interfaces import (
+    DatabaseData,
     SlurmctldReadyEvent,
     SlurmdbdProvider,
     block_unless,
     controller_ready,
     wait_unless,
 )
-from hpc_libs.utils import StopCharm, leader, reconfigure, refresh
+from hpc_libs.utils import StopCharm, get_ingress_address, leader, refresh
+from pydantic import ValidationError
 from slurm_ops import SlurmdbdManager, SlurmOpsError
-from state import check_slurmdbd, slurmdbd_installed
+from slurmutils import SlurmdbdConfig
+from state import check_slurmdbd, slurmdbd_installed, slurmdbd_ready
 
 logger = logging.getLogger(__name__)
-#
-reconfigure = reconfigure(hook=reconfigure_slurmdbd)
-reconfigure.__doc__ = """Reconfigure the `slurmdbd` service after an event handler completes."""
+
 refresh = refresh(hook=check_slurmdbd)
 refresh.__doc__ = """Refresh status of the `slurmdbd` unit after an event handler completes."""
 
@@ -59,19 +52,28 @@ refresh.__doc__ = """Refresh status of the `slurmdbd` unit after an event handle
 class SlurmdbdCharm(ops.CharmBase):
     """Charmed operator for `slurmdbd`, Slurm's database service."""
 
-    stored = ops.StoredState()
-    service_needs_restart: bool = False
-
     def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
 
         self.slurmdbd = SlurmdbdManager(snap=False)
-        self.stored.set_default(
-            database_info={},
-            custom_slurmdbd_config={},
-        )
+        try:
+            self.configmgr = self.load_config(ConfigManager)
+        except ValidationError as e:
+            logger.error(e)
+            self.unit.status = ops.BlockedStatus(
+                "Configuration option(s) "
+                + ", ".join(
+                    [
+                        f"'{option.replace('_', '-')}'"  # type: ignore
+                        for error in e.errors()
+                        for option in error.get("loc", ())
+                    ]
+                )
+                + " failed validation. See `juju debug-log` for details"
+            )
+            return
+
         framework.observe(self.on.install, self._on_install)
-        framework.observe(self.on.start, self._on_start)
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.update_status, self._on_update_status)
 
@@ -84,8 +86,6 @@ class SlurmdbdCharm(ops.CharmBase):
             database_name=SLURM_ACCT_DATABASE_NAME,
         )
         framework.observe(self.database.on.database_created, self._on_database_created)
-
-        self._grafana_agent = COSAgentProvider(self)
 
     @refresh
     def _on_install(self, event: ops.InstallEvent) -> None:
@@ -120,25 +120,28 @@ class SlurmdbdCharm(ops.CharmBase):
 
         self.unit.open_port("tcp", SLURMDBD_PORT)
 
-    @refresh
-    @reconfigure
-    def _on_start(self, _: ops.StartEvent) -> None:
-        """Write initial `slurmdbd.conf` file."""
-        if not self.unit.is_leader():
-            raise StopCharm(
-                ops.BlockedStatus(
-                    "`slurmdbd` high-availability is not supported. Scale down application"
-                )
-            )
-
-        init_config(self)
-
     @leader
     @refresh
-    @reconfigure
     def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
         """Update the `slurmdbd` charm's configuration."""
-        update_overrides(self)
+        # `slurmdbd.conf` must be updated here since the ingress address is not available
+        # in the `install` hook.
+        with self.slurmdbd.config.edit() as config:
+            config.auth_alt_parameters = {"jwt_key": f"{self.slurmdbd.jwt.path}"}
+            config.auth_alt_types = ["auth/jwt"]
+            config.auth_type = "auth/slurm"
+            config.dbd_addr = get_ingress_address(self, PEER_INTEGRATION_NAME)
+            config.dbd_host = self.slurmdbd.hostname
+            config.dbd_port = SLURMDBD_PORT
+            config.log_file = "/var/log/slurm/slurmdbd.log"
+            config.pid_file = "/var/run/slurmdbd/slurmdbd.pid"
+            config.plugin_dir = ["/usr/lib/x86_64-linux-gnu/slurm-wlm"]
+            config.slurm_user = self.slurmdbd.user
+            config.storage_type = "accounting_storage/mysql"
+
+        self.slurmdbd.overrides.dump(self.configmgr.slurmdbd_conf_parameters)
+
+        self._reconfigure()
 
     @leader
     @refresh
@@ -147,7 +150,6 @@ class SlurmdbdCharm(ops.CharmBase):
 
     @leader
     @refresh
-    @reconfigure
     @wait_unless(controller_ready)
     @block_unless(slurmdbd_installed)
     def _on_slurmctld_ready(self, event: SlurmctldReadyEvent) -> None:
@@ -156,10 +158,10 @@ class SlurmdbdCharm(ops.CharmBase):
 
         self.slurmdbd.key.set(data.auth_key)
         self.slurmdbd.jwt.set(data.jwt_key)
+        self._reconfigure()
 
     @leader
     @refresh
-    @reconfigure
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Process the `DatabaseCreatedEvent` and update the database parameters.
 
@@ -177,6 +179,11 @@ class SlurmdbdCharm(ops.CharmBase):
               updated as the database parameters in the slurmdbd.conf configuration file.
         """
         logger.debug("configuring new backend database for slurmdbd")
+
+        config = SlurmdbdConfig()
+        config.storage_user = event.username
+        config.storage_pass = event.password
+        config.storage_loc = SLURM_ACCT_DATABASE_NAME
 
         socket_endpoints = []
         tcp_endpoints = []
@@ -198,12 +205,6 @@ class SlurmdbdCharm(ops.CharmBase):
                 socket_endpoints.append(endpoint)
             else:
                 tcp_endpoints.append(endpoint)
-
-        database_info: dict[str, Any] = {
-            "storageuser": event.username,
-            "storagepass": event.password,
-            "storageloc": SLURM_ACCT_DATABASE_NAME,
-        }
 
         if socket_endpoints:
             # Socket endpoints will be preferred. This is the case when the mysql
@@ -231,12 +232,10 @@ class SlurmdbdCharm(ops.CharmBase):
             # Check IPv6 and strip any brackets
             if addr.startswith("[") and addr.endswith("]"):
                 addr = addr[1:-1]
-            database_info.update(
-                {
-                    "storagehost": addr,
-                    "storageport": int(port),
-                }
-            )
+
+            config.storage_host = addr
+            config.storage_port = int(port)
+
             # Make sure that the MYSQL_UNIX_PORT is removed from the env file.
             del self.slurmdbd.mysql_unix_port
         else:
@@ -247,7 +246,30 @@ class SlurmdbdCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus("No database endpoints provided")
             raise ValueError(f"no endpoints provided: {event.endpoints}")
 
-        update_storage(self, database_info)
+        self.slurmdbd.storage.dump(config)
+        self._reconfigure()
+
+    def _reconfigure(self) -> None:
+        """Reconfigure the `slurmdbd` service and update `slurmctld` integration databag.
+
+        Raises:
+            StopCharm: Raised if an error occurs when reconfiguring the `slurmdbd` service.
+        """
+        if not slurmdbd_ready(self):
+            return
+
+        try:
+            self.slurmdbd.reconfigure()
+        except SlurmOpsError as e:
+            logger.error(e.message)
+            raise StopCharm(
+                ops.BlockedStatus(
+                    "Failed to apply updated `slurmdbd` configuration. "
+                    "See `juju debug-log` for details"
+                )
+            )
+
+        self.slurmctld.set_database_data(DatabaseData(hostname=self.slurmdbd.hostname))
 
 
 if __name__ == "__main__":

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -41,7 +41,7 @@ from hpc_libs.utils import StopCharm, get_ingress_address, leader, refresh
 from pydantic import ValidationError
 from slurm_ops import SlurmdbdManager, SlurmOpsError
 from slurmutils import SlurmdbdConfig
-from state import check_slurmdbd, slurmdbd_installed, slurmdbd_ready
+from state import check_slurmdbd, slurmdbd_installed, slurmdbd_ready, unit_is_leader
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +88,7 @@ class SlurmdbdCharm(ops.CharmBase):
         framework.observe(self.database.on.database_created, self._on_database_created)
 
     @refresh
+    @block_unless(unit_is_leader)
     def _on_install(self, event: ops.InstallEvent) -> None:
         """Install `slurmdbd` after charm is deployed on the unit.
 
@@ -96,13 +97,6 @@ class SlurmdbdCharm(ops.CharmBase):
               so the service is stopped and disabled. The service is re-enabled after being
               integrated with a `slurmctld` application and backend database provider.
         """
-        if not self.unit.is_leader():
-            raise StopCharm(
-                ops.BlockedStatus(
-                    "`slurmdbd` high-availability is not supported. Scale down application"
-                )
-            )
-
         self.unit.status = ops.MaintenanceStatus("Installing `slurmdbd`")
         try:
             self.slurmdbd.install()
@@ -272,5 +266,5 @@ class SlurmdbdCharm(ops.CharmBase):
         self.slurmctld.set_database_data(DatabaseData(hostname=self.slurmdbd.hostname))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: nocover
     ops.main(SlurmdbdCharm)

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -41,7 +41,7 @@ from hpc_libs.utils import StopCharm, get_ingress_address, leader, refresh
 from pydantic import ValidationError
 from slurm_ops import SlurmdbdManager, SlurmOpsError
 from slurmutils import SlurmdbdConfig
-from state import check_slurmdbd, slurmdbd_installed, slurmdbd_ready, unit_is_leader
+from state import check_slurmdbd, slurmdbd_installed, slurmdbd_ready
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,6 @@ class SlurmdbdCharm(ops.CharmBase):
         framework.observe(self.database.on.database_created, self._on_database_created)
 
     @refresh
-    @block_unless(unit_is_leader)
     def _on_install(self, event: ops.InstallEvent) -> None:
         """Install `slurmdbd` after charm is deployed on the unit.
 
@@ -97,6 +96,13 @@ class SlurmdbdCharm(ops.CharmBase):
               so the service is stopped and disabled. The service is re-enabled after being
               integrated with a `slurmctld` application and backend database provider.
         """
+        if not self.unit.is_leader():
+            raise StopCharm(
+                ops.BlockedStatus(
+                    "`slurmdbd` high-availability is not supported. Scale down application"
+                )
+            )
+
         self.unit.status = ops.MaintenanceStatus("Installing `slurmdbd`")
         try:
             self.slurmdbd.install()

--- a/charms/slurmdbd/src/config.py
+++ b/charms/slurmdbd/src/config.py
@@ -15,112 +15,29 @@
 """Manage the configuration of the `slurmdbd` charmed operator."""
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
 
-import ops
-from constants import (
-    DEFAULT_SLURMDBD_CONFIG,
-    OVERRIDES_CONFIG_FILE,
-    PEER_INTEGRATION_NAME,
-    STORAGE_CONFIG_FILE,
-)
-from hpc_libs.interfaces import DatabaseData
-from hpc_libs.utils import StopCharm, get_ingress_address, plog
-from slurm_ops import SlurmOpsError
+from pydantic import BaseModel, ConfigDict, field_validator
 from slurmutils import ModelError, SlurmdbdConfig
-from state import slurmdbd_ready
-
-if TYPE_CHECKING:
-    from charm import SlurmdbdCharm
 
 _logger = logging.getLogger(__name__)
 
 
-def init_config(charm: "SlurmdbdCharm", /) -> None:
-    """Initialize the `slurmdbd` service's configuration.
+class ConfigManager(BaseModel):
+    """Interface to `slurmdbd` application configuration options."""
 
-    This function "seeds" the starting point for the `slurmdbd` service's configuration;
-    it provides the default configuration values used by the service, but it does not provide
-    all the required configuration for `slurmdbd` to start successfully.
-    """
-    # Seed the `slurmdbd.conf` configuration file.
-    config = SlurmdbdConfig(
-        dbdhost=charm.slurmdbd.hostname,
-        dbdaddr=get_ingress_address(charm, PEER_INTEGRATION_NAME),
-        authalttypes=["auth/jwt"],
-        authaltparameters={"jwt_key": f"{charm.slurmdbd.jwt.path}"},
-        **DEFAULT_SLURMDBD_CONFIG,
-    )
-    charm.slurmdbd.config.dump(config)
+    # FIXME: `arbitrary_types_allowed=True` must be used here since pydantic cannot construct
+    #  a schema for the `Partition` object. This config can be removed when slurmutils v2 has
+    #  transitioned to using pydantic models rather than custom ones.
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
+    slurmdbd_conf_parameters: SlurmdbdConfig
 
-def update_overrides(charm: "SlurmdbdCharm", /) -> None:
-    """Update the `slurmdbd.conf.overrides` configuration file.
+    @field_validator("slurmdbd_conf_parameters", mode="before")
+    @classmethod
+    def _build_slurmdbd_conf_parameters(cls, value: str) -> SlurmdbdConfig:
+        try:
+            config = SlurmdbdConfig.from_str(value)
+        except (ModelError, ValueError) as e:
+            raise ValueError(f"Invalid slurmdbd configuration override: {value}. Reason:\n{e}")
 
-    Raises:
-        StopCharm: Raised if the custom `slurmdbd.conf` configuration provided is invalid.
-    """
-    _logger.info("updating `%s`", OVERRIDES_CONFIG_FILE)
-    try:
-        config = SlurmdbdConfig.from_str(
-            cast(str, charm.config.get("slurmdbd-conf-parameters", ""))
-        )
-    except (ModelError, ValueError) as e:
-        _logger.error(e)
-        raise StopCharm(
-            ops.BlockedStatus(
-                "Failed to load custom `slurmdbd` configuration. "
-                + "See `juju debug-log` for details"
-            )
-        )
-
-    _logger.debug("`%s`:\n%s", OVERRIDES_CONFIG_FILE, plog(config.dict()))
-    charm.slurmdbd.config.includes[OVERRIDES_CONFIG_FILE].dump(config)
-    _logger.info("`%s` successfully updated", OVERRIDES_CONFIG_FILE)
-
-
-def update_storage(charm: "SlurmdbdCharm", /, config: dict[str, Any]) -> None:
-    """Update the `slurmdbd.conf.storage` configuration file.
-
-    Raises:
-        StopCharm: Raised if the `slurmdbd.conf` database configuration provided is invalid.
-    """
-    _logger.info("updating `%s`", STORAGE_CONFIG_FILE)
-    try:
-        storage = SlurmdbdConfig.from_dict(config)
-    except (ModelError, ValueError) as e:
-        _logger.error(e)
-        raise StopCharm(
-            ops.BlockedStatus(
-                "Failed to load database configuration for `slurmdbd`. "
-                + "See `juju debug-log` for details"
-            )
-        )
-
-    _logger.debug("`%s`:\n%s", STORAGE_CONFIG_FILE, plog(storage.dict()))
-    charm.slurmdbd.config.includes[STORAGE_CONFIG_FILE].dump(storage)
-    _logger.info("`%s` successfully updated", STORAGE_CONFIG_FILE)
-
-
-def reconfigure_slurmdbd(charm: "SlurmdbdCharm") -> None:
-    """Reconfigure and restart the `slurmdbd` service.
-
-    Raises:
-        SlurmOpsError: Raised if the `slurmdbd` service fails to start or restart.
-    """
-    if not slurmdbd_ready(charm):
-        return
-
-    try:
-        charm.slurmdbd.config.merge()
-        charm.slurmdbd.service.enable()
-        charm.slurmdbd.service.restart()
-    except SlurmOpsError as e:
-        _logger.error(e.message)
-        raise StopCharm(
-            ops.BlockedStatus(
-                "Failed to apply new `slurmdbd` configuration. See `juju debug-log` for details"
-            )
-        )
-
-    charm.slurmctld.set_database_data(DatabaseData(hostname=charm.slurmdbd.hostname))
+        return config

--- a/charms/slurmdbd/src/config.py
+++ b/charms/slurmdbd/src/config.py
@@ -26,7 +26,7 @@ class ConfigManager(BaseModel):
     """Interface to `slurmdbd` application configuration options."""
 
     # FIXME: `arbitrary_types_allowed=True` must be used here since pydantic cannot construct
-    #  a schema for the `Partition` object. This config can be removed when slurmutils v2 has
+    #  a schema for the `SlurmdbdConfig` object. This config can be removed when slurmutils v2 has
     #  transitioned to using pydantic models rather than custom ones.
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 

--- a/charms/slurmdbd/src/constants.py
+++ b/charms/slurmdbd/src/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Vantage Compute Corporation
+# Copyright 2025-2026 Vantage Compute Corporation
 # Copyright 2024 Omnivector, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,15 +21,3 @@ SLURMDBD_INTEGRATION_NAME = "slurmctld"
 
 SLURM_ACCT_DATABASE_NAME = "slurm_acct_db"
 SLURMDBD_PORT = 6819
-
-OVERRIDES_CONFIG_FILE = "slurmdbd.conf.overrides"
-STORAGE_CONFIG_FILE = "slurmdbd.conf.storage"
-DEFAULT_SLURMDBD_CONFIG = {
-    "dbdport": SLURMDBD_PORT,
-    "authtype": "auth/slurm",
-    "slurmuser": "slurm",
-    "plugindir": ["/usr/lib/x86_64-linux-gnu/slurm-wlm"],
-    "pidfile": "/var/run/slurmdbd/slurmdbd.pid",
-    "logfile": "/var/log/slurm/slurmdbd.log",
-    "storagetype": "accounting_storage/mysql",
-}

--- a/charms/slurmdbd/src/state.py
+++ b/charms/slurmdbd/src/state.py
@@ -43,6 +43,19 @@ def slurmdbd_installed(charm: "SlurmdbdCharm") -> ConditionEvaluation:
     )
 
 
+def unit_is_leader(charm: ops.CharmBase) -> ConditionEvaluation:
+    """Check if this slurmdbd unit is the application leader."""
+    is_leader = charm.unit.is_leader()
+    return ConditionEvaluation(
+        is_leader,
+        (
+            "`slurmdbd` service high-availability is not supported. Scale down application"
+            if not is_leader
+            else ""
+        ),
+    )
+
+
 database_exists = integration_exists(DATABASE_INTEGRATION_NAME)
 database_exists.__doc__ = """Check if the `database` integration exists."""
 

--- a/charms/slurmdbd/src/state.py
+++ b/charms/slurmdbd/src/state.py
@@ -43,19 +43,6 @@ def slurmdbd_installed(charm: "SlurmdbdCharm") -> ConditionEvaluation:
     )
 
 
-def unit_is_leader(charm: ops.CharmBase) -> ConditionEvaluation:
-    """Check if this slurmdbd unit is the application leader."""
-    is_leader = charm.unit.is_leader()
-    return ConditionEvaluation(
-        is_leader,
-        (
-            "`slurmdbd` service high-availability is not supported. Scale down application"
-            if not is_leader
-            else ""
-        ),
-    )
-
-
 database_exists = integration_exists(DATABASE_INTEGRATION_NAME)
 database_exists.__doc__ = """Check if the `database` integration exists."""
 

--- a/charms/slurmdbd/tests/unit/conftest.py
+++ b/charms/slurmdbd/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,46 @@
 
 import pytest
 from charm import SlurmdbdCharm
+from constants import PEER_INTEGRATION_NAME
 from ops import testing
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture(scope="function")
-def mock_charm() -> testing.Context[SlurmdbdCharm]:
-    """Mock `SlurmctldCharm`."""
+def peer_integration() -> testing.PeerRelation:
+    """`slurmdbd` peer integration fixture."""
+    return testing.PeerRelation(
+        endpoint=PEER_INTEGRATION_NAME,
+        interface="slurmdbd-peer",
+    )
+
+
+@pytest.fixture(scope="function")
+def mock_ctx() -> testing.Context[SlurmdbdCharm]:
+    """Mock `SlurmdbdCharm` context."""
     return testing.Context(SlurmdbdCharm)
+
+
+@pytest.fixture(scope="function")
+def mock_charm(
+    mock_ctx, mocker: MockerFixture, fs: FakeFilesystem
+) -> testing.Context[SlurmdbdCharm]:
+    """Mock `SlurmdbdCharm` context with fake filesystem.
+
+    Warnings:
+        - The mock charm context must come before the fake filesystem fixture,
+          otherwise `ops.testing.Context` will fail to locate the `slurmdbd` charm's
+          charmcraft.yaml file.
+    """
+    fs.create_dir("/etc/slurm")
+    fs.create_file("/etc/default/slurmdbd", create_missing_dirs=True)
+    mocker.patch("shutil.chown")  # User/group `slurm` doesn't exist on host.
+    mocker.patch("subprocess.run")
+    return mock_ctx
+
+
+@pytest.fixture(scope="function", params=(True, False), ids=("success", "failure"))
+def succeed(request: pytest.FixtureRequest) -> bool:
+    """Parameterize a test to succeed and fail."""
+    return request.param

--- a/charms/slurmdbd/tests/unit/test_charm.py
+++ b/charms/slurmdbd/tests/unit/test_charm.py
@@ -74,7 +74,7 @@ class TestSlurmdbdCharm:
             assert state.unit_status == expected
         else:
             assert state.unit_status == ops.BlockedStatus(
-                "`slurmdbd` service high-availability is not supported. Scale down application"
+                "`slurmdbd` high-availability is not supported. Scale down application"
             )
 
     def test_on_config_changed(

--- a/charms/slurmdbd/tests/unit/test_charm.py
+++ b/charms/slurmdbd/tests/unit/test_charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023-2025 Canonical Ltd.
+# Copyright 2023-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,135 @@
 
 """Unit tests for the `slurmdbd` charm."""
 
+import ops
+import pytest
+from constants import DATABASE_INTEGRATION_NAME, SLURMDBD_INTEGRATION_NAME
+from ops import testing
+from pytest_mock import MockerFixture
+from slurm_ops import SlurmOpsError
 
-def test_on_install() -> None:
-    """Test the `_on_install` event handler."""
+
+@pytest.mark.parametrize(
+    "leader",
+    (
+        pytest.param(True, id="leader"),
+        pytest.param(False, id="not leader"),
+    ),
+)
+class TestSlurmdbdCharm:
+    """Unit tests for the `slurmdbd` charmed operator."""
+
+    @pytest.mark.parametrize(
+        "mock_install,expected",
+        (
+            pytest.param(
+                None,
+                ops.BlockedStatus("Waiting for integrations: [`slurmctld`, `database`]"),
+                id="success",
+            ),
+            pytest.param(
+                SlurmOpsError("install failed"),
+                ops.BlockedStatus(
+                    "Failed to install `slurmdbd`. See `juju debug-log` for details."
+                ),
+                id="fail",
+            ),
+        ),
+    )
+    def test_on_install(
+        self,
+        mock_charm,
+        mocker: MockerFixture,
+        mock_install,
+        leader,
+        expected,
+    ) -> None:
+        """Test the `_on_install` event handler."""
+        with mock_charm(mock_charm.on.install(), testing.State(leader=leader)) as manager:
+            slurmdbd = manager.charm.slurmdbd
+            mocker.patch.object(slurmdbd, "install", side_effect=mock_install)
+            mocker.patch.object(slurmdbd, "is_installed")
+            mocker.patch.object(slurmdbd, "version", return_value="24.05.2-1")
+            mocker.patch.object(slurmdbd.service, "stop")
+            mocker.patch.object(slurmdbd.service, "disable")
+            mocker.patch.object(slurmdbd.service, "is_active", return_value=False)
+
+            state = manager.run()
+
+        if leader:
+            assert state.unit_status == expected
+        else:
+            assert state.unit_status == ops.BlockedStatus(
+                "`slurmdbd` service high-availability is not supported. Scale down application"
+            )
+
+    def test_on_config_changed(
+        self,
+        mock_charm,
+        mocker: MockerFixture,
+        peer_integration,
+        leader,
+    ) -> None:
+        """Test the `_on_config_changed` event handler."""
+        with mock_charm(
+            mock_charm.on.config_changed(),
+            testing.State(leader=leader, relations={peer_integration}),
+        ) as manager:
+            slurmdbd = manager.charm.slurmdbd
+            mocker.patch.object(slurmdbd, "is_installed", return_value=True)
+            mocker.patch.object(slurmdbd.service, "is_active", return_value=False)
+
+            manager.run()
+
+        if leader:
+            assert slurmdbd.config.path.exists()
+        else:
+            assert not slurmdbd.config.path.exists()
+
+    def test_reconfigure(
+        self,
+        mock_charm,
+        mocker: MockerFixture,
+        peer_integration,
+        leader,
+        succeed,
+    ) -> None:
+        """Test the `_reconfigure` method."""
+        slurmctld_integration = testing.Relation(
+            endpoint=SLURMDBD_INTEGRATION_NAME,
+            interface="slurmdbd",
+        )
+        database_integration = testing.Relation(
+            endpoint=DATABASE_INTEGRATION_NAME,
+            interface="mysql_client",
+        )
+
+        with mock_charm(
+            mock_charm.on.config_changed(),
+            testing.State(
+                leader=leader,
+                relations={peer_integration, slurmctld_integration, database_integration},
+            ),
+        ) as manager:
+            slurmdbd = manager.charm.slurmdbd
+            mocker.patch.object(slurmdbd, "is_installed", return_value=True)
+            mocker.patch.object(slurmdbd.service, "is_active", return_value=True)
+            mocker.patch("charm.slurmdbd_ready", return_value=True)
+
+            mock_reconfigure = mocker.patch.object(slurmdbd, "reconfigure")
+            if not succeed:
+                mock_reconfigure.side_effect = SlurmOpsError("reconfigure failed")
+
+            state = manager.run()
+
+        if not leader:
+            mock_reconfigure.assert_not_called()
+        elif succeed:
+            mock_reconfigure.assert_called_once()
+            assert state.unit_status == ops.ActiveStatus()
+        else:
+            mock_reconfigure.assert_called_once()
+            assert state.unit_status == ops.BlockedStatus(
+                "Failed to apply updated `slurmdbd` configuration. "
+                "See `juju debug-log` for details"
+            )

--- a/pkgs/slurm-ops/src/slurm_ops/slurmdbd.py
+++ b/pkgs/slurm-ops/src/slurm_ops/slurmdbd.py
@@ -16,7 +16,6 @@
 
 __all__ = ["SlurmdbdManager"]
 
-from functools import cached_property
 from os import PathLike
 
 from slurmutils import SlurmdbdConfigEditor
@@ -30,7 +29,7 @@ class SlurmdbdManager(SlurmManager):
     def __init__(self, snap: bool = False) -> None:
         super().__init__("slurmdbd", snap)
 
-    @cached_property
+    @property
     def config(self) -> SlurmConfigManager:
         """Get the configuration manager for the `slurmdbd.conf` file."""
         return SlurmConfigManager(
@@ -41,12 +40,12 @@ class SlurmdbdManager(SlurmManager):
             group=self.group,
         )
 
-    @cached_property
+    @property
     def overrides(self) -> SlurmConfigManager:
         """Get the configuration manager for the `slurmdbd.conf.overrides` file."""
         return self.config.includes["slurmdbd.conf.overrides"]
 
-    @cached_property
+    @property
     def storage(self) -> SlurmConfigManager:
         """Get the configuration manager for the `slurmdbd.conf.storage` file."""
         return self.config.includes["slurmdbd.conf.storage"]

--- a/pkgs/slurm-ops/src/slurm_ops/slurmdbd.py
+++ b/pkgs/slurm-ops/src/slurm_ops/slurmdbd.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 __all__ = ["SlurmdbdManager"]
 
+from functools import cached_property
 from os import PathLike
 
 from slurmutils import SlurmdbdConfigEditor
@@ -29,13 +30,26 @@ class SlurmdbdManager(SlurmManager):
     def __init__(self, snap: bool = False) -> None:
         super().__init__("slurmdbd", snap)
 
-        self.config = SlurmConfigManager(
+    @cached_property
+    def config(self) -> SlurmConfigManager:
+        """Get the configuration manager for the `slurmdbd.conf` file."""
+        return SlurmConfigManager(
             SlurmdbdConfigEditor,
             file=self._ops_manager.etc_path / "slurmdbd.conf",
             mode=0o600,
             user=self.user,
             group=self.group,
         )
+
+    @cached_property
+    def overrides(self) -> SlurmConfigManager:
+        """Get the configuration manager for the `slurmdbd.conf.overrides` file."""
+        return self.config.includes["slurmdbd.conf.overrides"]
+
+    @cached_property
+    def storage(self) -> SlurmConfigManager:
+        """Get the configuration manager for the `slurmdbd.conf.storage` file."""
+        return self.config.includes["slurmdbd.conf.storage"]
 
     @property
     def mysql_unix_port(self) -> str | None:
@@ -52,10 +66,19 @@ class SlurmdbdManager(SlurmManager):
 
     @property
     def user(self) -> str:
-        """Get the user that the `slurmd` service runs as."""
+        """Get the user that the `slurmdbd` service runs as."""
         return SLURM_USER
 
     @property
     def group(self) -> str:
-        """Get the group that the `slurmd` service runs as."""
+        """Get the group that the `slurmdbd` service runs as."""
         return SLURM_GROUP
+
+    def reconfigure(self) -> None:
+        """Reconfigure the `slurmdbd` service running on the machine.
+
+        Raises:
+            SlurmOpsError: Raised if a failure occurs when reconfiguring the `slurmdbd` service.
+        """
+        self.config.merge()
+        super().reconfigure()


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR banishes the `reconfigure` decorator from the slurmdbd charm. 

There is now a better separation of concerns between the `SlurmdbdManager` and `SlurmdbdCharm`. `SlurmdbdManager` focuses solely on updating the underlying slurmdbd service configuration, and `SlurmdbdCharm` focuses on updating the necessary integration data if conditions are satisfied. The private `_reconfigure` method is introduced to prevent duplicated lines of code since there are several handlers where the slurmdbd service must be reconfigured.

#### Related Issues, PRs, and Discussions

Related to me add @dsloanm's discussions on removing the reconfigure directory since it can get messy quickly and is logically dense when working with services such as `slurmctld`. 

### Other changes

I introduced the same `ConfigManager` changes from the `slurmd` charm to validate the custom `slurmdbd.conf` parameters supplied by a cluster administrator. 

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change.