### PR TITLE
fix(slurmd): remove unnecessary `.wokeignore` file

### DIFF
--- a/charms/slurmd/.wokeignore
+++ b/charms/slurmd/.wokeignore
@@ -1,1 +1,0 @@
-src/templates/nhc.conf.tmpl


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This .ignore file was originally present because `woke`
did not like the NHC template file originally distributed
with this charm, but since:

a. the template file no longer exists, and
b. NHC is no longer used in the slurmd charm

the .ignore file can be removed.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Noticed that this file is no longer relevant during some Slurm charm cleanup work.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change.