### PR TITLE
feat: implement auth key rotation

### DIFF
--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -16,11 +16,10 @@
 """Charmed operator for `sackd`, Slurm's authentication kiosk service."""
 
 import logging
-from subprocess import CalledProcessError
 
 import ops
-from charmed_hpc_libs.ops import call
-from charmed_hpc_libs.ops.conditions import StopCharm, block_unless, refresh, wait_unless
+from charmed_hpc_libs.errors import SystemdError
+from charmed_hpc_libs.ops import StopCharm, block_unless, refresh, systemctl, wait_unless
 from charmed_slurm_sackd_interface import (
     AUTH_KEY_LABEL,
     SackdProvider,
@@ -147,8 +146,8 @@ class SackdCharm(ops.CharmBase):
         # Necessary to load new key from file into the service
         # TODO: replace with self.service.reload()
         try:
-            call("/usr/bin/systemctl", "reload", "sackd.service")
-        except CalledProcessError as e:
+            systemctl("reload", "sackd.service")
+        except SystemdError as e:
             logger.error("failed to reload sackd.service. reason:\n%s", e)
             event.defer()
             raise StopCharm(

--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -16,6 +16,7 @@
 """Charmed operator for `sackd`, Slurm's authentication kiosk service."""
 
 import logging
+from subprocess import CalledProcessError
 
 import ops
 from charmed_hpc_libs.ops.conditions import StopCharm, block_unless, refresh, wait_unless
@@ -43,6 +44,7 @@ class SackdCharm(ops.CharmBase):
         self.sackd = SackdManager(snap=False)
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.update_status, self._on_update_status)
+        framework.observe(self.on.secret_changed, self._on_secret_changed)
 
         self.slurmctld = SackdProvider(self, SACKD_INTEGRATION_NAME)
         framework.observe(
@@ -90,7 +92,7 @@ class SackdCharm(ops.CharmBase):
         data = self.slurmctld.get_controller_data(event.relation.id)
 
         try:
-            self.sackd.key.set(data.auth_key)
+            self.sackd.key.set(data.auth_key, data.auth_key_content_id)
             self.sackd.conf_server = data.controllers
             self.sackd.service.enable()
             self.sackd.service.restart()
@@ -114,6 +116,44 @@ class SackdCharm(ops.CharmBase):
             event.defer()
             raise StopCharm(
                 ops.BlockedStatus("Failed to stop `sackd`. See `juju debug-log` for details")
+            )
+
+    @refresh
+    @block_unless(sackd_installed)
+    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
+        """Handle when a secret is changed."""
+        if event.secret.label != AUTH_KEY_LABEL:
+            logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
+            return
+
+        content = event.secret.get_content(refresh=True)
+        auth_key = content.get("key")
+        auth_key_id = content.get("keyid")
+        if not auth_key or not auth_key_id:
+            logger.error(
+                "auth key or key ID is empty in secret with label '%s'", event.secret.label
+            )
+            event.defer()
+            raise StopCharm(
+                ops.BlockedStatus(
+                    "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
+                )
+            )
+
+        self.sackd.key.set(auth_key, auth_key_id)
+
+        # Necessary to load new key from file into the service
+        # TODO: replace with self.service.reload()
+        slurm_service = "sackd.service"
+        try:
+            call("/usr/bin/systemctl", "reload", slurm_service)
+        except CalledProcessError as e:
+            logger.exception("failed to reload %s. reason:\n%s", slurm_service, e)
+            event.defer()
+            raise StopCharm(
+                ops.BlockedStatus(
+                    "Failed to reload %s. See `juju debug-log` for details" % slurm_service
+                )
             )
 
 

--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -146,15 +146,14 @@ class SackdCharm(ops.CharmBase):
 
         # Necessary to load new key from file into the service
         # TODO: replace with self.service.reload()
-        slurm_service = "sackd.service"
         try:
-            call("/usr/bin/systemctl", "reload", slurm_service)
+            call("/usr/bin/systemctl", "reload", "sackd.service")
         except CalledProcessError as e:
-            logger.exception("failed to reload %s. reason:\n%s", slurm_service, e)
+            logger.error("failed to reload sackd.service. reason:\n%s", e)
             event.defer()
             raise StopCharm(
                 ops.BlockedStatus(
-                    "Failed to reload %s. See `juju debug-log` for details" % slurm_service
+                    "Failed to reload sackd.service. See `juju debug-log` for details"
                 )
             )
 

--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -152,7 +152,7 @@ class SackdCharm(ops.CharmBase):
             event.defer()
             raise StopCharm(
                 ops.BlockedStatus(
-                    "Failed to reload sackd.service. See `juju debug-log` for details"
+                    "Failed to reload `sackd` configuration. See `juju debug-log` for details"
                 )
             )
 

--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -19,8 +19,10 @@ import logging
 from subprocess import CalledProcessError
 
 import ops
+from charmed_hpc_libs.ops import call
 from charmed_hpc_libs.ops.conditions import StopCharm, block_unless, refresh, wait_unless
 from charmed_slurm_sackd_interface import (
+    AUTH_KEY_LABEL,
     SackdProvider,
     SlurmctldDisconnectedEvent,
     SlurmctldReadyEvent,
@@ -92,7 +94,7 @@ class SackdCharm(ops.CharmBase):
         data = self.slurmctld.get_controller_data(event.relation.id)
 
         try:
-            self.sackd.key.set(data.auth_key, data.auth_key_content_id)
+            self.sackd.key.set(data.auth_key, data.auth_key_id)
             self.sackd.conf_server = data.controllers
             self.sackd.service.enable()
             self.sackd.service.restart()

--- a/charms/sackd/tests/unit/conftest.py
+++ b/charms/sackd/tests/unit/conftest.py
@@ -36,7 +36,7 @@ def mock_charm(mock_ctx, fs: FakeFilesystem, mocker: MockerFixture) -> testing.C
           otherwise `ops.testing.Context` will fail to locate the `sackd` charm's
           charmcraft.yaml file.
     """
-    fs.create_file("/etc/slurm/slurm.key", create_missing_dirs=True)
+    fs.create_file("/etc/slurm/slurm.jwks", create_missing_dirs=True)
     fs.create_file("/etc/default/sackd", create_missing_dirs=True)
     mocker.patch("subprocess.run")
 

--- a/charms/sackd/tests/unit/test_charm.py
+++ b/charms/sackd/tests/unit/test_charm.py
@@ -16,16 +16,28 @@
 """Unit tests for the `sackd` charmed operator."""
 
 import json
+from pathlib import Path
 
 import ops
 import pytest
 from constants import SACKD_INTEGRATION_NAME
+from hpc_libs.interfaces import AUTH_KEY_LABEL
 from ops import testing
 from pytest_mock import MockerFixture
 from slurm_ops import SlurmOpsError
 
 EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_KEY_ID = "12345678-90ab-cdef-1234-567890abcdef"
 EXAMPLE_CONTROLLERS = ["juju-988225-0:6817", "juju-988225-1:6817"]
+
+
+@pytest.fixture
+def auth_key_secret() -> testing.Secret:
+    """Mock Slurm auth key secret."""
+    return testing.Secret(
+        label=AUTH_KEY_LABEL,
+        tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID},
+    )
 
 
 @pytest.mark.parametrize(
@@ -102,11 +114,16 @@ class TestSackdCharm:
         ),
     )
     def test_on_slurmctld_ready(
-        self, mock_charm, mocker: MockerFixture, mock_restart, ready, leader, expected
+        self,
+        mock_charm,
+        mocker: MockerFixture,
+        mock_restart,
+        ready,
+        leader,
+        expected,
+        auth_key_secret,
     ) -> None:
         """Test the `_on_slurmctld_ready` event handler."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY})
-
         integration_id = 1
         integration = testing.Relation(
             endpoint=SACKD_INTEGRATION_NAME,
@@ -154,11 +171,9 @@ class TestSackdCharm:
         ),
     )
     def test_on_slurmctld_disconnected(
-        self, mock_charm, mocker: MockerFixture, mock_stop, leader, expected
+        self, mock_charm, mocker: MockerFixture, mock_stop, leader, expected, auth_key_secret
     ) -> None:
         """Test the `_on_slurmctld_disconnected` event handler."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY})
-
         integration_id = 1
         integration = testing.Relation(
             endpoint=SACKD_INTEGRATION_NAME,
@@ -183,3 +198,77 @@ class TestSackdCharm:
             state = manager.run()
 
         assert state.unit_status == expected
+
+    def test_on_secret_changed_success(
+        self, mock_charm, mocker: MockerFixture, leader, auth_key_secret
+    ) -> None:
+        """Test successful execution of the `_on_secret_changed` event handler."""
+        key_file_path = Path("/etc/slurm/slurm.jwks")
+        expected_key_file_content = {
+            "keys": [
+                {"alg": "HS256", "kty": "oct", "kid": EXAMPLE_AUTH_KEY_ID, "k": EXAMPLE_AUTH_KEY}
+            ]
+        }
+
+        integration_id = 1
+        integration = testing.Relation(
+            endpoint=SACKD_INTEGRATION_NAME,
+            interface="sackd",
+            id=integration_id,
+            remote_app_name="slurmctld",
+            remote_app_data={
+                "auth_key": '"***"',
+                "auth_key_id": json.dumps(auth_key_secret.id),
+                "controllers": json.dumps(EXAMPLE_CONTROLLERS),
+            },
+        )
+
+        with mock_charm(
+            mock_charm.on.secret_changed(auth_key_secret),
+            testing.State(leader=leader, relations={integration}, secrets={auth_key_secret}),
+        ) as manager:
+            sackd = manager.charm.sackd
+            mocker.patch.object(sackd, "is_installed", return_value=True)
+            mocker.patch.object(sackd.service, "is_active")
+            mocker.patch("shutil.chown")  # User/group `slurm` doesn't exist on host.
+
+            state = manager.run()
+
+        assert key_file_path.exists(), f"File {key_file_path} does not exist"
+        key_file_text = key_file_path.read_text()
+        actual_key_file_content = json.loads(key_file_text)
+        assert actual_key_file_content == expected_key_file_content
+        assert state.unit_status == ops.ActiveStatus()
+
+    def test_on_secret_changed_empty_key_id_failure(
+        self, mock_charm, mocker: MockerFixture, leader
+    ) -> None:
+        """Test `_on_secret_changed` event handler when auth key ID is empty."""
+        auth_key_secret = testing.Secret(
+            label=AUTH_KEY_LABEL, tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": ""}
+        )
+        integration_id = 1
+        integration = testing.Relation(
+            endpoint=SACKD_INTEGRATION_NAME,
+            interface="sackd",
+            id=integration_id,
+            remote_app_name="slurmctld",
+            remote_app_data={
+                "auth_key": '"***"',
+                "auth_key_id": json.dumps(auth_key_secret.id),
+                "controllers": json.dumps(EXAMPLE_CONTROLLERS),
+            },
+        )
+
+        with mock_charm(
+            mock_charm.on.secret_changed(auth_key_secret),
+            testing.State(leader=leader, relations={integration}, secrets={auth_key_secret}),
+        ) as manager:
+            sackd = manager.charm.sackd
+            mocker.patch.object(sackd, "is_installed", return_value=True)
+
+            state = manager.run()
+
+        assert state.unit_status == ops.BlockedStatus(
+            "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
+        )

--- a/charms/sackd/tests/unit/test_charm.py
+++ b/charms/sackd/tests/unit/test_charm.py
@@ -20,8 +20,8 @@ from pathlib import Path
 
 import ops
 import pytest
+from charmed_slurm_slurmctld_interface import AUTH_KEY_LABEL
 from constants import SACKD_INTEGRATION_NAME
-from hpc_libs.interfaces import AUTH_KEY_LABEL
 from ops import testing
 from pytest_mock import MockerFixture
 from slurm_ops import SlurmOpsError
@@ -132,8 +132,7 @@ class TestSackdCharm:
             remote_app_name="slurmctld",
             remote_app_data=(
                 {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "controllers": json.dumps(EXAMPLE_CONTROLLERS),
                 }
                 if ready
@@ -181,8 +180,7 @@ class TestSackdCharm:
             id=integration_id,
             remote_app_name="slurmctld",
             remote_app_data={
-                "auth_key": '"***"',
-                "auth_key_id": json.dumps(auth_key_secret.id),
+                "auth_secret_id": json.dumps(auth_key_secret.id),
                 "controllers": json.dumps(EXAMPLE_CONTROLLERS),
             },
         )
@@ -217,8 +215,7 @@ class TestSackdCharm:
             id=integration_id,
             remote_app_name="slurmctld",
             remote_app_data={
-                "auth_key": '"***"',
-                "auth_key_id": json.dumps(auth_key_secret.id),
+                "auth_secret_id": json.dumps(auth_key_secret.id),
                 "controllers": json.dumps(EXAMPLE_CONTROLLERS),
             },
         )
@@ -254,8 +251,7 @@ class TestSackdCharm:
             id=integration_id,
             remote_app_name="slurmctld",
             remote_app_data={
-                "auth_key": '"***"',
-                "auth_key_id": json.dumps(auth_key_secret.id),
+                "auth_secret_id": json.dumps(auth_key_secret.id),
                 "controllers": json.dumps(EXAMPLE_CONTROLLERS),
             },
         )

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -118,6 +118,16 @@ config:
         https://github.com/neilmunday/slurm-mail/blob/v4.31/etc/slurm-mail/slurm-mail.conf#L16
 
 actions:
+  rotate-auth-key:
+    description: |
+      Perform a cluster-wide rotation of the key used to authenticate Slurm remote procedure calls.
+
+      Example usage:
+
+      ```bash
+      juju run slurmctld/leader rotate-auth-key
+      ```
+
   show-current-config:
     description: |
       Display the currently used `slurm.conf`.

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -121,6 +121,7 @@ actions:
   rotate-auth-key:
     description: |
       Perform a cluster-wide rotation of the key used to authenticate Slurm remote procedure calls.
+      See: https://documentation.ubuntu.com/charmed-hpc/latest/explanation/key-rotation/#authentication-key-rotation
 
       Example usage:
 

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -18,6 +18,7 @@
 
 import logging
 import secrets
+from uuid import uuid4
 
 import mail
 import ops
@@ -138,6 +139,9 @@ class SlurmctldCharm(ops.CharmBase):
         framework.observe(self.on.start, self._on_start)
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.update_status, self._on_update_status)
+        framework.observe(self.on.secret_changed, self._on_secret_changed)
+        framework.observe(self.on.secret_remove, self._on_secret_remove)
+        framework.observe(self.on.rotate_auth_key_action, self._on_rotate_auth_key_action)
         framework.observe(self.on.show_current_config_action, self._on_show_current_config_action)
         framework.observe(self.on.set_node_state_action, self._on_set_node_state_action)
 
@@ -217,8 +221,24 @@ class SlurmctldCharm(ops.CharmBase):
                 # new unit is elected leader as it is being deployed
                 if not self.slurmctld.jwt.path.exists():
                     self.slurmctld.jwt.generate()
-                if not self.slurmctld.key.path.exists():
-                    self.slurmctld.key.generate()
+
+                try:
+                    secret = self.model.get_secret(label=AUTH_KEY_LABEL)
+                    logger.debug("auth key secret found. skipping generation")
+
+                    if not self.slurmctld.key.path.exists():
+                        logger.warning("auth key file not found. restoring from secret")
+                        content = secret.get_content()
+                        self.slurmctld.key.set(content["key"], content["keyid"])
+                except ops.SecretNotFoundError:
+                    key = self.slurmctld.key.generate()
+                    # Auth key entries must each have a unique ID consistent across all units.
+                    # Secret revision number cannot be used as it is not known to secret observers.
+                    # Secret `unique_identifier` property is not unique per revision.
+                    # Therefore, a newly generated UUID is included with the secret contents.
+                    key_id = str(uuid4())
+                    self.app.add_secret({"key": key, "keyid": key_id}, label=AUTH_KEY_LABEL)
+                    self.slurmctld.key.set(key, key_id)
 
             self.unit.set_workload_version(self.slurmctld.version())
         except SlurmOpsError as e:
@@ -401,10 +421,11 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_sackd_connected(self, event: SackdConnectedEvent) -> None:
         """Handle when a new `sackd` application is connected."""
+        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         new_endpoints = [f"{c}:{SLURMCTLD_PORT}" for c in self._get_controllers()]
         self.sackd.set_controller_data(
             ControllerData(
-                auth_key=self.slurmctld.key.get(),
+                auth_key_id=auth_key_id,
                 controllers=new_endpoints,
             ),
             integration_id=event.relation.id,
@@ -415,6 +436,7 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_slurmd_ready(self, event: SlurmdReadyEvent) -> None:
         """Handle when partition data is ready from a `slurmd` application."""
+        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         data = self.slurmd.get_compute_data(event.relation.id)
         name = data.partition.partition_name
         include = f"slurm.conf.{name}"
@@ -435,7 +457,7 @@ class SlurmctldCharm(ops.CharmBase):
         new_endpoints = [f"{c}:{SLURMCTLD_PORT}" for c in self._get_controllers()]
         self.slurmd.set_controller_data(
             ControllerData(
-                auth_key=self.slurmctld.key.get(),
+                auth_key_id=auth_key_id,
                 controllers=new_endpoints,
             ),
             integration_id=event.relation.id,
@@ -463,9 +485,10 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_slurmdbd_connected(self, event: SlurmdbdConnectedEvent) -> None:
         """Handle when a new `slurmdbd` application is connected."""
+        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         self.slurmdbd.set_controller_data(
             ControllerData(
-                auth_key=self.slurmctld.key.get(),
+                auth_key_id=auth_key_id,
                 jwt_key=self.slurmctld.jwt.get(),
             ),
             integration_id=event.relation.id,
@@ -520,9 +543,10 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_slurmrestd_connected(self, event: SlurmrestdConnectedEvent) -> None:
         """Handle when a new `slurmrestd` application is connected."""
+        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         self.slurmrestd.set_controller_data(
             ControllerData(
-                auth_key=self.slurmctld.key.get(),
+                auth_key_id=auth_key_id,
                 slurmconfig={
                     "slurm.conf": self.slurmctld.config.load(),
                     **{k: v.load() for k, v in self.slurmctld.config.includes.items()},
@@ -625,6 +649,65 @@ class SlurmctldCharm(ops.CharmBase):
         logger.info("`%s` configuration deleted successfully", self.slurmctld.oci.name)
 
         self._reconfigure()
+
+    @block_unless(slurmctld_installed)
+    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
+        """Handle when a secret is changed."""
+        if event.secret.label != AUTH_KEY_LABEL:
+            logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
+            return
+
+        # Force tracking of the new revision. Needed as this application is both the owner and
+        # an observer. Without this get_content call, the secret-remove event is not emitted
+        # after all other observers complete their key rotation, as this unit, and backup units in
+        # an HA configuration, still observe the old revision
+        # TODO: Confirm if this behavior has changed in Juju 4
+        event.secret.get_content(refresh=True)
+
+    @leader
+    @refresh
+    @block_unless(slurmctld_installed)
+    def _on_secret_remove(self, event: ops.SecretRemoveEvent) -> None:
+        """Handle when a secret is removed."""
+        if event.secret.label != AUTH_KEY_LABEL:
+            logger.warning("secret with label '%s' removed. ignoring", event.secret.label)
+            return
+
+        self.slurmctld.key.keep_latest_key()
+        # Reconfigure must come before revision is removed to ensure secret ID can be retrieved for
+        # slurmrestd databag. This prevents a SecretNotFoundError.
+        # TODO: This will not be necessary once merging of values into the databag is implemented
+        # and the secret ID no longer needs set in _reconfigure.
+        self._reconfigure()
+
+        event.remove_revision()
+
+    @refresh
+    def _on_rotate_auth_key_action(self, event: ops.ActionEvent) -> None:
+        """Rotate the Slurm authentication key across the cluster."""
+        if not self.unit.is_leader():
+            event.fail("Only the leader unit can rotate the authentication key.")
+            return
+
+        # Update secrets backend with new key revision
+        new_key = self.slurmctld.key.generate()
+        new_key_id = str(uuid4())
+        try:
+            # Update key file first to ensure key is available before observers apply new revision
+            self.slurmctld.key.add(new_key, new_key_id)
+            self._reconfigure()
+        except Exception as e:
+            logger.error("failed to update auth key. reason:\n%s", e)
+            event.fail("Failed to update auth key. See `juju debug-log` for details.")
+            return
+
+        try:
+            secret = self.model.get_secret(label=AUTH_KEY_LABEL)
+            secret.set_content({"key": new_key, "keyid": new_key_id})
+        except (ops.SecretNotFoundError, ModelError) as e:
+            logger.error("failed to publish new auth key secret. reason:\n%s", e)
+            event.fail("Failed to publish new auth key secret. See `juju debug-log` for details.")
+            return
 
     def _on_show_current_config_action(self, event: ops.ActionEvent) -> None:
         """Show current slurm.conf."""
@@ -822,14 +905,21 @@ class SlurmctldCharm(ops.CharmBase):
             )
 
         if self.slurmrestd.is_joined():
-            self.slurmrestd.set_controller_data(
-                ControllerData(
-                    slurmconfig={
-                        "slurm.conf": self.slurmctld.config.load(),
-                        **{k: v.load() for k, v in self.slurmctld.config.includes.items()},
-                    }
+            # Workaround for: https://github.com/charmed-hpc/slurm-charms/issues/203
+            # TODO: Remove setting of key ID once merging of databag info is implemented. Only the
+            # slurmconfig needs updated. The auth_key_id should not be overwritten
+            auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
+            for integration in self.model.relations.get(SLURMRESTD_INTEGRATION_NAME, []):
+                self.slurmrestd.set_controller_data(
+                    ControllerData(
+                        auth_key_id=auth_key_id,
+                        slurmconfig={
+                            "slurm.conf": self.slurmctld.config.load(),
+                            **{k: v.load() for k, v in self.slurmctld.config.includes.items()},
+                        },
+                    ),
+                    integration_id=integration.id,
                 )
-            )
 
     def _merge_controller_data(self, app: SackdRequirer | SlurmdRequirer, new_endpoints) -> None:
         """Merge new controller endpoints with existing controller data."""

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -690,7 +690,7 @@ class SlurmctldCharm(ops.CharmBase):
             # Update key file first to ensure key is available before observers apply new revision
             self.slurmctld.key.add(new_key, new_key_id)
             self._reconfigure()
-        except Exception as e:
+        except (SlurmOpsError, ValueError) as e:
             logger.error("failed to update auth key. reason:\n%s", e)
             event.fail("Failed to update auth key. See `juju debug-log` for details.")
             return

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -18,7 +18,6 @@
 
 import logging
 import secrets
-from uuid import uuid4
 
 import mail
 import ops
@@ -232,12 +231,7 @@ class SlurmctldCharm(ops.CharmBase):
                         content = secret.get_content()
                         self.slurmctld.key.set(content["key"], content["keyid"])
                 except ops.SecretNotFoundError:
-                    key = self.slurmctld.key.generate()
-                    # Auth key entries must each have a unique ID consistent across all units.
-                    # Secret revision number cannot be used as it is not known to secret observers.
-                    # Secret `unique_identifier` property is not unique per revision.
-                    # Therefore, a newly generated UUID is included with the secret contents.
-                    key_id = str(uuid4())
+                    key, key_id = self.slurmctld.key.generate()
                     self.app.add_secret({"key": key, "keyid": key_id}, label=AUTH_KEY_LABEL)
                     self.slurmctld.key.set(key, key_id)
 
@@ -691,8 +685,7 @@ class SlurmctldCharm(ops.CharmBase):
             return
 
         # Update secrets backend with new key revision
-        new_key = self.slurmctld.key.generate()
-        new_key_id = str(uuid4())
+        new_key, new_key_id = self.slurmctld.key.generate()
         try:
             # Update key file first to ensure key is available before observers apply new revision
             self.slurmctld.key.add(new_key, new_key_id)

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -40,6 +40,7 @@ from charmed_slurm_sackd_interface import (
     SackdRequirer,
 )
 from charmed_slurm_slurmctld_interface import (
+    AUTH_KEY_LABEL,
     ControllerData,
 )
 from charmed_slurm_slurmd_interface import (
@@ -421,11 +422,11 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_sackd_connected(self, event: SackdConnectedEvent) -> None:
         """Handle when a new `sackd` application is connected."""
-        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
+        auth_secret_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         new_endpoints = [f"{c}:{SLURMCTLD_PORT}" for c in self._get_controllers()]
         self.sackd.set_controller_data(
             ControllerData(
-                auth_key_id=auth_key_id,
+                auth_secret_id=auth_secret_id,
                 controllers=new_endpoints,
             ),
             integration_id=event.relation.id,
@@ -436,7 +437,7 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_slurmd_ready(self, event: SlurmdReadyEvent) -> None:
         """Handle when partition data is ready from a `slurmd` application."""
-        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
+        auth_secret_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         data = self.slurmd.get_compute_data(event.relation.id)
         name = data.partition.partition_name
         include = f"slurm.conf.{name}"
@@ -457,7 +458,7 @@ class SlurmctldCharm(ops.CharmBase):
         new_endpoints = [f"{c}:{SLURMCTLD_PORT}" for c in self._get_controllers()]
         self.slurmd.set_controller_data(
             ControllerData(
-                auth_key_id=auth_key_id,
+                auth_secret_id=auth_secret_id,
                 controllers=new_endpoints,
             ),
             integration_id=event.relation.id,
@@ -485,10 +486,10 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_slurmdbd_connected(self, event: SlurmdbdConnectedEvent) -> None:
         """Handle when a new `slurmdbd` application is connected."""
-        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
+        auth_secret_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         self.slurmdbd.set_controller_data(
             ControllerData(
-                auth_key_id=auth_key_id,
+                auth_secret_id=auth_secret_id,
                 jwt_key=self.slurmctld.jwt.get(),
             ),
             integration_id=event.relation.id,
@@ -543,10 +544,10 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_slurmrestd_connected(self, event: SlurmrestdConnectedEvent) -> None:
         """Handle when a new `slurmrestd` application is connected."""
-        auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
+        auth_secret_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
         self.slurmrestd.set_controller_data(
             ControllerData(
-                auth_key_id=auth_key_id,
+                auth_secret_id=auth_secret_id,
                 slurmconfig={
                     "slurm.conf": self.slurmctld.config.load(),
                     **{k: v.load() for k, v in self.slurmctld.config.includes.items()},
@@ -907,12 +908,12 @@ class SlurmctldCharm(ops.CharmBase):
         if self.slurmrestd.is_joined():
             # Workaround for: https://github.com/charmed-hpc/slurm-charms/issues/203
             # TODO: Remove setting of key ID once merging of databag info is implemented. Only the
-            # slurmconfig needs updated. The auth_key_id should not be overwritten
-            auth_key_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
+            # slurmconfig needs updated. The auth Secret ID should not be overwritten
+            auth_secret_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
             for integration in self.model.relations.get(SLURMRESTD_INTEGRATION_NAME, []):
                 self.slurmrestd.set_controller_data(
                     ControllerData(
-                        auth_key_id=auth_key_id,
+                        auth_secret_id=auth_secret_id,
                         slurmconfig={
                             "slurm.conf": self.slurmctld.config.load(),
                             **{k: v.load() for k, v in self.slurmctld.config.includes.items()},
@@ -934,7 +935,7 @@ class SlurmctldCharm(ops.CharmBase):
 
             data = ControllerData(
                 auth_key="",  # Don't set keys here or secrets will be replaced with "***"
-                auth_key_id=current.auth_key_id,
+                auth_secret_id=current.auth_secret_id,
                 controllers=new_endpoints,  # Update only the controllers
                 jwt_key="",
                 jwt_key_id=current.jwt_key_id,

--- a/charms/slurmctld/src/state.py
+++ b/charms/slurmctld/src/state.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 import ops
 from charmed_hpc_libs.ops.conditions import ConditionEvaluation
 from constants import HA_MOUNT_INTEGRATION_NAME
+from slurm_ops.core.errors import SlurmOpsError
 
 if TYPE_CHECKING:
     from charm import SlurmctldCharm
@@ -151,6 +152,25 @@ def slurmctld_ready(charm: "SlurmctldCharm") -> bool:
     )
 
 
+def auth_key_ready(charm: "SlurmctldCharm") -> ConditionEvaluation:
+    """Check if the Slurm authentication key is valid."""
+    try:
+        keys = charm.slurmctld.key.get()
+    except SlurmOpsError as e:
+        return ConditionEvaluation(False, e.message)
+
+    num_keys = len(keys.get("keys", []))
+    if num_keys == 0:
+        return ConditionEvaluation(False, "Authentication key file contains no keys")
+    if num_keys > 1:
+        return ConditionEvaluation(
+            False,
+            "Authentication key rotation in progress. Waiting for rotation to complete.",
+        )
+
+    return ConditionEvaluation(True, "")
+
+
 def check_slurmctld(charm: "SlurmctldCharm") -> ops.StatusBase:
     """Determine the state of the `slurmctld` application/unit based on satisfied conditions."""
     ok, message = slurmctld_installed(charm)
@@ -162,6 +182,10 @@ def check_slurmctld(charm: "SlurmctldCharm") -> ops.StatusBase:
         return ops.WaitingStatus(message)
 
     ok, message = slurmctld_is_active(charm)
+    if not ok:
+        return ops.WaitingStatus(message)
+
+    ok, message = auth_key_ready(charm)
     if not ok:
         return ops.WaitingStatus(message)
 

--- a/charms/slurmctld/src/state.py
+++ b/charms/slurmctld/src/state.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 import ops
 from charmed_hpc_libs.ops.conditions import ConditionEvaluation
 from constants import HA_MOUNT_INTEGRATION_NAME
-from slurm_ops.core.errors import SlurmOpsError
+from slurm_ops import SlurmOpsError
 
 if TYPE_CHECKING:
     from charm import SlurmctldCharm

--- a/charms/slurmctld/src/state.py
+++ b/charms/slurmctld/src/state.py
@@ -165,7 +165,7 @@ def auth_key_ready(charm: "SlurmctldCharm") -> ConditionEvaluation:
     if num_keys > 1:
         return ConditionEvaluation(
             False,
-            "Authentication key rotation in progress. Waiting for rotation to complete.",
+            "Authentication key rotation in progress. Waiting for rotation to complete",
         )
 
     return ConditionEvaluation(True, "")

--- a/charms/slurmctld/tests/unit/conftest.py
+++ b/charms/slurmctld/tests/unit/conftest.py
@@ -40,7 +40,7 @@ def mock_charm(
     mock_ctx, fs: FakeFilesystem, mocker: MockerFixture, mock_scontrol
 ) -> testing.Context[SlurmctldCharm]:
     """Mock `SlurmctldCharm` context with fake filesystem."""
-    fs.create_file("/etc/slurm/slurm.key", create_missing_dirs=True)
+    fs.create_file("/etc/slurm/slurm.jwks", contents='{"keys": []}', create_missing_dirs=True)
     mocker.patch("shutil.chown")  # User/group `slurm` doesn't exist on host.
     mocker.patch("subprocess.run")
     return mock_ctx

--- a/charms/slurmctld/tests/unit/test_charm.py
+++ b/charms/slurmctld/tests/unit/test_charm.py
@@ -40,6 +40,7 @@ EXAMPLE_OCI_CONFIG = OCIConfig(
     runtimekill="kill -s SIGTERM %p",
     runtimedelete="kill -s SIGKILL %p",
 )
+EXAMPLE_KEY_ENTRY = {"keys": [{"alg": "HS256", "kty": "oct", "kid": "0", "k": "xyz123=="}]}
 
 
 @pytest.fixture
@@ -231,6 +232,7 @@ class TestSlurmctldCharm:
             mocker.patch.object(manager.charm.slurmctld, "is_installed", return_value=True)
             mocker.patch.object(manager.charm.slurmctld.service, "is_active", return_value=True)
             mocker.patch.object(manager.charm.slurmdbd, "is_ready", return_value=True)
+            mocker.patch.object(manager.charm.slurmctld.key, "get", return_value=EXAMPLE_KEY_ENTRY)
             state = manager.run()
 
         mock_add_package.assert_called_once_with("slurm-mail")
@@ -250,6 +252,7 @@ class TestSlurmctldCharm:
             mocker.patch.object(manager.charm.slurmctld, "is_installed", return_value=True)
             mocker.patch.object(manager.charm.slurmctld.service, "is_active", return_value=True)
             mocker.patch.object(manager.charm.slurmdbd, "is_ready", return_value=True)
+            mocker.patch.object(manager.charm.slurmctld.key, "get", return_value=EXAMPLE_KEY_ENTRY)
             state = manager.run()
 
         assert state.unit_status == testing.BlockedStatus(
@@ -269,6 +272,7 @@ class TestSlurmctldCharm:
             mocker.patch.object(manager.charm.slurmctld, "is_installed", return_value=True)
             mocker.patch.object(manager.charm.slurmctld.service, "is_active", return_value=True)
             mocker.patch.object(manager.charm.slurmdbd, "is_ready", return_value=True)
+            mocker.patch.object(manager.charm.slurmctld.key, "get", return_value=EXAMPLE_KEY_ENTRY)
             state = manager.run()
 
         mock_remove_package.assert_called_once_with("slurm-mail")
@@ -288,6 +292,7 @@ class TestSlurmctldCharm:
             mocker.patch.object(manager.charm.slurmctld, "is_installed", return_value=True)
             mocker.patch.object(manager.charm.slurmctld.service, "is_active", return_value=True)
             mocker.patch.object(manager.charm.slurmdbd, "is_ready", return_value=True)
+            mocker.patch.object(manager.charm.slurmctld.key, "get", return_value=EXAMPLE_KEY_ENTRY)
             state = manager.run()
 
         assert state.unit_status == testing.BlockedStatus(
@@ -355,6 +360,7 @@ class TestSlurmctldCharm:
             mocker.patch.object(manager.charm.slurmctld, "is_installed", return_value=True)
             mocker.patch.object(manager.charm.slurmctld.service, "is_active", return_value=True)
             mocker.patch.object(manager.charm.slurmdbd, "is_ready", return_value=True)
+            mocker.patch.object(manager.charm.slurmctld.key, "get", return_value=EXAMPLE_KEY_ENTRY)
             state = manager.run()
 
         assert config_path.read_text().strip() == expected_config_content.strip()

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -71,6 +71,7 @@ class SlurmdCharm(ops.CharmBase):
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.update_status, self._on_update_status)
+        framework.observe(self.on.secret_changed, self._on_secret_changed)
         framework.observe(self.on.set_node_config_action, self._on_set_node_config_action)
 
         self.slurmctld = SlurmdProvider(self, SLURMD_INTEGRATION_NAME)
@@ -155,7 +156,7 @@ class SlurmdCharm(ops.CharmBase):
         """Handle when controller data is ready from the `slurmctld` application."""
         data = self.slurmctld.get_controller_data(event.relation.id)
 
-        self.slurmd.key.set(data.auth_key)
+        self.slurmd.key.set(data.auth_key, data.auth_key_content_id)
         self.slurmd.conf_server = data.controllers
 
         # Set default state and reason if this compute node is being added to a Slurm cluster.
@@ -192,6 +193,36 @@ class SlurmdCharm(ops.CharmBase):
             raise StopCharm(
                 ops.BlockedStatus("Failed to stop `slurmd`. See `juju debug-log` for details")
             )
+
+    @refresh
+    @block_unless(slurmd_installed)
+    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
+        """Handle when a secret is changed."""
+        if event.secret.label != AUTH_KEY_LABEL:
+            logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
+            return
+
+        content = event.secret.get_content(refresh=True)
+        auth_key = content.get("key")
+        auth_key_id = content.get("keyid")
+        if not auth_key or not auth_key_id:
+            logger.error(
+                "auth key or key ID is empty in secret with label '%s'", event.secret.label
+            )
+            event.defer()
+            raise StopCharm(
+                ops.BlockedStatus(
+                    "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
+                )
+            )
+
+        self.slurmd.key.set(auth_key, auth_key_id)
+
+        # Necessary to load new key from file into the service
+        # FIXME: slurmd reloading is currently broken. Service restart is used as a workaround but
+        # this breaks zero-downtime key rotation. This must be replaced with a reload
+        # See: https://github.com/charmed-hpc/slurm-charms/issues/204
+        self.slurmd.service.restart()
 
     @refresh
     def _on_set_node_config_action(self, event: ops.ActionEvent) -> None:

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -24,6 +24,7 @@ import rdma
 from charmed_hpc_libs.errors import SystemdError
 from charmed_hpc_libs.ops.conditions import StopCharm, block_unless, refresh, wait_unless
 from charmed_slurm_slurmd_interface import (
+    AUTH_KEY_LABEL,
     ComputeData,
     SlurmctldConnectedEvent,
     SlurmctldDisconnectedEvent,
@@ -156,7 +157,7 @@ class SlurmdCharm(ops.CharmBase):
         """Handle when controller data is ready from the `slurmctld` application."""
         data = self.slurmctld.get_controller_data(event.relation.id)
 
-        self.slurmd.key.set(data.auth_key, data.auth_key_content_id)
+        self.slurmd.key.set(data.auth_key, data.auth_key_id)
         self.slurmd.conf_server = data.controllers
 
         # Set default state and reason if this compute node is being added to a Slurm cluster.

--- a/charms/slurmd/tests/unit/conftest.py
+++ b/charms/slurmd/tests/unit/conftest.py
@@ -41,7 +41,7 @@ def mock_charm(
           otherwise `ops.testing.Context` will fail to locate the `slurmd` charm's
           charmcraft.yaml file.
     """
-    fs.create_file("/etc/slurm/slurm.key", create_missing_dirs=True)
+    fs.create_file("/etc/slurm/slurm.jwks", create_missing_dirs=True)
     fs.create_file("/etc/default/slurmd", create_missing_dirs=True)
     fs.create_dir("/usr/sbin")
     mocker.patch("subprocess.run")

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -188,14 +188,12 @@ class TestSlurmdCharm:
             remote_app_name="slurmctld",
             remote_app_data=(
                 {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "controllers": json.dumps(EXAMPLE_CONTROLLERS),
                 }
                 if ready
                 else {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "controllers": json.dumps([]),
                 }
             ),

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -27,6 +27,7 @@ from slurm_ops import SlurmOpsError
 from slurmutils import Node
 
 EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_CONTENT_ID = "12345678-90ab-cdef-1234-567890abcdef"
 EXAMPLE_CONTROLLERS = ["juju-988225-0:6817", "juju-988225-1:6817"]
 
 
@@ -175,7 +176,9 @@ class TestSlurmdCharm:
         self, mock_charm, mocker: MockerFixture, mock_restart, ready, leader, expected
     ) -> None:
         """Test the `_on_slurmctld_ready` event handler."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY})
+        auth_key_secret = testing.Secret(
+            tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_CONTENT_ID}
+        )
 
         integration_id = 1
         integration = testing.Relation(

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -23,6 +23,7 @@ import ops
 from charmed_hpc_libs.ops import get_ingress_address
 from charmed_hpc_libs.ops.conditions import StopCharm, block_unless, leader, refresh, wait_unless
 from charmed_slurm_slurmdbd_interface import (
+    AUTH_KEY_LABEL,
     DatabaseData,
     SlurmctldReadyEvent,
     SlurmdbdProvider,
@@ -156,7 +157,7 @@ class SlurmdbdCharm(ops.CharmBase):
         """Handle when controller data is ready from `slurmctld`."""
         data = self.slurmctld.get_controller_data(event.relation.id)
 
-        self.slurmdbd.key.set(data.auth_key, data.auth_key_content_id)
+        self.slurmdbd.key.set(data.auth_key, data.auth_key_id)
         self.slurmdbd.jwt.set(data.jwt_key)
         self._reconfigure()
 

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -75,6 +75,7 @@ class SlurmdbdCharm(ops.CharmBase):
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.update_status, self._on_update_status)
+        framework.observe(self.on.secret_changed, self._on_secret_changed)
 
         self.slurmctld = SlurmdbdProvider(self, SLURMDBD_INTEGRATION_NAME)
         framework.observe(self.slurmctld.on.slurmctld_ready, self._on_slurmctld_ready)
@@ -155,9 +156,39 @@ class SlurmdbdCharm(ops.CharmBase):
         """Handle when controller data is ready from `slurmctld`."""
         data = self.slurmctld.get_controller_data(event.relation.id)
 
-        self.slurmdbd.key.set(data.auth_key)
+        self.slurmdbd.key.set(data.auth_key, data.auth_key_content_id)
         self.slurmdbd.jwt.set(data.jwt_key)
         self._reconfigure()
+
+    @refresh
+    @block_unless(slurmdbd_installed)
+    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
+        """Handle when a secret is changed."""
+        if event.secret.label != AUTH_KEY_LABEL:
+            logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
+            return
+
+        content = event.secret.get_content(refresh=True)
+        auth_key = content.get("key")
+        auth_key_id = content.get("keyid")
+        if not auth_key or not auth_key_id:
+            logger.error(
+                "auth key or key ID is empty in secret with label '%s'", event.secret.label
+            )
+            event.defer()
+            raise StopCharm(
+                ops.BlockedStatus(
+                    "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
+                )
+            )
+
+        self.slurmdbd.key.set(auth_key, auth_key_id)
+
+        # Other Slurm charms reload the service here. That is not possible for slurmdbd as the
+        # SIGHUP reload signal does not reload the key file. Restart instead.
+        # TODO: Determine a zero-downtime solution. Consider filing a Slurm bug requesting slurmdbd
+        # reloading match the behavior of sackd, slurmctld and slurmd.
+        self.slurmdbd.service.restart()
 
     @leader
     @refresh

--- a/charms/slurmrestd/src/charm.py
+++ b/charms/slurmrestd/src/charm.py
@@ -44,6 +44,7 @@ class SlurmrestdCharm(ops.CharmBase):
         self.slurmrestd = SlurmrestdManager(snap=False)
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.update_status, self._on_update_status)
+        framework.observe(self.on.secret_changed, self._on_secret_changed)
 
         self.slurmctld = SlurmrestdProvider(self, SLURMRESTD_INTEGRATION_NAME)
         framework.observe(
@@ -93,7 +94,7 @@ class SlurmrestdCharm(ops.CharmBase):
         data = self.slurmctld.get_controller_data(event.relation.id)
 
         try:
-            self.slurmrestd.key.set(data.auth_key)
+            self.slurmrestd.key.set(data.auth_key, data.auth_key_content_id)
             for name, config in data.slurmconfig.items():
                 self.slurmrestd.config.includes[name].dump(config)
             self.slurmrestd.service.enable()
@@ -117,6 +118,34 @@ class SlurmrestdCharm(ops.CharmBase):
             raise StopCharm(
                 ops.BlockedStatus("Failed to stop `slurmrestd`. See `juju debug-log` for details")
             )
+
+    @refresh
+    @block_unless(slurmrestd_installed)
+    def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
+        """Handle when a secret is changed."""
+        if event.secret.label != AUTH_KEY_LABEL:
+            logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
+            return
+
+        content = event.secret.get_content(refresh=True)
+        auth_key = content.get("key")
+        auth_key_id = content.get("keyid")
+        if not auth_key or not auth_key_id:
+            logger.error(
+                "auth key or key ID is empty in secret with label '%s'", event.secret.label
+            )
+            event.defer()
+            raise StopCharm(
+                ops.BlockedStatus(
+                    "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
+                )
+            )
+
+        self.slurmrestd.key.set(auth_key, auth_key_id)
+        # Other Slurm charms reload the service here. That is not possible for slurmrestd as the
+        # process shuts down when the reload signal is sent. Restart instead.
+        # TODO: Determine a zero-downtime solution
+        self.slurmrestd.service.restart()
 
 
 if __name__ == "__main__":

--- a/charms/slurmrestd/src/charm.py
+++ b/charms/slurmrestd/src/charm.py
@@ -21,6 +21,7 @@ import logging
 import ops
 from charmed_hpc_libs.ops import StopCharm, block_unless, refresh, wait_unless
 from charmed_slurm_slurmrestd_interface import (
+    AUTH_KEY_LABEL,
     SlurmctldDisconnectedEvent,
     SlurmctldReadyEvent,
     SlurmrestdProvider,
@@ -94,7 +95,7 @@ class SlurmrestdCharm(ops.CharmBase):
         data = self.slurmctld.get_controller_data(event.relation.id)
 
         try:
-            self.slurmrestd.key.set(data.auth_key, data.auth_key_content_id)
+            self.slurmrestd.key.set(data.auth_key, data.auth_key_id)
             for name, config in data.slurmconfig.items():
                 self.slurmrestd.config.includes[name].dump(config)
             self.slurmrestd.service.enable()

--- a/charms/slurmrestd/tests/unit/conftest.py
+++ b/charms/slurmrestd/tests/unit/conftest.py
@@ -17,9 +17,23 @@
 import pytest
 from charm import SlurmrestdCharm
 from ops import testing
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture(scope="function")
-def mock_charm() -> testing.Context[SlurmrestdCharm]:
-    """Mock `SlurmctldCharm`."""
+def mock_ctx() -> testing.Context[SlurmrestdCharm]:
+    """Mock `SlurmrestdCharm`."""
     return testing.Context(SlurmrestdCharm)
+
+
+@pytest.fixture(scope="function")
+def mock_charm(
+    mock_ctx, fs: FakeFilesystem, mocker: MockerFixture
+) -> testing.Context[SlurmrestdCharm]:
+    """Mock `SlurmrestdCharm` context with fake filesystem."""
+    fs.create_file("/etc/slurm/slurm.jwks", create_missing_dirs=True)
+    fs.create_file("/etc/default/slurmrestd", create_missing_dirs=True)
+    mocker.patch("subprocess.run")
+
+    return mock_ctx

--- a/charms/slurmrestd/tests/unit/test_charm.py
+++ b/charms/slurmrestd/tests/unit/test_charm.py
@@ -15,6 +15,110 @@
 
 """Unit tests for the `slurmrestd` charm."""
 
+import json
+from pathlib import Path
 
-def test_on_install() -> None:
-    """Test the `_on_install` event handler."""
+import ops
+import pytest
+from constants import SLURMRESTD_INTEGRATION_NAME
+from hpc_libs.interfaces import AUTH_KEY_LABEL
+from ops import testing
+from pytest_mock import MockerFixture
+
+EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_KEY_ID = "12345678-90ab-cdef-1234-567890abcdef"
+EXAMPLE_CONTROLLERS = ["juju-988225-0:6817", "juju-988225-1:6817"]
+
+
+@pytest.fixture
+def auth_key_secret() -> testing.Secret:
+    """Mock Slurm auth key secret."""
+    return testing.Secret(
+        label=AUTH_KEY_LABEL,
+        tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID},
+    )
+
+
+@pytest.mark.parametrize(
+    "leader",
+    (
+        pytest.param(True, id="leader"),
+        pytest.param(False, id="not leader"),
+    ),
+)
+class TestSlurmrestdCharm:
+    """Unit tests for the `slurmrestd` charmed operator."""
+
+    def test_on_secret_changed_success(
+        self, mock_charm, mocker: MockerFixture, leader, auth_key_secret
+    ) -> None:
+        """Test successful execution of the `_on_secret_changed` event handler."""
+        key_file_path = Path("/etc/slurm/slurm.jwks")
+        expected_key_file_content = {
+            "keys": [
+                {"alg": "HS256", "kty": "oct", "kid": EXAMPLE_AUTH_KEY_ID, "k": EXAMPLE_AUTH_KEY}
+            ]
+        }
+
+        integration_id = 1
+        integration = testing.Relation(
+            endpoint=SLURMRESTD_INTEGRATION_NAME,
+            interface="slurmrestd",
+            id=integration_id,
+            remote_app_name="slurmctld",
+            remote_app_data={
+                "auth_key": '"***"',
+                "auth_key_id": json.dumps(auth_key_secret.id),
+                "controllers": json.dumps(EXAMPLE_CONTROLLERS),
+            },
+        )
+
+        with mock_charm(
+            mock_charm.on.secret_changed(auth_key_secret),
+            testing.State(leader=leader, relations={integration}, secrets={auth_key_secret}),
+        ) as manager:
+            slurmrestd = manager.charm.slurmrestd
+            mocker.patch.object(slurmrestd, "is_installed", return_value=True)
+            mocker.patch.object(slurmrestd.service, "is_active")
+            mocker.patch("shutil.chown")  # User/group `slurm` doesn't exist on host.
+
+            state = manager.run()
+
+        assert key_file_path.exists(), f"File {key_file_path} does not exist"
+        key_file_text = key_file_path.read_text()
+        actual_key_file_content = json.loads(key_file_text)
+        assert actual_key_file_content == expected_key_file_content
+        assert state.unit_status == ops.ActiveStatus()
+
+    def test_on_secret_changed_empty_key_id_failure(
+        self, mock_charm, mocker: MockerFixture, leader
+    ) -> None:
+        """Test `_on_secret_changed` event handler when auth key ID is empty."""
+        auth_key_secret = testing.Secret(
+            label=AUTH_KEY_LABEL, tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": ""}
+        )
+        integration_id = 1
+        integration = testing.Relation(
+            endpoint=SLURMRESTD_INTEGRATION_NAME,
+            interface="slurmrestd",
+            id=integration_id,
+            remote_app_name="slurmctld",
+            remote_app_data={
+                "auth_key": '"***"',
+                "auth_key_id": json.dumps(auth_key_secret.id),
+                "controllers": json.dumps(EXAMPLE_CONTROLLERS),
+            },
+        )
+
+        with mock_charm(
+            mock_charm.on.secret_changed(auth_key_secret),
+            testing.State(leader=leader, relations={integration}, secrets={auth_key_secret}),
+        ) as manager:
+            slurmrestd = manager.charm.slurmrestd
+            mocker.patch.object(slurmrestd, "is_installed", return_value=True)
+
+            state = manager.run()
+
+        assert state.unit_status == ops.BlockedStatus(
+            "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
+        )

--- a/charms/slurmrestd/tests/unit/test_charm.py
+++ b/charms/slurmrestd/tests/unit/test_charm.py
@@ -20,8 +20,8 @@ from pathlib import Path
 
 import ops
 import pytest
+from charmed_slurm_slurmctld_interface import AUTH_KEY_LABEL
 from constants import SLURMRESTD_INTEGRATION_NAME
-from hpc_libs.interfaces import AUTH_KEY_LABEL
 from ops import testing
 from pytest_mock import MockerFixture
 

--- a/internal/sackd-interface/src/charmed_slurm_sackd_interface/__init__.py
+++ b/internal/sackd-interface/src/charmed_slurm_sackd_interface/__init__.py
@@ -15,6 +15,7 @@
 """Integration interface implementation for the `sackd` interface."""
 
 __all__ = [
+    "AUTH_KEY_LABEL",
     "SackdConnectedEvent",
     "SackdProvider",
     "SackdRequirer",
@@ -27,6 +28,7 @@ __all__ = [
 import ops
 from charmed_hpc_libs.ops import leader
 from charmed_slurm_slurmctld_interface import (
+    AUTH_KEY_LABEL,
     SlurmctldDisconnectedEvent,
     SlurmctldProvider,
     SlurmctldReadyEvent,
@@ -35,7 +37,7 @@ from charmed_slurm_slurmctld_interface import (
 )
 
 _REQUIRED_APP_DATA = {
-    "auth_key_id": lambda value: value != '""',
+    "auth_secret_id": lambda value: value != '""',
     "controllers": lambda value: value != "[]",
 }
 

--- a/internal/sackd-interface/tests/unit/test_sackd.py
+++ b/internal/sackd-interface/tests/unit/test_sackd.py
@@ -21,6 +21,7 @@ import ops
 import pytest
 from charmed_hpc_libs.ops.conditions import refresh, wait_unless
 from charmed_slurm_sackd_interface import (
+    AUTH_KEY_LABEL,
     SackdConnectedEvent,
     SackdProvider,
     SackdRequirer,
@@ -33,6 +34,7 @@ from ops import testing
 
 SACKD_INTEGRATION_NAME = "sackd"
 EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_KEY_ID = "12345678-90ab-cdef-1234-567890abcdef"
 EXAMPLE_CONTROLLERS = ["127.0.0.1", "127.0.1.1"]
 
 
@@ -74,9 +76,12 @@ class MockSackdRequirerCharm(ops.CharmBase):
         )
 
     def _on_sackd_connected(self, event: SackdConnectedEvent) -> None:
+        auth_key_secret = self.app.add_secret(
+            {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
+        )
         self.sackd.set_controller_data(
             ControllerData(
-                auth_key=EXAMPLE_AUTH_KEY,
+                auth_secret_id=auth_key_secret.get_info().id,
                 controllers=EXAMPLE_CONTROLLERS,
             ),
             integration_id=event.relation.id,
@@ -126,7 +131,10 @@ class TestSackdInterface:
     )
     def test_provider_on_slurmctld_ready_event(self, provider_ctx, leader, ready) -> None:
         """Test that the `sackd` provider waits for controller data."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY})
+        auth_key_secret = testing.Secret(
+            label=AUTH_KEY_LABEL,
+            tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID},
+        )
 
         sackd_integration_id = 1
         sackd_integration = testing.Relation(
@@ -136,14 +144,12 @@ class TestSackdInterface:
             remote_app_name="sackd-requirer",
             remote_app_data=(
                 {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "controllers": json.dumps(EXAMPLE_CONTROLLERS),
                 }
                 if ready
                 else {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(""),
+                    "auth_secret_id": json.dumps(""),
                     "controllers": json.dumps([]),
                 }
             ),
@@ -190,17 +196,17 @@ class TestSackdInterface:
 
         state = requirer_ctx.run(
             requirer_ctx.on.relation_created(sackd_integration),
-            testing.State(leader=leader, relations={sackd_integration}),
+            testing.State(
+                leader=leader,
+                relations={sackd_integration},
+            ),
         )
 
         integration = state.get_relation(sackd_integration_id)
         if leader:
             # Verify that the leader unit has set the required data for `sackd`.
-            assert "auth_key" in integration.local_app_data
-            assert integration.local_app_data["auth_key"] == '"***"'
-
-            assert "auth_key_id" in integration.local_app_data
-            assert integration.local_app_data["auth_key_id"] != '""'
+            assert "auth_secret_id" in integration.local_app_data
+            assert integration.local_app_data["auth_secret_id"] != '""'
 
             assert "controllers" in integration.local_app_data
             assert integration.local_app_data["controllers"] == json.dumps(EXAMPLE_CONTROLLERS)

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -20,6 +20,8 @@ __all__ = [
 ]
 
 import base64
+import datetime
+import json
 import logging
 import secrets
 import shutil
@@ -501,33 +503,159 @@ class _JWTSecretManager(SecretManager):
         return self._file
 
 
-class _SlurmSecretManager(SecretManager):
-    """Manage the `slurm.key` secret file."""
+class _SlurmSecretManager:
+    """Manage the `slurm.jwks` key file."""
 
     def __init__(self, ops_manager: OpsManager, /, user: str, group: str) -> None:
-        self._file = ops_manager.etc_path / "slurm.key"
+        self._file = ops_manager.etc_path / "slurm.jwks"
         self._user = user
         self._group = group
 
-    def get(self) -> str:
-        """Get the contents of the current `slurm.key` secret file."""
-        return base64.b64encode(self._file.read_bytes()).decode()
+    def generate(self) -> str:
+        """Generate cryptographically secure Slurm auth key data.
 
-    def set(self, secret: str) -> None:
-        """Set the contents of the `slurm.key` secret file."""
-        self._file.write_bytes(base64.b64decode(secret.encode()))
-        self._file.chmod(0o600)
-        shutil.chown(self._file, self._user, self._group)
+        Returns:
+            A base64-encoded random byte string suitable for use as a Slurm authentication key.
+        """
+        key = base64.b64encode(secrets.token_bytes(2048)).decode()
+        return key
 
-    def generate(self) -> None:
-        """Generate a new, cryptographically secure `slurm.key` secret."""
-        key = secrets.token_bytes(2048)
-        self.set(base64.b64encode(key).decode())
+    def add(self, key: str, key_id: str) -> None:
+        """Append a key to the `slurm.jwks` key file.
+
+        Args:
+            key: The base64-encoded key material to add.
+            key_id: A unique identifier for the key.
+
+        Raises:
+            ValueError: If `key` or `key_id` is empty.
+        """
+        data = self.get()
+        new_entry = self._get_new_entry(key, key_id)
+        data["keys"].append(new_entry)
+        self._write(data)
+
+        _log_security_event(
+            "INFO",
+            "authn_token_created",
+            "slurm-auth",
+            f"New Slurm authentication key added with key ID: {key_id}",
+        )
+
+    def keep_latest_key(self) -> None:
+        """Preserve only the most recently added key in the `slurm.jwks` key file.
+
+        Removes all previously added keys, keeping only the last entry.
+
+        Raises:
+            SlurmOpsError: If the key file contains no keys.
+        """
+        data = self.get()
+        if not data["keys"]:
+            raise SlurmOpsError("No keys found in slurm.jwks")
+
+        # Most recently added key is last in list
+        last_entry = data["keys"][-1]
+        removed_key_ids = [entry["kid"] for entry in data["keys"][:-1]]
+        self._write({"keys": [last_entry]})
+
+        _log_security_event(
+            "INFO",
+            "authn_token_deleted",
+            "slurm-auth",
+            f"Deleted Slurm authentication key IDs: {removed_key_ids}. Current key ID: {last_entry['kid']}",
+        )
+
+    def get(self) -> dict[str, list[dict[str, str]]]:
+        """Read and validate the `slurm.jwks` key file.
+
+        Returns:
+            A dict with a `"keys"` list. Returns `{"keys": []}` if the file does not exist.
+
+        Raises:
+            SlurmOpsError: If the file exists but cannot be read or contains invalid data.
+        """
+        try:
+            data = json.loads(self._file.read_text())
+        except FileNotFoundError:
+            _logger.warning("%s not found. returning empty keys list", self._file)
+            return {"keys": []}
+        except OSError as e:
+            raise SlurmOpsError(f"Failed to read {self._file}") from e
+        except json.JSONDecodeError as e:
+            raise SlurmOpsError(f"Failed to parse {self._file}") from e
+
+        if not isinstance(data, dict):
+            raise SlurmOpsError(f"Invalid key data in {self._file}: expected a JSON object")
+
+        if not isinstance(data.get("keys"), list):
+            raise SlurmOpsError(f"Invalid key data in {self._file}: 'keys' must be a list")
+
+        return data
+
+    def set(self, key: str, key_id: str) -> None:
+        """Replace the `slurm.jwks` key file with a single key entry.
+
+        Args:
+            key: The base64-encoded key material to set.
+            key_id: A unique identifier for the key.
+
+        Raises:
+            ValueError: If `key` or `key_id` is empty.
+        """
+        new_entry = self._get_new_entry(key, key_id)
+        self._write({"keys": [new_entry]})
+
+        _log_security_event(
+            "INFO",
+            "authn_token_created",
+            "slurm-auth",
+            f"Slurm authentication key set with key ID: {key_id}",
+        )
 
     @property
     def path(self) -> Path:
-        """Get the path to the `slurm.key` secret file."""
+        """Get the path to the `slurm.jwks` secret file.
+
+        Returns:
+            Path to the `slurm.jwks` file.
+        """
         return self._file
+
+    @staticmethod
+    def _get_new_entry(key: str, key_id: str) -> dict[str, str]:
+        """Build a new key entry for the `slurm.jwks` key file.
+
+        Args:
+            key: The base64-encoded key material.
+            key_id: A unique identifier for the key.
+
+        Returns:
+            A dictionary representing a JWK entry with `alg`, `kty`, `kid`, and `k` fields,
+            as described in the Slurm authentication documentation.
+
+        Raises:
+            ValueError: If `key` or `key_id` is empty.
+
+        Note:
+            The format of the key entry is defined in the Slurm documentation:
+            https://slurm.schedmd.com/authentication.html#multiple_key_setup
+        """
+        if not key:
+            raise ValueError("Empty key provided")
+        if not key_id:
+            raise ValueError("Empty key ID provided")
+        return {
+            "alg": "HS256",
+            "kty": "oct",
+            "kid": key_id,
+            "k": key,
+        }
+
+    def _write(self, data: dict[str, list[dict[str, str]]]) -> None:
+        self._file.write_text(json.dumps(data))
+        self._file.chmod(0o600)
+        shutil.chown(self._file, self._user, self._group)
 
 
 class SlurmManager(ABC):
@@ -588,3 +716,32 @@ class SlurmManager(ABC):
         self._env_manager.set(
             {f"{self._service.upper()}_OPTIONS": marshal_options(options)}, quote=False
         )
+
+
+def _log_security_event(level: str, event_type: str, event_data: str, description: str) -> None:
+    """Log an OWASP security event.
+
+    Args:
+        level: OWASP log level of the security event (e.g. `"INFO"`, `"WARN"`).
+        event_type: The OWASP event type.
+        event_data: Name of the event data field in OWASP format.
+        description: Human-readable description of the event.
+
+    Note:
+        The `level` argument is the OWASP severity level, not the Python log level.
+        All security events are emitted at `DEBUG` level in the charm logs.
+
+    See Also:
+        https://cheatsheetseries.owasp.org/cheatsheets/Logging_Vocabulary_Cheat_Sheet.html
+    """
+    # Implementation of this function is inspired by the function with the same name in `ops`:
+    # https://github.com/canonical/operator/blob/9affc1e/ops/log.py#L154
+    log_message = {
+        "datetime": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "level": level,
+        "type": "security",
+        "appid": "slurm-charms",
+        "event": f"{event_type}:{event_data}",
+        "description": description,
+    }
+    _logger.debug(json.dumps(log_message))

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -530,8 +530,8 @@ class _SlurmSecretManager:
         Raises:
             ValueError: If `key` or `key_id` is empty.
         """
-        data = self.get()
         new_entry = self._build_new_entry(key, key_id)
+        data = self.get()
         data["keys"].append(new_entry)
         self._write(data)
 

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -620,11 +620,7 @@ class _SlurmSecretManager:
 
     @property
     def path(self) -> Path:
-        """Get the path to the `slurm.jwks` secret file.
-
-        Returns:
-            Path to the `slurm.jwks` file.
-        """
+        """Get the path to the `slurm.jwks` secret file."""
         return self._file
 
     def _write(self, data: dict[str, list[dict[str, str]]]) -> None:

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -627,6 +627,11 @@ class _SlurmSecretManager:
         """
         return self._file
 
+    def _write(self, data: dict[str, list[dict[str, str]]]) -> None:
+        self._file.write_text(json.dumps(data))
+        self._file.chmod(0o600)
+        shutil.chown(self._file, self._user, self._group)
+
     @staticmethod
     def _build_new_entry(key: str, key_id: str) -> dict[str, str]:
         """Build a new key entry for the `slurm.jwks` key file.
@@ -656,11 +661,6 @@ class _SlurmSecretManager:
             "kid": key_id,
             "k": key,
         }
-
-    def _write(self, data: dict[str, list[dict[str, str]]]) -> None:
-        self._file.write_text(json.dumps(data))
-        self._file.chmod(0o600)
-        shutil.chown(self._file, self._user, self._group)
 
 
 class SlurmManager(ABC):

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -33,6 +33,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Any, Protocol
+from uuid import uuid4
 
 import distro
 import yaml
@@ -511,14 +512,18 @@ class _SlurmSecretManager:
         self._user = user
         self._group = group
 
-    def generate(self) -> str:
+    def generate(self) -> tuple[str, str]:
         """Generate cryptographically secure Slurm auth key data.
 
         Returns:
-            A base64-encoded random byte string suitable for use as a Slurm authentication key.
+            A tuple of `(key, key_id)` where `key` is a base64-encoded random byte string suitable
+            for use as a Slurm authentication key, and `key_id` is a unique identifier for the key.
         """
-        key = base64.b64encode(secrets.token_bytes(2048)).decode()
-        return key
+        # Auth key entries must each have a unique ID consistent across all units.
+        # Secret revision number cannot be used as it is not known to secret observers.
+        # Secret `unique_identifier` property is not unique per revision.
+        # Therefore, a newly generated UUID is included with the secret contents.
+        return base64.b64encode(secrets.token_bytes(2048)).decode(), str(uuid4())
 
     def add(self, key: str, key_id: str) -> None:
         """Append a key to the `slurm.jwks` key file.

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -643,7 +643,7 @@ class _SlurmSecretManager:
         Raises:
             ValueError: If `key` or `key_id` is empty.
 
-        Note:
+        See Also:
             The format of the key entry is defined in the Slurm documentation:
             https://slurm.schedmd.com/authentication.html#multiple_key_setup
         """

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -531,7 +531,7 @@ class _SlurmSecretManager:
             ValueError: If `key` or `key_id` is empty.
         """
         data = self.get()
-        new_entry = self._get_new_entry(key, key_id)
+        new_entry = self._build_new_entry(key, key_id)
         data["keys"].append(new_entry)
         self._write(data)
 
@@ -603,7 +603,7 @@ class _SlurmSecretManager:
         Raises:
             ValueError: If `key` or `key_id` is empty.
         """
-        new_entry = self._get_new_entry(key, key_id)
+        new_entry = self._build_new_entry(key, key_id)
         self._write({"keys": [new_entry]})
 
         _log_security_event(
@@ -623,7 +623,7 @@ class _SlurmSecretManager:
         return self._file
 
     @staticmethod
-    def _get_new_entry(key: str, key_id: str) -> dict[str, str]:
+    def _build_new_entry(key: str, key_id: str) -> dict[str, str]:
         """Build a new key entry for the `slurm.jwks` key file.
 
         Args:

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -624,6 +624,11 @@ class _SlurmSecretManager:
         return self._file
 
     def _write(self, data: dict[str, list[dict[str, str]]]) -> None:
+        """Write out slurm.jwks data to a file.
+
+        Args:
+            data: slurm.jwks file data to write out.
+        """
         self._file.write_text(json.dumps(data))
         self._file.chmod(0o600)
         shutil.chown(self._file, self._user, self._group)

--- a/internal/slurm-ops/tests/unit/constants.py
+++ b/internal/slurm-ops/tests/unit/constants.py
@@ -26,7 +26,16 @@ FAKE_USER = pwd.getpwuid(FAKE_USER_UID).pw_name
 FAKE_GROUP_GID = os.getgid()
 FAKE_GROUP = grp.getgrgid(FAKE_GROUP_GID).gr_name
 
-SLURM_KEY_BASE64 = "MTIzNDU2Nzg5MA=="
+SLURM_KEY_CONTENTS = {
+    "keys": [
+        {
+            "alg": "HS256",
+            "kty": "oct",
+            "kid": "12345678-90ab-cdef-1234-567890abcdef",
+            "k": "MTIzNDU2Nzg5MA==",
+        }
+    ]
+}
 
 JWT_KEY = """-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAt3PLWkwUOeckDwyMpHgGqmOZhitC8KfOQY/zPWfo+up5RQXz

--- a/internal/slurm-ops/tests/unit/test_managers.py
+++ b/internal/slurm-ops/tests/unit/test_managers.py
@@ -221,14 +221,14 @@ class TestManager:
     def test_generate_slurm_valid_key(self, mock_slurm_key) -> None:
         """Test the `<manager>.key.generate()` method produces valid keys."""
         # Verify it can be decoded back from Base64
-        key = mock_slurm_key.key.generate()
+        key, _ = mock_slurm_key.key.generate()
         decoded = base64.b64decode(key)
         assert len(decoded) == 2048
 
     def test_generate_slurm_key_is_unique(self, mock_slurm_key) -> None:
         """Test the `<manager>.key.generate()` method produces unique keys."""
         # Statistically, two keys should never be identical
-        assert mock_slurm_key.key.generate() != mock_slurm_key.key.generate()
+        assert mock_slurm_key.key.generate()[0] != mock_slurm_key.key.generate()[0]
 
     # Test `<manager>.jwt` component.
 

--- a/internal/slurm-ops/tests/unit/test_managers.py
+++ b/internal/slurm-ops/tests/unit/test_managers.py
@@ -26,7 +26,7 @@ from constants import (
     FAKE_USER,
     JWT_KEY,
     SCONTROL_SHOW_NODE_OUTPUT,
-    SLURM_KEY_BASE64,
+    SLURM_KEY_CONTENTS,
     SLURM_SNAP_INFO_ACTIVE,
     SLURM_SNAP_INFO_INACTIVE,
     SLURMD_C_OUTPUT,
@@ -64,16 +64,18 @@ class TestManager:
 
     @pytest.fixture
     def mock_slurm_key(self, fs: FakeFilesystem, mock_manager, snap_backend) -> SlurmManager:
-        """Request a Slurm service manager with a fake `slurm.key` secret file."""
+        """Request a Slurm service manager with a fake Slurm auth key file."""
         if snap_backend:
-            fs.create_file("/var/snap/slurm/common/etc/slurm/slurm.key")
+            fs.create_file(
+                "/var/snap/slurm/common/etc/slurm/slurm.jwks",
+                contents=json.dumps(SLURM_KEY_CONTENTS),
+            )
         else:
-            fs.create_file("/etc/slurm/slurm.key")
+            fs.create_file("/etc/slurm/slurm.jwks", contents=json.dumps(SLURM_KEY_CONTENTS))
 
         manager, _ = mock_manager
         manager.key._user = FAKE_USER
         manager.key._group = FAKE_GROUP
-        manager.key._file.write_bytes(base64.b64decode(SLURM_KEY_BASE64))
         return manager
 
     @pytest.fixture
@@ -174,22 +176,59 @@ class TestManager:
             assert mock_run.call_args[0][0] == ["systemctl", "is-active", "--quiet", service]
             assert status == active
 
-    # Test `<manager>.key` component.
+    # Test auth key component.
 
-    def test_get_slurm_key(self, mock_slurm_key) -> None:
-        """Test the `<manager>.key.get()` method."""
-        assert mock_slurm_key.key.get() == SLURM_KEY_BASE64
+    def test_add_slurm_key(self, mock_slurm_key) -> None:
+        """Test the `<manager>.key.add(...)` method appends a new key."""
+        new_key = "xyz123=="
+        new_key_id = "abcdef12-3456-7890-abcd-ef1234567890"
+        new_key_entry = {"alg": "HS256", "kty": "oct", "kid": new_key_id, "k": new_key}
+
+        mock_slurm_key.key.add(new_key, new_key_id)
+
+        file_contents = json.loads(mock_slurm_key.key.path.read_text())
+        assert len(file_contents["keys"]) == 2
+        assert file_contents["keys"][0] == SLURM_KEY_CONTENTS["keys"][0]
+        assert file_contents["keys"][1] == new_key_entry
+
+    def test_keep_latest_slurm_key(self, mock_slurm_key) -> None:
+        """Test the `<manager>.key.keep_latest_key()` preserves only the latest key."""
+        new_key = "xyz123=="
+        new_key_id = "abcdef12-3456-7890-abcd-ef1234567890"
+        new_key_contents = {
+            "keys": [{"alg": "HS256", "kty": "oct", "kid": new_key_id, "k": new_key}]
+        }
+
+        mock_slurm_key.key.add(new_key, new_key_id)
+        mock_slurm_key.key.keep_latest_key()
+
+        file_contents = json.loads(mock_slurm_key.key.path.read_text())
+        assert file_contents == new_key_contents
 
     def test_set_slurm_key(self, mock_slurm_key) -> None:
-        """Test the `<manager>.key.set(...)` method."""
-        mock_slurm_key.key.set(SLURM_KEY_BASE64)
-        assert mock_slurm_key.key.get() == SLURM_KEY_BASE64
+        """Test the `<manager>.key.set(...)` method successfully overwrites key file."""
+        new_key = "xyz123=="
+        new_key_id = "abcdef12-3456-7890-abcd-ef1234567890"
+        new_key_contents = {
+            "keys": [{"alg": "HS256", "kty": "oct", "kid": new_key_id, "k": new_key}]
+        }
 
-    def test_generate_slurm_key(self, mock_slurm_key) -> None:
-        """Test the `<manager>.key.generate()` method."""
-        mock_slurm_key.key.generate()
-        key = base64.b64encode(mock_slurm_key.key.path.read_bytes()).decode()
-        assert mock_slurm_key.key.get() == key
+        mock_slurm_key.key.set(new_key, new_key_id)
+
+        file_contents = json.loads(mock_slurm_key.key.path.read_text())
+        assert file_contents == new_key_contents
+
+    def test_generate_slurm_valid_key(self, mock_slurm_key) -> None:
+        """Test the `<manager>.key.generate()` method produces valid keys."""
+        # Verify it can be decoded back from Base64
+        key = mock_slurm_key.key.generate()
+        decoded = base64.b64decode(key)
+        assert len(decoded) == 2048
+
+    def test_generate_slurm_key_is_unique(self, mock_slurm_key) -> None:
+        """Test the `<manager>.key.generate()` method produces unique keys."""
+        # Statistically, two keys should never be identical
+        assert mock_slurm_key.key.generate() != mock_slurm_key.key.generate()
 
     # Test `<manager>.jwt` component.
 

--- a/internal/slurmd-interface/src/charmed_slurm_slurmd_interface/__init__.py
+++ b/internal/slurmd-interface/src/charmed_slurm_slurmd_interface/__init__.py
@@ -14,6 +14,7 @@
 """Integration interface implementation for the `slurmd` interface."""
 
 __all__ = [
+    "AUTH_KEY_LABEL",
     "ComputeData",
     "SlurmdConnectedEvent",
     "SlurmdReadyEvent",
@@ -32,6 +33,7 @@ from dataclasses import dataclass
 import ops
 from charmed_hpc_libs.ops import ConditionEvaluation, leader
 from charmed_slurm_slurmctld_interface import (
+    AUTH_KEY_LABEL,
     SlurmctldConnectedEvent,
     SlurmctldDisconnectedEvent,
     SlurmctldProvider,
@@ -43,7 +45,7 @@ from charmed_slurm_slurmctld_interface import (
 from slurmutils import Partition
 
 _REQUIRED_APP_DATA = {
-    "auth_key_id": lambda value: value != '""',
+    "auth_secret_id": lambda value: value != '""',
     "controllers": lambda value: value != "[]",
 }
 

--- a/internal/slurmd-interface/tests/unit/test_slurmd.py
+++ b/internal/slurmd-interface/tests/unit/test_slurmd.py
@@ -22,6 +22,7 @@ import pytest
 from charmed_hpc_libs.ops.conditions import refresh, wait_unless
 from charmed_slurm_slurmctld_interface import ControllerData
 from charmed_slurm_slurmd_interface import (
+    AUTH_KEY_LABEL,
     ComputeData,
     SlurmctldConnectedEvent,
     SlurmctldReadyEvent,
@@ -37,6 +38,7 @@ from slurmutils import Partition
 
 SLURMD_INTEGRATION_NAME = "slurmd"
 EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_KEY_ID = "12345678-90ab-cdef-1234-567890abcdef"
 EXAMPLE_CONTROLLERS = ["127.0.0.1", "127.0.1.1"]
 EXAMPLE_PARTITION_CONFIG = Partition(partitionname="polaris")
 
@@ -108,9 +110,13 @@ class MockSlurmdRequirerCharm(ops.CharmBase):
         # Assume `remote_app_data` contains partition configuration data.
         assert data.partition.dict() == EXAMPLE_PARTITION_CONFIG.dict()
 
+        auth_key_secret = self.app.add_secret(
+            {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
+        )
+
         self.slurmd.set_controller_data(
             ControllerData(
-                auth_key=EXAMPLE_AUTH_KEY,
+                auth_secret_id=auth_key_secret.get_info().id,
                 controllers=EXAMPLE_CONTROLLERS,
             ),
             integration_id=event.relation.id,
@@ -239,14 +245,12 @@ class TestSlurmdInterface:
             remote_app_name="slurmd-requirer",
             remote_app_data=(
                 {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "controllers": json.dumps(EXAMPLE_CONTROLLERS),
                 }
                 if ready
                 else {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "controllers": json.dumps([]),
                 }
             ),
@@ -314,11 +318,8 @@ class TestSlurmdInterface:
             if ready:
                 integration = state.get_relation(slurmd_integration_id)
 
-                # Assert `auth_key` is redacted in the integration data.
-                assert integration.local_app_data["auth_key"] == '"***"'
-
                 # Assert that `auth_key_id` is set to the `auth_key` secret URI.
-                assert integration.local_app_data["auth_key_id"] != '""'
+                assert integration.local_app_data["auth_secret_id"] != '""'
 
                 # Assert that `SlurmdReadyEvent` was emitted only once.
                 occurred = defaultdict(lambda: 0)

--- a/internal/slurmdbd-interface/src/charmed_slurm_slurmdbd_interface/__init__.py
+++ b/internal/slurmdbd-interface/src/charmed_slurm_slurmdbd_interface/__init__.py
@@ -100,7 +100,9 @@ class SlurmdbdProvider(SlurmctldRequirer):
     """
 
     def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
-        super().__init__(charm, integration_name, required_app_data={"auth_secret_id", "jwt_key_id"})
+        super().__init__(
+            charm, integration_name, required_app_data={"auth_secret_id", "jwt_key_id"}
+        )
 
     @leader
     def _on_relation_created(self, event: ops.RelationCreatedEvent) -> None:

--- a/internal/slurmdbd-interface/src/charmed_slurm_slurmdbd_interface/__init__.py
+++ b/internal/slurmdbd-interface/src/charmed_slurm_slurmdbd_interface/__init__.py
@@ -15,6 +15,7 @@
 """Integration interface implementation for the `slurmdbd` interface."""
 
 __all__ = [
+    "AUTH_KEY_LABEL",
     "DatabaseData",
     "SlurmdbdConnectedEvent",
     "SlurmdbdReadyEvent",
@@ -31,6 +32,7 @@ from dataclasses import dataclass
 import ops
 from charmed_hpc_libs.ops.conditions import ConditionEvaluation, leader
 from charmed_slurm_slurmctld_interface import (
+    AUTH_KEY_LABEL,
     SlurmctldProvider,
     SlurmctldReadyEvent,
     SlurmctldRequirer,
@@ -98,7 +100,7 @@ class SlurmdbdProvider(SlurmctldRequirer):
     """
 
     def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
-        super().__init__(charm, integration_name, required_app_data={"auth_key_id", "jwt_key_id"})
+        super().__init__(charm, integration_name, required_app_data={"auth_secret_id", "jwt_key_id"})
 
     @leader
     def _on_relation_created(self, event: ops.RelationCreatedEvent) -> None:

--- a/internal/slurmdbd-interface/tests/unit/test_slurmdbd.py
+++ b/internal/slurmdbd-interface/tests/unit/test_slurmdbd.py
@@ -26,6 +26,7 @@ from charmed_slurm_slurmctld_interface import (
     SlurmctldDisconnectedEvent,
 )
 from charmed_slurm_slurmdbd_interface import (
+    AUTH_KEY_LABEL,
     DatabaseData,
     SlurmctldReadyEvent,
     SlurmdbdConnectedEvent,
@@ -40,6 +41,7 @@ from ops import testing
 
 SLURMDBD_INTEGRATION_NAME = "slurmdbd"
 EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_KEY_ID = "12345678-90ab-cdef-1234-567890abcdef"
 EXAMPLE_HOSTNAME = "127.0.0.1"
 EXAMPLE_JWT_KEY = "abc987||"
 
@@ -101,9 +103,12 @@ class MockSlurmdbdRequirerCharm(ops.CharmBase):
         )
 
     def _on_slurmdbd_connected(self, event: SlurmdbdConnectedEvent) -> None:
+        auth_key_secret = self.app.add_secret(
+            {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
+        )
         self.slurmdbd.set_controller_data(
             ControllerData(
-                auth_key=EXAMPLE_AUTH_KEY,
+                auth_secret_id=auth_key_secret.get_info().id,
                 jwt_key=EXAMPLE_JWT_KEY,
             ),
             integration_id=event.relation.id,
@@ -201,13 +206,12 @@ class TestSlurmdbdInterface:
             remote_app_name="slurmdbd-requirer",
             remote_app_data=(
                 {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "jwt_key": '"***"',
                     "jwt_key_id": json.dumps(jwt_key_secret.id),
                 }
                 if ready
-                else {"auth_key": '"***"', "jwt_key": '"***"'}
+                else {"auth_secret_id": '""', "jwt_key": '"***"'}
             ),
         )
 
@@ -299,11 +303,8 @@ class TestSlurmdbdInterface:
         if leader:
             integration = state.get_relation(slurmdbd_integration_id)
 
-            # Assert `auth_key` is redacted in the integration data.
-            assert integration.local_app_data["auth_key"] == '"***"'
-
-            # Assert that `auth_key_id` is set to the `auth_key` secret URI.
-            assert integration.local_app_data["auth_key_id"] != '""'
+            # Assert that `auth_secret_id` is set to the `auth_key` secret URI.
+            assert integration.local_app_data["auth_secret_id"] != '""'
 
             # Assert `jwt_key` is redacted in the integration data.
             assert integration.local_app_data["jwt_key"] == '"***"'

--- a/internal/slurmrestd-interface/src/charmed_slurm_slurmrestd_interface/__init__.py
+++ b/internal/slurmrestd-interface/src/charmed_slurm_slurmrestd_interface/__init__.py
@@ -54,7 +54,9 @@ class SlurmrestdProvider(SlurmctldRequirer):
     """
 
     def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
-        super().__init__(charm, integration_name, required_app_data={"auth_secret_id", "slurmconfig"})
+        super().__init__(
+            charm, integration_name, required_app_data={"auth_secret_id", "slurmconfig"}
+        )
 
 
 class SlurmrestdRequirer(SlurmctldProvider):

--- a/internal/slurmrestd-interface/src/charmed_slurm_slurmrestd_interface/__init__.py
+++ b/internal/slurmrestd-interface/src/charmed_slurm_slurmrestd_interface/__init__.py
@@ -15,6 +15,7 @@
 """Integration interface implementation for the `slurmrestd` interface."""
 
 __all__ = [
+    "AUTH_KEY_LABEL",
     "SlurmctldDisconnectedEvent",
     "SlurmctldReadyEvent",
     "SlurmrestdConnectedEvent",
@@ -26,6 +27,7 @@ __all__ = [
 import ops
 from charmed_hpc_libs.ops.conditions import leader
 from charmed_slurm_slurmctld_interface import (
+    AUTH_KEY_LABEL,
     SlurmctldDisconnectedEvent,
     SlurmctldProvider,
     SlurmctldReadyEvent,
@@ -52,7 +54,7 @@ class SlurmrestdProvider(SlurmctldRequirer):
     """
 
     def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
-        super().__init__(charm, integration_name, required_app_data={"auth_key_id", "slurmconfig"})
+        super().__init__(charm, integration_name, required_app_data={"auth_secret_id", "slurmconfig"})
 
 
 class SlurmrestdRequirer(SlurmctldProvider):

--- a/internal/slurmrestd-interface/tests/unit/test_slurmrestd.py
+++ b/internal/slurmrestd-interface/tests/unit/test_slurmrestd.py
@@ -22,6 +22,7 @@ import pytest
 from charmed_hpc_libs.ops.conditions import refresh, wait_unless
 from charmed_slurm_slurmctld_interface import ControllerData
 from charmed_slurm_slurmrestd_interface import (
+    AUTH_KEY_LABEL,
     SlurmctldReadyEvent,
     SlurmrestdConnectedEvent,
     SlurmrestdProvider,
@@ -33,6 +34,7 @@ from slurmutils import SlurmConfig
 
 SLURMRESTD_INTEGRATION_NAME = "slurmrestd"
 EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_KEY_ID = "12345678-90ab-cdef-1234-567890abcdef"
 EXAMPLE_SLURM_CONFIG = {
     "slurm.conf": SlurmConfig(
         clustername="charmed-hpc-abc_",
@@ -82,9 +84,12 @@ class MockSlurmrestdRequirerCharm(ops.CharmBase):
         )
 
     def _on_slurmrestd_connected(self, event: SlurmrestdConnectedEvent) -> None:
+        auth_key_secret = self.app.add_secret(
+            {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
+        )
         self.slurmrestd.set_controller_data(
             ControllerData(
-                auth_key=EXAMPLE_AUTH_KEY,
+                auth_secret_id=auth_key_secret.get_info().id,
                 slurmconfig=EXAMPLE_SLURM_CONFIG,
             ),
             integration_id=event.relation.id,
@@ -144,14 +149,13 @@ class TestSlurmrestdInterface:
             remote_app_name="slurmrestd-requirer",
             remote_app_data=(
                 {
-                    "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "slurmconfig": json.dumps(
                         {k: v.dict() for k, v in EXAMPLE_SLURM_CONFIG.items()}
                     ),
                 }
                 if ready
-                else {"auth_key": '"***"'}
+                else {"auth_secret_id": json.dumps("")}
             ),
         )
 
@@ -202,11 +206,8 @@ class TestSlurmrestdInterface:
         integration = state.get_relation(slurmrestd_integration_id)
         if leader:
             # Verify that the leader unit has set the required data for `slurmrestd`.
-            assert "auth_key" in integration.local_app_data
-            assert integration.local_app_data["auth_key"] == '"***"'
-
-            assert "auth_key_id" in integration.local_app_data
-            assert integration.local_app_data["auth_key_id"] != '""'
+            assert "auth_secret_id" in integration.local_app_data
+            assert integration.local_app_data["auth_secret_id"] != '""'
 
             assert "slurmconfig" in integration.local_app_data
             assert integration.local_app_data["slurmconfig"] == json.dumps(

--- a/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
+++ b/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
@@ -41,7 +41,7 @@ from slurmutils import Model, SlurmConfig
 _logger = logging.getLogger(__name__)
 
 # Label for the Juju secret storing the Slurm auth key. Used by multiple Slurm services
-AUTH_KEY_LABEL = "auth-key-secret"
+AUTH_KEY_LABEL = "slurm-auth-key"
 JWT_KEY_TEMPLATE_LABEL = Template("integration-$id-jwt-key-secret")
 
 

--- a/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
+++ b/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
@@ -15,6 +15,7 @@
 """Integration interface implementation for the `slurmctld` interface."""
 
 __all__ = [
+    "AUTH_KEY_LABEL",
     "ControllerData",
     "SlurmctldConnectedEvent",
     "SlurmctldDisconnectedEvent",
@@ -39,7 +40,9 @@ from slurmutils import Model, SlurmConfig
 
 _logger = logging.getLogger(__name__)
 
-AUTH_KEY_TEMPLATE_LABEL = Template("integration-$id-auth-key-secret")
+AUTH_KEY_LABEL = "auth-key-secret"
+"""Label for the Juju secret storing the Slurm auth key. Used by multiple Slurm services."""
+
 JWT_KEY_TEMPLATE_LABEL = Template("integration-$id-jwt-key-secret")
 
 
@@ -64,7 +67,8 @@ class ControllerData:
 
     Attributes:
         auth_key: Base64-encoded string representing the `auth/slurm` key.
-        auth_key_id: ID of the `auth/slurm` key Juju secret for this integration instance.
+        auth_key_id: ID of the current `auth/slurm` key revision.
+        auth_secret_id: ID of the `auth/slurm` key Juju secret for this integration instance.
         controllers:
             List of controller addresses for that can be used by Slurm services
             for contacting the `slurmctld` application. The first entry in the list is the
@@ -74,14 +78,15 @@ class ControllerData:
         slurmconfig: Mapping containing the `slurm.conf` and other included configuration files.
 
     Notes:
-        - `sackd` requires:         `auth_key_id`, `controllers`
-        - `slurmd` requires:        `auth_key_id`, `controllers`
-        - `slurmdbd` requires:      `auth_key_id`, `jwt_key_id`
-        - `slurmrestd` requires:    `auth_key_id`, `slurmconfig`
+        - `sackd` requires:         `auth_secret_id`, `controllers`
+        - `slurmd` requires:        `auth_secret_id`, `controllers`
+        - `slurmdbd` requires:      `auth_secret_id`, `jwt_key_id`
+        - `slurmrestd` requires:    `auth_secret_id`, `slurmconfig`
     """
 
     auth_key: str = ""
     auth_key_id: str = ""
+    auth_secret_id: str = ""
     controllers: list[str] = field(default_factory=list)
     jwt_key: str = ""
     jwt_key_id: str = ""
@@ -168,12 +173,6 @@ class SlurmctldProvider(Interface):
         if self._stored.unit_departing:
             return
 
-        if auth_secret := load_secret(
-            self.charm,
-            label=AUTH_KEY_TEMPLATE_LABEL.substitute(id=event.relation.id),
-        ):
-            auth_secret.remove_all_revisions()
-
         if jwt_secret := load_secret(
             self.charm,
             label=JWT_KEY_TEMPLATE_LABEL.substitute(id=event.relation.id),
@@ -196,14 +195,9 @@ class SlurmctldProvider(Interface):
         if integration_id is not None:
             integration = self.get_integration(integration_id)
 
-            if data.auth_key:
-                secret = update_secret(
-                    self.charm,
-                    AUTH_KEY_TEMPLATE_LABEL.substitute(id=integration_id),
-                    {"key": data.auth_key},
-                )
+            if data.auth_secret_id:
+                secret = self.model.get_secret(id=data.auth_secret_id)
                 secret.grant(integration)
-                object.__setattr__(data, "auth_key_id", secret.id)
 
             if data.jwt_key:
                 secret = update_secret(
@@ -215,7 +209,6 @@ class SlurmctldProvider(Interface):
                 object.__setattr__(data, "jwt_key_id", secret.id)
 
         # Redact secrets. "***" indicates that an interface did not unlock a secret.
-        object.__setattr__(data, "auth_key", "***")
         object.__setattr__(data, "jwt_key", "***")
 
         self._save_integration_data(data, self.app, integration_id, encoder=encoder)
@@ -286,9 +279,12 @@ class SlurmctldRequirer(Interface):
             integration_id: ID of integration to pull controller data from.
         """
         data = self._load_integration_data(ControllerData, integration_id=integration_id).pop()
-        if data.auth_key_id:
-            auth_key = self.charm.model.get_secret(id=data.auth_key_id)
+        if data.auth_secret_id:
+            # Get by both ID and label to ensure secret is updated with the correct label on the
+            # observer side
+            auth_key = self.charm.model.get_secret(id=data.auth_secret_id, label=AUTH_KEY_LABEL)
             object.__setattr__(data, "auth_key", auth_key.get_content().get("key"))
+            object.__setattr__(data, "auth_key_id", auth_key.get_content().get("keyid"))
         if data.jwt_key_id:
             jwt_key = self.charm.model.get_secret(id=data.jwt_key_id)
             object.__setattr__(data, "jwt_key", jwt_key.get_content().get("key"))

--- a/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
+++ b/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
@@ -40,9 +40,8 @@ from slurmutils import Model, SlurmConfig
 
 _logger = logging.getLogger(__name__)
 
+# Label for the Juju secret storing the Slurm auth key. Used by multiple Slurm services
 AUTH_KEY_LABEL = "auth-key-secret"
-"""Label for the Juju secret storing the Slurm auth key. Used by multiple Slurm services."""
-
 JWT_KEY_TEMPLATE_LABEL = Template("integration-$id-jwt-key-secret")
 
 

--- a/pkg/slurmctld-interface/tests/unit/test_slurmctld.py
+++ b/pkg/slurmctld-interface/tests/unit/test_slurmctld.py
@@ -21,6 +21,7 @@ import ops
 import pytest
 from charmed_hpc_libs.ops.conditions import refresh, wait_unless
 from charmed_slurm_slurmctld_interface import (
+    AUTH_KEY_LABEL,
     ControllerData,
     SlurmctldConnectedEvent,
     SlurmctldDisconnectedEvent,
@@ -34,6 +35,7 @@ from slurmutils import SlurmConfig
 
 SLURMCTLD_INTEGRATION_NAME = "slurmctld"
 EXAMPLE_AUTH_KEY = "xyz123=="
+EXAMPLE_AUTH_KEY_ID = "12345678-90ab-cdef-1234-567890abcdef"
 EXAMPLE_JWT_KEY = "abc987||"
 EXAMPLE_CONTROLLERS = ["127.0.0.1", "127.0.1.1"]
 EXAMPLE_SLURM_CONFIG = {
@@ -58,9 +60,15 @@ class MockSlurmctldProviderCharm(ops.CharmBase):
         )
 
     def _on_relation_created(self, event: ops.RelationCreatedEvent) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        auth_key_secret = self.app.add_secret(
+            {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
+        )
         self.slurmctld.set_controller_data(
             ControllerData(
-                auth_key=EXAMPLE_AUTH_KEY,
+                auth_secret_id=auth_key_secret.get_info().id,
                 jwt_key=EXAMPLE_JWT_KEY,
                 controllers=EXAMPLE_CONTROLLERS,
                 slurmconfig=EXAMPLE_SLURM_CONFIG,
@@ -154,12 +162,11 @@ class TestSlurmctldInterface:
 
         integration = state.get_relation(slurmctld_integration_id)
         if leader:
-            # Verify that auth_key and jwt_key are redacted in the integration data.
-            assert integration.local_app_data["auth_key"] == '"***"'
+            # Verify jwt_key is redacted in the integration data.
             assert integration.local_app_data["jwt_key"] == '"***"'
 
             # Verify that secret IDs have been set (non-empty).
-            assert integration.local_app_data["auth_key_id"] != '""'
+            assert integration.local_app_data["auth_secret_id"] != '""'
             assert integration.local_app_data["jwt_key_id"] != '""'
 
             # Verify controllers and slurmconfig are set correctly.
@@ -172,10 +179,10 @@ class TestSlurmctldInterface:
     @pytest.mark.parametrize(
         "auth_key,jwt_key",
         (
-            pytest.param(EXAMPLE_AUTH_KEY, "", id="auth-key-only"),
-            pytest.param("", EXAMPLE_JWT_KEY, id="jwt-key-only"),
-            pytest.param(EXAMPLE_AUTH_KEY, EXAMPLE_JWT_KEY, id="both-keys"),
-            pytest.param("", "", id="no-keys"),
+            pytest.param(True, "", id="auth-key-only"),
+            pytest.param(False, EXAMPLE_JWT_KEY, id="jwt-key-only"),
+            pytest.param(True, EXAMPLE_JWT_KEY, id="both-keys"),
+            pytest.param(False, "", id="no-keys"),
         ),
     )
     def test_provider_set_controller_data_secret_handling(
@@ -201,8 +208,18 @@ class TestSlurmctldInterface:
                 )
 
             def _on_relation_created(self, event: ops.RelationCreatedEvent) -> None:
+                if not self.model.unit.is_leader():
+                    return
+
+                auth_secret_id = ""
+                if auth_key:
+                    auth_key_secret = self.app.add_secret(
+                        {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
+                    )
+                    auth_secret_id=auth_key_secret.get_info().id
+
                 self.slurmctld.set_controller_data(
-                    ControllerData(auth_key=auth_key, jwt_key=jwt_key),
+                    ControllerData(auth_secret_id=auth_secret_id, jwt_key=jwt_key),
                     integration_id=event.relation.id,
                 )
 
@@ -222,15 +239,14 @@ class TestSlurmctldInterface:
         if leader:
             integration = state.get_relation(slurmctld_integration_id)
 
-            # auth_key and jwt_key are always redacted after set_controller_data.
-            assert integration.local_app_data["auth_key"] == '"***"'
+            # jwt_key is always redacted after set_controller_data.
             assert integration.local_app_data["jwt_key"] == '"***"'
 
             # Secret IDs are set only when the key was non-empty.
             if auth_key:
-                assert integration.local_app_data["auth_key_id"] != '""'
+                assert integration.local_app_data["auth_secret_id"] != '""'
             else:
-                assert integration.local_app_data["auth_key_id"] == '""'
+                assert integration.local_app_data["auth_secret_id"] == '""'
 
             if jwt_key:
                 assert integration.local_app_data["jwt_key_id"] != '""'
@@ -274,8 +290,7 @@ class TestSlurmctldInterface:
         )
 
         if leader:
-            # Both secrets should have been removed by the leader.
-            assert auth_key_secret.id not in {s.id for s in state.secrets}
+            # Only JWT secret should be removed by the leader.
             assert jwt_key_secret.id not in {s.id for s in state.secrets}
 
     # Test requirer-side of the `slurmctld` interface.
@@ -311,7 +326,7 @@ class TestSlurmctldInterface:
     )
     def test_requirer_on_slurmctld_ready_event(self, requirer_ctx, leader, ready) -> None:
         """Test that the `slurmctld` requirer waits for controller data to be available."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY})
+        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID})
         jwt_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_JWT_KEY})
 
         slurmctld_integration_id = 1
@@ -325,7 +340,7 @@ class TestSlurmctldInterface:
             remote_app_data=(
                 {
                     "auth_key": '"***"',
-                    "auth_key_id": json.dumps(auth_key_secret.id),
+                    "auth_secret_id": json.dumps(auth_key_secret.id),
                     "jwt_key": '"***"',
                     "jwt_key_id": json.dumps(jwt_key_secret.id),
                     "controllers": json.dumps(EXAMPLE_CONTROLLERS),
@@ -388,7 +403,7 @@ class TestSlurmctldInterface:
 
     def test_requirer_get_controller_data(self, requirer_ctx, leader) -> None:
         """Test that `get_controller_data` correctly retrieves and decrypts secret values."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY})
+        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID})
         jwt_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_JWT_KEY})
 
         slurmctld_integration_id = 1
@@ -398,8 +413,8 @@ class TestSlurmctldInterface:
             id=slurmctld_integration_id,
             remote_app_name="slurmctld-provider",
             remote_app_data={
-                "auth_key": '"***"',
-                "auth_key_id": json.dumps(auth_key_secret.id),
+                "auth_key": '""',
+                "auth_secret_id": json.dumps(auth_key_secret.id),
                 "jwt_key": '"***"',
                 "jwt_key_id": json.dumps(jwt_key_secret.id),
                 "controllers": json.dumps(EXAMPLE_CONTROLLERS),

--- a/pkg/slurmctld-interface/tests/unit/test_slurmctld.py
+++ b/pkg/slurmctld-interface/tests/unit/test_slurmctld.py
@@ -214,9 +214,10 @@ class TestSlurmctldInterface:
                 auth_secret_id = ""
                 if auth_key:
                     auth_key_secret = self.app.add_secret(
-                        {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
+                        {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID},
+                        label=AUTH_KEY_LABEL,
                     )
-                    auth_secret_id=auth_key_secret.get_info().id
+                    auth_secret_id = auth_key_secret.get_info().id
 
                 self.slurmctld.set_controller_data(
                     ControllerData(auth_secret_id=auth_secret_id, jwt_key=jwt_key),
@@ -326,7 +327,9 @@ class TestSlurmctldInterface:
     )
     def test_requirer_on_slurmctld_ready_event(self, requirer_ctx, leader, ready) -> None:
         """Test that the `slurmctld` requirer waits for controller data to be available."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID})
+        auth_key_secret = testing.Secret(
+            tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}
+        )
         jwt_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_JWT_KEY})
 
         slurmctld_integration_id = 1
@@ -403,7 +406,9 @@ class TestSlurmctldInterface:
 
     def test_requirer_get_controller_data(self, requirer_ctx, leader) -> None:
         """Test that `get_controller_data` correctly retrieves and decrypts secret values."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID})
+        auth_key_secret = testing.Secret(
+            tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}
+        )
         jwt_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_JWT_KEY})
 
         slurmctld_integration_id = 1

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -248,7 +248,7 @@ def test_rotate_auth_key(juju: jubilant.Juju) -> None:
 
     juju.run(slurmctld_unit, "rotate-auth-key")
 
-    # Wait for action to complete and for all Slurm applications to return to ActiveStatus
+    # Wait for action to complete and for all Slurm applications to return to ActiveStatus.
     juju.wait(
         lambda status: jubilant.all_active(status, *SLURM_APPS),
         error=lambda status: jubilant.any_error(status, *SLURM_APPS),
@@ -258,7 +258,7 @@ def test_rotate_auth_key(juju: jubilant.Juju) -> None:
     # Key rotation does not complete until the secret-remove event has completed on slurmctld. This
     # event is triggered after all observers have updated to the new secret revision. There may be
     # a gap where all Slurm applications are in ActiveStatus but secret-remove has not yet run so
-    # the old key is still present on slurmctld. Account for this with tenacity
+    # the old key is still present on slurmctld. Account for this with tenacity.
     attempts = tenacity.Retrying(
         wait=tenacity.wait.wait_exponential(multiplier=2, min=1),
         stop=tenacity.stop_after_attempt(5),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -228,6 +228,67 @@ def test_set_node_state(juju: jubilant.Juju) -> None:
 
 
 @pytest.mark.order(10)
+def test_rotate_auth_key(juju: jubilant.Juju) -> None:
+    """Test that the `rotate-auth-key` action updates the Slurm authentication key across the cluster."""
+    slurmctld_unit = f"{SLURMCTLD_APP_NAME}/0"
+    sackd_unit = f"{SACKD_APP_NAME}/0"
+    slurmd_unit = f"{SLURMD_APP_NAME}/0"
+    non_controller_units = [
+        sackd_unit,
+        slurmd_unit,
+        f"{SLURMDBD_APP_NAME}/0",
+        f"{SLURMRESTD_APP_NAME}/0",
+    ]
+
+    logger.info("testing that the `rotate-auth-key` action updates the Slurm authentication key")
+
+    # Gather existing authentication key from `slurmctld/0`.
+    result = juju.exec("sudo cat /etc/slurm/slurm.jwks", unit=slurmctld_unit)
+    initial_key_entry = json.loads(result.stdout)
+
+    juju.run(slurmctld_unit, "rotate-auth-key")
+
+    # Wait for action to complete and for all Slurm applications to return to ActiveStatus
+    juju.wait(
+        lambda status: jubilant.all_active(status, *SLURM_APPS),
+        error=lambda status: jubilant.any_error(status, *SLURM_APPS),
+    )
+
+    # Check authentication key has been updated on all units
+    # Key rotation does not complete until the secret-remove event has completed on slurmctld. This
+    # event is triggered after all observers have updated to the new secret revision. There may be
+    # a gap where all Slurm applications are in ActiveStatus but secret-remove has not yet run so
+    # the old key is still present on slurmctld. Account for this with tenacity
+    attempts = tenacity.Retrying(
+        wait=tenacity.wait.wait_exponential(multiplier=2, min=1),
+        stop=tenacity.stop_after_attempt(5),
+        reraise=True,
+    )
+    for attempt in attempts:
+        with attempt:
+            result = juju.exec("sudo cat /etc/slurm/slurm.jwks", unit=slurmctld_unit)
+            new_key_entry = json.loads(result.stdout)
+
+            # Check old key removed from controller and new key present
+            assert len(new_key_entry["keys"]) == 1
+            assert new_key_entry != initial_key_entry
+
+            # Check new key present on all other units
+            for unit in non_controller_units:
+                result = juju.exec("sudo cat /etc/slurm/slurm.jwks", unit=unit)
+                key_entry = json.loads(result.stdout)
+                assert len(key_entry["keys"]) == 1
+                assert key_entry == new_key_entry, f"auth key rotation failed on: {unit}"
+
+            # Check units can communicate with controller
+            assert juju.exec("sinfo", unit=sackd_unit).success
+            assert juju.exec("sinfo", unit=slurmd_unit).success
+            # Database does not have client tools installed. Query from the controller
+            assert juju.exec("sacct", unit=slurmctld_unit).success
+            # TODO: confirm slurmrestd connectivity
+
+
+@pytest.mark.order(11)
 def test_job_submission(juju: jubilant.Juju) -> None:
     """Test that a job can be successfully submitted to the Slurm cluster."""
     sackd_unit = f"{SACKD_APP_NAME}/0"
@@ -241,7 +302,7 @@ def test_job_submission(juju: jubilant.Juju) -> None:
     assert sackd_result.stdout == slurmd_result.stdout
 
 
-@pytest.mark.order(11)
+@pytest.mark.order(12)
 def test_gpu_job_submission(juju: jubilant.Juju) -> None:
     """Test that a job requesting a GPU can be successfully submitted to the Slurm cluster.
 

--- a/uv.lock
+++ b/uv.lock
@@ -709,15 +709,15 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.40.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
 ]
 
 [[package]]
@@ -773,11 +773,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -843,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.5"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -851,38 +851,39 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6b/69fd5c7194b21ebde0f8637e2a4ddc766ada29d472bfa6a5ca533d79549a/pydantic-2.13.0.tar.gz", hash = "sha256:b89b575b6e670ebf6e7448c01b41b244f471edd276cd0b6fe02e7e7aca320070", size = 843468, upload-time = "2026-04-13T10:51:35.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d7/c3a52c61f5b7be648e919005820fbac33028c6149994cd64453f49951c17/pydantic-2.13.0-py3-none-any.whl", hash = "sha256:ab0078b90da5f3e2fd2e71e3d9b457ddcb35d0350854fbda93b451e28d56baaf", size = 471872, upload-time = "2026-04-13T10:51:33.343Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.5"
+version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0a/9414cddf82eda3976b14048cc0fa8f5b5d1aecb0b22e1dcd2dbfe0e139b1/pydantic_core-2.46.0.tar.gz", hash = "sha256:82d2498c96be47b47e903e1378d1d0f770097ec56ea953322f39936a7cf34977", size = 471441, upload-time = "2026-04-13T09:06:33.813Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
-    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
-    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
-    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
-    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d2/206c72ad47071559142a35f71efc29eb16448a4a5ae9487230ab8e4e292b/pydantic_core-2.46.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:66ccedb02c934622612448489824955838a221b3a35875458970521ef17b2f9c", size = 2117060, upload-time = "2026-04-13T09:04:47.443Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2c/7a53b33f91c8b77e696b1a6aa3bed609bf9374bdc0f8dcda681bc7d922b8/pydantic_core-2.46.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a44f27f4d2788ef9876ec47a43739b118c5904d74f418f53398f6ced3bbcacf2", size = 1951802, upload-time = "2026-04-13T09:05:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/20/90e548c1f6d38800ef11c915881525770ce270d8e5e887563ff046a08674/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f26a1032bcce6ca4b4670eb3f7d8195bd0a8b8f255f1307823e217ca3cfa7c27", size = 1976621, upload-time = "2026-04-13T09:04:03.909Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3c/9c5810ca70b60c623488cdd80f7e9ee1a0812df81e97098b64788719860f/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b8d1412f725060527e56675904b17a2d421dddcf861eecf7c75b9dda47921a4", size = 2056721, upload-time = "2026-04-13T09:04:40.992Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a3/d6e5f4cdec84278431c75540f90838c9d0a4dfe9402a8f3902073660ff28/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc3d1569edd859cabaa476cabce9eecd05049a7966af7b4a33b541bfd4ca1104", size = 2239634, upload-time = "2026-04-13T09:03:52.478Z" },
+    { url = "https://files.pythonhosted.org/packages/46/42/ef58aacf330d8de6e309d62469aa1f80e945eaf665929b4037ac1bfcebc1/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:38108976f2d8afaa8f5067fd1390a8c9f5cc580175407cda636e76bc76e88054", size = 2315739, upload-time = "2026-04-13T09:05:04.971Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/86/c63b12fafa2d86a515bfd1840b39c23a49302f02b653161bf9c3a0566c50/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5a06d8ed01dad5575056b5187e5959b336793c6047920a3441ee5b03533836", size = 2098169, upload-time = "2026-04-13T09:07:27.151Z" },
+    { url = "https://files.pythonhosted.org/packages/76/19/b5b33a2f6be4755b21a20434293c4364be255f4c1a108f125d101d4cc4ee/pydantic_core-2.46.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:04017ace142da9ce27cafd423a480872571b5c7e80382aec22f7d715ca8eb870", size = 2170830, upload-time = "2026-04-13T09:04:39.448Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ae/7559f99a29b7d440012ddb4da897359304988a881efaca912fd2f655652e/pydantic_core-2.46.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2629ad992ed1b1c012e6067f5ffafd3336fcb9b54569449fabb85621f1444ed3", size = 2203901, upload-time = "2026-04-13T09:04:01.048Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0e/b0ef945a39aeb4ac58da316813e1106b7fbdfbf20ac141c1c27904355ac5/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3068b1e7bd986aebc88f6859f8353e72072538dcf92a7fb9cf511a0f61c5e729", size = 2191789, upload-time = "2026-04-13T09:06:39.915Z" },
+    { url = "https://files.pythonhosted.org/packages/90/f4/830484e07188c1236b013995818888ab93bab8fd88aa9689b1d8fd22220d/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:1e366916ff69ff700aa9326601634e688581bc24c5b6b4f8738d809ec7d72611", size = 2344423, upload-time = "2026-04-13T09:05:12.252Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/e455c18cbdc333177af754e740be4fe9d1de173d65bbe534daf88da02ac0/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:485a23e8f4618a1b8e23ac744180acde283fffe617f96923d25507d5cade62ec", size = 2384037, upload-time = "2026-04-13T09:06:24.503Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1f/b35d20d73144a41e78de0ae398e60fdd8bed91667daa1a5a92ab958551ba/pydantic_core-2.46.0-cp312-cp312-win32.whl", hash = "sha256:520940e1b702fe3b33525d0351777f25e9924f1818ca7956447dabacf2d339fd", size = 1967068, upload-time = "2026-04-13T09:05:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/4b6252e9606e8295647b848233cc4137ee0a04ebba8f0f9fb2977655b38c/pydantic_core-2.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:90d2048e0339fa365e5a66aefe760ddd3b3d0a45501e088bc5bc7f4ed9ff9571", size = 2071008, upload-time = "2026-04-13T09:05:21.392Z" },
+    { url = "https://files.pythonhosted.org/packages/39/95/d08eb508d4d5560ccbd226ee5971e5ef9b749aba9b413c0c4ed6e406d4f6/pydantic_core-2.46.0-cp312-cp312-win_arm64.whl", hash = "sha256:a70247649b7dffe36648e8f34be5ce8c5fa0a27ff07b071ea780c20a738c05ce", size = 2036634, upload-time = "2026-04-13T09:05:48.299Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0c/106ed5cc50393d90523f09adcc50d05e42e748eb107dc06aea971137f02d/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:bc0e2fefe384152d7da85b5c2fe8ce2bf24752f68a58e3f3ea42e28a29dfdeb2", size = 2104968, upload-time = "2026-04-13T09:06:26.967Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/71/b494cef3165e3413ee9bbbb5a9eedc9af0ea7b88d8638beef6c2061b110e/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:a2ab0e785548be1b4362a62c4004f9217598b7ee465f1f420fc2123e2a5b5b02", size = 1940442, upload-time = "2026-04-13T09:06:29.332Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3e/a4d578c8216c443e26a1124f8c1e07c0654264ce5651143d3883d85ff140/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16d45aecb18b8cba1c68eeb17c2bb2d38627ceed04c5b30b882fc9134e01f187", size = 1999672, upload-time = "2026-04-13T09:04:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/9114560468685525a21770138382fd0cb849aaf351ff2c7b97f760d121e0/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5078f6c377b002428e984259ac327ef8902aacae6c14b7de740dd4869a491501", size = 2154533, upload-time = "2026-04-13T09:04:50.868Z" },
 ]
 
 [[package]]
@@ -1087,27 +1088,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.9"
+version = "0.15.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
-    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
-    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
-    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
-    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
-    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
-    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> ~Draft commit as relies on a personal fork of `hpc-libs`.~
> ~Updates to the secrets handling must be merged into an `hpc-libs` release to unblock this PR.~
> Out of draft status. Necessary secret handing changes have been included in this PR

# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

The new `rotate-auth-key` action is implemented on `slurmctld` to perform a cluster-wide rotation of the Slurm auth key. To facilitate this:

* Slurm key manager in `slurm-ops` has been rewritten to support Slurm's multiple key setup using `slurm.jwks` in place of `slurm.key`: https://slurm.schedmd.com/authentication.html#multiple_key_setup
* SSDLC-compliant logging of key changes to `slurm.jwks` is added

Rotation is performed by:

* Admin runs `juju run slurmctld/leader rotate-auth-key`
* Controller adds a new key to the `slurm.jwks` file alongside the old key
* The auth key Juju secret is updated to a new revision with the new key
* All secret observers/other Slurm units receive a SecretChangedEvent and update local key file with the new key
* Controller receives a SecretRemoveEvent after all Slurm units have updated to the new key and removes the old key from the `slurm.jwks` file

Slurm interfaces have been updated to use a model-level auth key secret:

* A constant `AUTH_KEY_LABEL` is now used to refer to the secret
* `auth_key_id` is renamed to `auth_secret_id` in `ControllerData`
* `auth_key_id` is reused to refer to ID for the key revision rather than secret itself
* Auth key secret is no longer created in the interface. This is now done in charm code
* Auth key revisions are no longer removed when a relation is broken.
  * Secret access does not require manual revocation in charm code: ["If the relation is removed, the secret access will be revoked."](https://documentation.ubuntu.com/juju/3.6/reference/secret/#secret-lifecycle) 
  * Secret revisions do not require manual cleanup in charm code. They are cleaned up when `slurmctld` is removed:  ["juju has code which removes any charm owned secrets if the application is removed"](https://matrix.to/#/!xzmWHtGpPfVCXKivIh:ubuntu.com/$10ns2_hnyZqrj8baKHDxUkn9yGmdh9jqWqDfeZVy4gk?via=ubuntu.com&via=matrix.org&via=tchncs.de)

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

The rotation is currently not a zero-downtime process due to:

* https://github.com/charmed-hpc/slurm-charms/issues/204 preventing reload of slurmd.service, necessitating a restart to load the new key
* slurmdbd.service not reloading its auth key on a `systemctl reload slurmdbd.service`, necessitating a restart.
  * This may be a Slurm bug. It is inconsistent with the behavior of other Slurm services (`systemctl reload sackd.service` reloads the key as expected) and documentation states the `SIGHUP` signal ["Reloads the slurm configuration files"](https://slurm.schedmd.com/slurmdbd.html#OPT_SIGHUP)
* slurmrestd.service not supporting a reload signal, necessitating a restart. The process exits on a `systemctl reload slurmrestd.service`. No relevant signals are listed in https://slurm.schedmd.com/slurmrestd.html#SECTION_SIGNALS

All workarounds in the code are marked with `#TODO` or `#FIXME` comments.

This PR fixes:

* https://github.com/charmed-hpc/slurm-charms/issues/147
* https://github.com/charmed-hpc/slurm-charms/issues/203

## Docs

* [X] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [ ] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

https://github.com/charmed-hpc/docs/pull/130