### PR TITLE
feat: implement jwt key rotation

### DIFF
--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -93,7 +93,7 @@ class SackdCharm(ops.CharmBase):
         data = self.slurmctld.get_controller_data(event.relation.id)
 
         try:
-            self.sackd.key.set(data.auth_key, data.auth_key_id)
+            self.sackd.key.set({"key": data.auth_key, "keyid": data.auth_key_id})
             self.sackd.conf_server = data.controllers
             self.sackd.service.enable()
             self.sackd.service.restart()
@@ -127,21 +127,17 @@ class SackdCharm(ops.CharmBase):
             logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
             return
 
-        content = event.secret.get_content(refresh=True)
-        auth_key = content.get("key")
-        auth_key_id = content.get("keyid")
-        if not auth_key or not auth_key_id:
-            logger.error(
-                "auth key or key ID is empty in secret with label '%s'", event.secret.label
-            )
+        try:
+            content = event.secret.get_content(refresh=True)
+            self.sackd.key.set(content)
+        except (ops.SecretNotFoundError, ops.ModelError, ValueError) as e:
+            logger.error("failed to retrieve auth key contents. reason:\n%s", e)
             event.defer()
             raise StopCharm(
                 ops.BlockedStatus(
                     "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
                 )
             )
-
-        self.sackd.key.set(auth_key, auth_key_id)
 
         # Necessary to load new key from file into the service
         # TODO: replace with self.service.reload()

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -121,12 +121,23 @@ actions:
   rotate-auth-key:
     description: |
       Perform a cluster-wide rotation of the key used to authenticate Slurm remote procedure calls.
-      See: https://documentation.ubuntu.com/charmed-hpc/latest/explanation/key-rotation/#authentication-key-rotation
+      See: https://documentation.ubuntu.com/charmed-hpc/latest/explanation/key-rotation/#authentication-key-rotation-process
 
       Example usage:
 
       ```bash
       juju run slurmctld/leader rotate-auth-key
+      ```
+
+  rotate-jwt-key:
+    description: |
+      Perform a rotation of the JSON Web Tokens (JWT) key alternative authentication mechanism.
+      See: https://documentation.ubuntu.com/charmed-hpc/latest/explanation/key-rotation/#jwt-key-rotation-process
+
+      Example usage:
+
+      ```bash
+      juju run slurmctld/leader rotate-jwt-key
       ```
 
   show-current-config:

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -40,6 +40,7 @@ from charmed_slurm_sackd_interface import (
 )
 from charmed_slurm_slurmctld_interface import (
     AUTH_KEY_LABEL,
+    JWT_KEY_LABEL,
     ControllerData,
 )
 from charmed_slurm_slurmd_interface import (
@@ -81,7 +82,7 @@ from integrations import SlurmctldPeer, SlurmctldPeerConnectedEvent
 from interface_influxdb import InfluxDB, InfluxDBAvailableEvent, InfluxDBUnavailableEvent
 from psutil import net_if_addrs
 from pydantic import ValidationError
-from slurm_ops import SlurmctldManager, SlurmOpsError, scontrol
+from slurm_ops import SecretManager, SlurmctldManager, SlurmOpsError, scontrol
 from slurmutils import (
     AcctGatherConfig,
     ModelError,
@@ -142,6 +143,7 @@ class SlurmctldCharm(ops.CharmBase):
         framework.observe(self.on.secret_changed, self._on_secret_changed)
         framework.observe(self.on.secret_remove, self._on_secret_remove)
         framework.observe(self.on.rotate_auth_key_action, self._on_rotate_auth_key_action)
+        framework.observe(self.on.rotate_jwt_key_action, self._on_rotate_jwt_key_action)
         framework.observe(self.on.show_current_config_action, self._on_show_current_config_action)
         framework.observe(self.on.set_node_state_action, self._on_set_node_state_action)
 
@@ -216,24 +218,23 @@ class SlurmctldCharm(ops.CharmBase):
             self.slurmctld.service.stop()
             self.slurmctld.service.disable()
 
+            # Ensure key files in place
             if self.unit.is_leader():
-                # Check for existence of keys to avoid erroneous regeneration in the case where a
-                # new unit is elected leader as it is being deployed
-                if not self.slurmctld.jwt.path.exists():
-                    self.slurmctld.jwt.generate()
+                for manager, label, name in [
+                    (self.slurmctld.jwt, JWT_KEY_LABEL, "JWT"),
+                    (self.slurmctld.key, AUTH_KEY_LABEL, "auth"),
+                ]:
+                    try:
+                        secret = self.model.get_secret(label=label)
+                        logger.debug("%s key secret found. skipping generation", name)
 
-                try:
-                    secret = self.model.get_secret(label=AUTH_KEY_LABEL)
-                    logger.debug("auth key secret found. skipping generation")
-
-                    if not self.slurmctld.key.path.exists():
-                        logger.warning("auth key file not found. restoring from secret")
-                        content = secret.get_content()
-                        self.slurmctld.key.set(content["key"], content["keyid"])
-                except ops.SecretNotFoundError:
-                    key, key_id = self.slurmctld.key.generate()
-                    self.app.add_secret({"key": key, "keyid": key_id}, label=AUTH_KEY_LABEL)
-                    self.slurmctld.key.set(key, key_id)
+                        if not manager.path.exists():
+                            logger.warning("%s key file not found. restoring from secret", name)
+                            manager.set(secret.get_content(refresh=True))
+                    except ops.SecretNotFoundError:
+                        content = manager.generate()
+                        self.app.add_secret(content, label=label)
+                        manager.set(content)
 
             self.unit.set_workload_version(self.slurmctld.version())
         except SlurmOpsError as e:
@@ -481,10 +482,11 @@ class SlurmctldCharm(ops.CharmBase):
     def _on_slurmdbd_connected(self, event: SlurmdbdConnectedEvent) -> None:
         """Handle when a new `slurmdbd` application is connected."""
         auth_secret_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id
+        jwt_secret_id = self.model.get_secret(label=JWT_KEY_LABEL).get_info().id
         self.slurmdbd.set_controller_data(
             ControllerData(
                 auth_secret_id=auth_secret_id,
-                jwt_key=self.slurmctld.jwt.get(),
+                jwt_secret_id=jwt_secret_id,
             ),
             integration_id=event.relation.id,
         )
@@ -648,7 +650,7 @@ class SlurmctldCharm(ops.CharmBase):
     @block_unless(slurmctld_installed)
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle when a secret is changed."""
-        if event.secret.label != AUTH_KEY_LABEL:
+        if event.secret.label not in (AUTH_KEY_LABEL, JWT_KEY_LABEL):
             logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
             return
 
@@ -665,7 +667,9 @@ class SlurmctldCharm(ops.CharmBase):
     def _on_secret_remove(self, event: ops.SecretRemoveEvent) -> None:
         """Handle when a secret is removed."""
         if event.secret.label != AUTH_KEY_LABEL:
-            logger.warning("secret with label '%s' removed. ignoring", event.secret.label)
+            logger.warning(
+                "secret with label '%s' does not require removal. ignoring", event.secret.label
+            )
             return
 
         self.slurmctld.key.keep_latest_key()
@@ -680,28 +684,12 @@ class SlurmctldCharm(ops.CharmBase):
     @refresh
     def _on_rotate_auth_key_action(self, event: ops.ActionEvent) -> None:
         """Rotate the Slurm authentication key across the cluster."""
-        if not self.unit.is_leader():
-            event.fail("Only the leader unit can rotate the authentication key.")
-            return
+        self._rotate_key(event, self.slurmctld.key, AUTH_KEY_LABEL, "auth")
 
-        # Update secrets backend with new key revision
-        new_key, new_key_id = self.slurmctld.key.generate()
-        try:
-            # Update key file first to ensure key is available before observers apply new revision
-            self.slurmctld.key.add(new_key, new_key_id)
-            self._reconfigure()
-        except (SlurmOpsError, ValueError) as e:
-            logger.error("failed to update auth key. reason:\n%s", e)
-            event.fail("Failed to update auth key. See `juju debug-log` for details.")
-            return
-
-        try:
-            secret = self.model.get_secret(label=AUTH_KEY_LABEL)
-            secret.set_content({"key": new_key, "keyid": new_key_id})
-        except (ops.SecretNotFoundError, ModelError) as e:
-            logger.error("failed to publish new auth key secret. reason:\n%s", e)
-            event.fail("Failed to publish new auth key secret. See `juju debug-log` for details.")
-            return
+    @refresh
+    def _on_rotate_jwt_key_action(self, event: ops.ActionEvent) -> None:
+        """Rotate the Slurm JSON Web Tokens (JWT) key across the cluster."""
+        self._rotate_key(event, self.slurmctld.jwt, JWT_KEY_LABEL, "JWT")
 
     def _on_show_current_config_action(self, event: ops.ActionEvent) -> None:
         """Show current slurm.conf."""
@@ -931,7 +919,7 @@ class SlurmctldCharm(ops.CharmBase):
                 auth_secret_id=current.auth_secret_id,
                 controllers=new_endpoints,  # Update only the controllers
                 jwt_key="",
-                jwt_key_id=current.jwt_key_id,
+                jwt_secret_id=current.jwt_secret_id,
                 slurmconfig=current.slurmconfig,
             )
 
@@ -958,6 +946,34 @@ class SlurmctldCharm(ops.CharmBase):
         new_endpoints = [f"{c}:{SLURMCTLD_PORT}" for c in new_controllers]
         self._merge_controller_data(self.sackd, new_endpoints)
         self._merge_controller_data(self.slurmd, new_endpoints)
+
+    def _rotate_key(
+        self,
+        event: ops.ActionEvent,
+        manager: SecretManager,
+        label: str,
+        name: str,
+    ) -> None:
+        if not self.unit.is_leader():
+            event.fail(f"Only the leader unit can rotate the {name} key.")
+            return
+
+        content = manager.generate()
+        try:
+            manager.apply(content)
+            self._reconfigure()
+        except (SlurmOpsError, ValueError) as e:
+            logger.error("failed to update %s key. reason:\n%s", name, e)
+            event.fail(f"Failed to update {name} key. See `juju debug-log` for details.")
+            return
+
+        try:
+            self.model.get_secret(label=label).set_content(content)
+        except (ops.SecretNotFoundError, ops.ModelError) as e:
+            logger.error("failed to publish new %s key secret. reason:\n%s", name, e)
+            event.fail(
+                f"Failed to publish new {name} key secret. See `juju debug-log` for details."
+            )
 
 
 if __name__ == "__main__":  # noqa

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -218,7 +218,9 @@ class SlurmctldCharm(ops.CharmBase):
             self.slurmctld.service.stop()
             self.slurmctld.service.disable()
 
-            # Ensure key files in place
+            # Create auth and JWT key Juju Secrets and key files if they do not exist. Use Secret as
+            # source of truth to prevent erroneous overwrites when a new unit is elected application
+            # leader as it is deployed.
             if self.unit.is_leader():
                 for manager, label, name in [
                     (self.slurmctld.jwt, JWT_KEY_LABEL, "JWT"),

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -157,7 +157,7 @@ class SlurmdCharm(ops.CharmBase):
         """Handle when controller data is ready from the `slurmctld` application."""
         data = self.slurmctld.get_controller_data(event.relation.id)
 
-        self.slurmd.key.set(data.auth_key, data.auth_key_id)
+        self.slurmd.key.set({"key": data.auth_key, "keyid": data.auth_key_id})
         self.slurmd.conf_server = data.controllers
 
         # Set default state and reason if this compute node is being added to a Slurm cluster.
@@ -203,21 +203,17 @@ class SlurmdCharm(ops.CharmBase):
             logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
             return
 
-        content = event.secret.get_content(refresh=True)
-        auth_key = content.get("key")
-        auth_key_id = content.get("keyid")
-        if not auth_key or not auth_key_id:
-            logger.error(
-                "auth key or key ID is empty in secret with label '%s'", event.secret.label
-            )
+        try:
+            content = event.secret.get_content(refresh=True)
+            self.slurmd.key.set(content)
+        except (ops.SecretNotFoundError, ops.ModelError, ValueError) as e:
+            logger.error("failed to retrieve auth key contents. reason:\n%s", e)
             event.defer()
             raise StopCharm(
                 ops.BlockedStatus(
                     "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
                 )
             )
-
-        self.slurmd.key.set(auth_key, auth_key_id)
 
         # Necessary to load new key from file into the service
         # FIXME: slurmd reloading is currently broken. Service restart is used as a workaround but

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 import ops
 from charmed_hpc_libs.ops import get_ingress_address
 from charmed_hpc_libs.ops.conditions import StopCharm, block_unless, leader, refresh, wait_unless
+from charmed_slurm_slurmctld_interface import JWT_KEY_LABEL
 from charmed_slurm_slurmdbd_interface import (
     AUTH_KEY_LABEL,
     DatabaseData,
@@ -157,39 +158,40 @@ class SlurmdbdCharm(ops.CharmBase):
         """Handle when controller data is ready from `slurmctld`."""
         data = self.slurmctld.get_controller_data(event.relation.id)
 
-        self.slurmdbd.key.set(data.auth_key, data.auth_key_id)
-        self.slurmdbd.jwt.set(data.jwt_key)
+        self.slurmdbd.key.set({"key": data.auth_key, "keyid": data.auth_key_id})
+        self.slurmdbd.jwt.set({"key": data.jwt_key})
         self._reconfigure()
 
     @refresh
     @block_unless(slurmdbd_installed)
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle when a secret is changed."""
-        if event.secret.label != AUTH_KEY_LABEL:
+        if event.secret.label == AUTH_KEY_LABEL:
+            manager = self.slurmdbd.key
+        elif event.secret.label == JWT_KEY_LABEL:
+            manager = self.slurmdbd.jwt
+        else:
             logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
             return
 
-        content = event.secret.get_content(refresh=True)
-        auth_key = content.get("key")
-        auth_key_id = content.get("keyid")
-        if not auth_key or not auth_key_id:
+        try:
+            content = event.secret.get_content(refresh=True)
+            manager.set(content)
+        except (ops.SecretNotFoundError, ops.ModelError, ValueError) as e:
             logger.error(
-                "auth key or key ID is empty in secret with label '%s'", event.secret.label
+                "failed to retrieve contents from secret '%s'. reason:\n%s", event.secret.label, e
             )
             event.defer()
             raise StopCharm(
-                ops.BlockedStatus(
-                    "Failed to retrieve Slurm authentication key. See `juju debug-log` for details"
-                )
+                ops.BlockedStatus("Failed to retrieve key. See `juju debug-log` for details")
             )
-
-        self.slurmdbd.key.set(auth_key, auth_key_id)
 
         # Other Slurm charms reload the service here. That is not possible for slurmdbd as the
         # SIGHUP reload signal does not reload the key file. Restart instead.
         # TODO: Determine a zero-downtime solution. Consider filing a Slurm bug requesting slurmdbd
         # reloading match the behavior of sackd, slurmctld and slurmd.
         self.slurmdbd.service.restart()
+        logger.info("%s updated successfully", event.secret.label)
 
     @leader
     @refresh

--- a/charms/slurmdbd/src/charm.py
+++ b/charms/slurmdbd/src/charm.py
@@ -167,9 +167,9 @@ class SlurmdbdCharm(ops.CharmBase):
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle when a secret is changed."""
         if event.secret.label == AUTH_KEY_LABEL:
-            manager = self.slurmdbd.key
+            manager, name = self.slurmdbd.key, "auth"
         elif event.secret.label == JWT_KEY_LABEL:
-            manager = self.slurmdbd.jwt
+            manager, name = self.slurmdbd.jwt, "JWT"
         else:
             logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
             return
@@ -183,7 +183,9 @@ class SlurmdbdCharm(ops.CharmBase):
             )
             event.defer()
             raise StopCharm(
-                ops.BlockedStatus("Failed to retrieve key. See `juju debug-log` for details")
+                ops.BlockedStatus(
+                    f"Failed to retrieve {name} key. See `juju debug-log` for details"
+                )
             )
 
         # Other Slurm charms reload the service here. That is not possible for slurmdbd as the

--- a/charms/slurmrestd/src/charm.py
+++ b/charms/slurmrestd/src/charm.py
@@ -95,7 +95,7 @@ class SlurmrestdCharm(ops.CharmBase):
         data = self.slurmctld.get_controller_data(event.relation.id)
 
         try:
-            self.slurmrestd.key.set(data.auth_key, data.auth_key_id)
+            self.slurmrestd.key.set({"key": data.auth_key, "keyid": data.auth_key_id})
             for name, config in data.slurmconfig.items():
                 self.slurmrestd.config.includes[name].dump(config)
             self.slurmrestd.service.enable()
@@ -128,13 +128,11 @@ class SlurmrestdCharm(ops.CharmBase):
             logger.warning("secret with label '%s' changed. ignoring", event.secret.label)
             return
 
-        content = event.secret.get_content(refresh=True)
-        auth_key = content.get("key")
-        auth_key_id = content.get("keyid")
-        if not auth_key or not auth_key_id:
-            logger.error(
-                "auth key or key ID is empty in secret with label '%s'", event.secret.label
-            )
+        try:
+            content = event.secret.get_content(refresh=True)
+            self.slurmrestd.key.set(content)
+        except (ops.SecretNotFoundError, ops.ModelError, ValueError) as e:
+            logger.error("failed to retrieve auth key contents. reason:\n%s", e)
             event.defer()
             raise StopCharm(
                 ops.BlockedStatus(
@@ -142,7 +140,6 @@ class SlurmrestdCharm(ops.CharmBase):
                 )
             )
 
-        self.slurmrestd.key.set(auth_key, auth_key_id)
         # Other Slurm charms reload the service here. That is not possible for slurmrestd as the
         # process shuts down when the reload signal is sent. Restart instead.
         # TODO: Determine a zero-downtime solution

--- a/internal/slurm-ops/src/slurm_ops/__init__.py
+++ b/internal/slurm-ops/src/slurm_ops/__init__.py
@@ -16,6 +16,7 @@
 
 __all__ = [
     # From `core` module
+    "SecretManager",
     "SLURM_GROUP",
     "SLURM_USER",
     "SLURMD_GROUP",
@@ -44,6 +45,7 @@ from .core import (
     SLURMD_USER,
     SLURMRESTD_GROUP,
     SLURMRESTD_USER,
+    SecretManager,
     SlurmOpsError,
 )
 from .sackd import SackdManager

--- a/internal/slurm-ops/src/slurm_ops/core/__init__.py
+++ b/internal/slurm-ops/src/slurm_ops/core/__init__.py
@@ -16,6 +16,7 @@
 
 __all__ = [
     # From `base.py`
+    "SecretManager",
     "SlurmManager",
     # From `config.py`
     "SlurmConfigManager",
@@ -33,7 +34,7 @@ __all__ = [
     "parse_options",
 ]
 
-from .base import SlurmManager
+from .base import SecretManager, SlurmManager
 from .config import SlurmConfigManager
 from .constants import (
     SLURM_GROUP,

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -129,11 +129,11 @@ class SecretManager(Protocol):  # pragma: no cover
         """Generate a new, cryptographically secure secret."""
         raise NotImplementedError
 
-    def set(self, content: dict[str, str]) -> None:
+    def set(self, content: Mapping[str, str]) -> None:
         """Write secret content to the key file, replacing any existing content."""
         raise NotImplementedError
 
-    def apply(self, content: dict[str, str]) -> None:
+    def apply(self, content: Mapping[str, str]) -> None:
         """Apply new secret content to the key file, overwriting or extending existing content."""
         raise NotImplementedError
 
@@ -473,7 +473,7 @@ class _JWTSecretManager(SecretManager):
     """Manage the `jwt_hs256.key` secret file."""
 
     def __init__(self, ops_manager: OpsManager, /, user: str, group: str) -> None:
-        """Initialise the JWT secret manager.
+        """Initialize the JWT secret manager.
 
         Args:
             ops_manager: The operations manager for the Slurm backend.
@@ -488,7 +488,7 @@ class _JWTSecretManager(SecretManager):
         """Generate a new, cryptographically secure `jwt_hs256.key` secret.
 
         Returns:
-            A dict with a single ``"key"`` entry containing the
+            A dictionary with a single ``"key"`` entry containing the
             PEM-encoded RSA private key as a string.
         """
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -511,11 +511,12 @@ class _JWTSecretManager(SecretManager):
         """
         return self._file.read_text()
 
-    def set(self, content: dict[str, str]) -> None:
+    def set(self, content: Mapping[str, str]) -> None:
         """Replace the `jwt_hs256.key` file with the provided key.
 
         Args:
-            content: A dict with a "key" entry containing a PEM-encoded RSA private key string.
+            content: A dictionary with a "key" entry containing a PEM-encoded RSA private key
+            string.
 
         Raises:
             OSError: If the key file cannot be written or its permissions cannot be set.
@@ -538,13 +539,14 @@ class _JWTSecretManager(SecretManager):
             "New Slurm JWT key set",
         )
 
-    def apply(self, content: dict[str, str]) -> None:
+    def apply(self, content: Mapping[str, str]) -> None:
         """Apply new JWT key content to the `jwt_hs256.key` secret file, overwriting existing.
 
         This is equivalent to calling `set`.
 
         Args:
-            content: A dict with a "key" entry containing a PEM-encoded RSA private key string.
+            content: A dictionary with a "key" entry containing a PEM-encoded RSA private key
+            string.
 
         Raises:
             OSError: If the key file cannot be written or its permissions cannot be set.
@@ -561,7 +563,7 @@ class _SlurmSecretManager(SecretManager):
     """Manage the `slurm.jwks` key file."""
 
     def __init__(self, ops_manager: OpsManager, /, user: str, group: str) -> None:
-        """Initialise the Slurm auth key secret manager.
+        """Initialize the Slurm auth key secret manager.
 
         Args:
             ops_manager: The operations manager for the Slurm backend.
@@ -576,8 +578,9 @@ class _SlurmSecretManager(SecretManager):
         """Generate cryptographically secure Slurm auth key data.
 
         Returns:
-            A dict of where the `key` entry is a base64-encoded random byte string suitable for use
-            as a Slurm authentication key, and the `keyid` entry is a unique identifier for the key.
+            A dictionary where the `key` entry is a base64-encoded random byte string suitable for
+            use as a Slurm authentication key, and the `keyid` entry is a unique identifier for the
+            key.
         """
         # Auth key entries must each have a unique ID consistent across all units.
         # Secret revision number cannot be used as it is not known to secret observers.
@@ -589,7 +592,7 @@ class _SlurmSecretManager(SecretManager):
         """Read and validate the `slurm.jwks` key file.
 
         Returns:
-            A dict with a `"keys"` list. Returns `{"keys": []}` if the file does not exist.
+            A dictionary with a `"keys"` list. Returns `{"keys": []}` if the file does not exist.
 
         Raises:
             SlurmOpsError: If the file exists but cannot be read or contains invalid data.
@@ -612,12 +615,12 @@ class _SlurmSecretManager(SecretManager):
 
         return data
 
-    def set(self, content: dict[str, str]) -> None:
+    def set(self, content: Mapping[str, str]) -> None:
         """Replace the `slurm.jwks` key file with a single key entry.
 
         Args:
-            content: A dict containing `key`, the base64-encoded key material to set, and `keyid`, a
-            unique identifier for the key.
+            content: A dictionary containing `key`, the base64-encoded key material to set, and
+            `keyid`, a unique identifier for the key.
 
         Raises:
             ValueError: If `key` or `keyid` is empty.
@@ -632,12 +635,12 @@ class _SlurmSecretManager(SecretManager):
             f"Slurm authentication key set with key ID: {content['keyid']}",
         )
 
-    def apply(self, content: dict[str, str]) -> None:
+    def apply(self, content: Mapping[str, str]) -> None:
         """Append a key to the `slurm.jwks` key file.
 
         Args:
-            content: A dict containing `key`, the base64-encoded key material to add, and `keyid`, a
-            unique identifier for the key.
+            content: A dictionary containing `key`, the base64-encoded key material to add, and
+            `keyid`, a unique identifier for the key.
 
         Raises:
             ValueError: If `key` or `keyid` is empty.

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -629,7 +629,7 @@ class _SlurmSecretManager(SecretManager):
             "INFO",
             "authn_token_created",
             "slurm-auth",
-            f"Slurm authentication key set with key ID: {content["keyid"]}",
+            f"Slurm authentication key set with key ID: {content['keyid']}",
         )
 
     def apply(self, content: dict[str, str]) -> None:
@@ -651,7 +651,7 @@ class _SlurmSecretManager(SecretManager):
             "INFO",
             "authn_token_created",
             "slurm-auth",
-            f"New Slurm authentication key added with key ID: {content["keyid"]}",
+            f"New Slurm authentication key added with key ID: {content['keyid']}",
         )
 
     def keep_latest_key(self) -> None:

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -125,16 +125,16 @@ class OpsManager(Protocol):  # pragma: no cover
 class SecretManager(Protocol):  # pragma: no cover
     """Protocol for defining Slurm secret managers."""
 
-    def get(self) -> str:
-        """Get the contents of the current secret file."""
-        raise NotImplementedError
-
-    def set(self, secret: str) -> None:
-        """Set the contents of the secret file."""
-        raise NotImplementedError
-
-    def generate(self) -> None:
+    def generate(self) -> dict[str, str]:
         """Generate a new, cryptographically secure secret."""
+        raise NotImplementedError
+
+    def set(self, content: dict[str, str]) -> None:
+        """Write secret content to the key file, replacing any existing content."""
+        raise NotImplementedError
+
+    def apply(self, content: dict[str, str]) -> None:
+        """Apply new secret content to the key file, overwriting or extending existing content."""
         raise NotImplementedError
 
     @property
@@ -473,30 +473,83 @@ class _JWTSecretManager(SecretManager):
     """Manage the `jwt_hs256.key` secret file."""
 
     def __init__(self, ops_manager: OpsManager, /, user: str, group: str) -> None:
+        """Initialise the JWT secret manager.
+
+        Args:
+            ops_manager: The operations manager for the Slurm backend.
+            user: The system user that owns the key.
+            group: The system group that owns the key.
+        """
         self._file = ops_manager.etc_path / "jwt_hs256.key"
         self._user = user
         self._group = group
 
+    def generate(self) -> dict[str, str]:
+        """Generate a new, cryptographically secure `jwt_hs256.key` secret.
+
+        Returns:
+            A dict with a single ``"key"`` entry containing the
+            PEM-encoded RSA private key as a string.
+        """
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_bytes = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        return {"key": key_bytes}
+
     def get(self) -> str:
-        """Get the contents of the current `jwt_hs256.key` secret file."""
+        """Get the contents of the current `jwt_hs256.key` secret file.
+
+        Returns:
+            The PEM-encoded RSA private key as a string.
+
+        Raises:
+            FileNotFoundError: If the key file does not exist.
+            OSError: If the key file cannot be read.
+        """
         return self._file.read_text()
 
-    def set(self, secret: str) -> None:
-        """Set the contents of the `jwt_hs256.key` secret file."""
-        self._file.write_text(secret)
+    def set(self, content: dict[str, str]) -> None:
+        """Replace the `jwt_hs256.key` file with the provided key.
+
+        Args:
+            content: A dict with a "key" entry containing a PEM-encoded RSA private key string.
+
+        Raises:
+            OSError: If the key file cannot be written or its permissions cannot be set.
+        """
+        self._file.write_text(content["key"])
         self._file.chmod(0o600)
         shutil.chown(self._file, self._user, self._group)
 
-    def generate(self) -> None:
-        """Generate a new, cryptographically secure `jwt_hs256.key` secret."""
-        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        self.set(
-            key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption(),
-            ).decode()
+        _log_security_event(
+            "INFO",
+            "authn_token_deleted",
+            "slurm-jwt",
+            "Deleted Slurm JWT key",
         )
+
+        _log_security_event(
+            "INFO",
+            "authn_token_created",
+            "slurm-jwt",
+            "New Slurm JWT key set",
+        )
+
+    def apply(self, content: dict[str, str]) -> None:
+        """Apply new JWT key content to the `jwt_hs256.key` secret file, overwriting existing.
+
+        This is equivalent to calling `set`.
+
+        Args:
+            content: A dict with a "key" entry containing a PEM-encoded RSA private key string.
+
+        Raises:
+            OSError: If the key file cannot be written or its permissions cannot be set.
+        """
+        self.set(content)
 
     @property
     def path(self) -> Path:
@@ -504,72 +557,33 @@ class _JWTSecretManager(SecretManager):
         return self._file
 
 
-class _SlurmSecretManager:
+class _SlurmSecretManager(SecretManager):
     """Manage the `slurm.jwks` key file."""
 
     def __init__(self, ops_manager: OpsManager, /, user: str, group: str) -> None:
+        """Initialise the Slurm auth key secret manager.
+
+        Args:
+            ops_manager: The operations manager for the Slurm backend.
+            user: The system user that owns the key.
+            group: The system group that owns the key.
+        """
         self._file = ops_manager.etc_path / "slurm.jwks"
         self._user = user
         self._group = group
 
-    def generate(self) -> tuple[str, str]:
+    def generate(self) -> dict[str, str]:
         """Generate cryptographically secure Slurm auth key data.
 
         Returns:
-            A tuple of `(key, key_id)` where `key` is a base64-encoded random byte string suitable
-            for use as a Slurm authentication key, and `key_id` is a unique identifier for the key.
+            A dict of where the `key` entry is a base64-encoded random byte string suitable for use
+            as a Slurm authentication key, and the `keyid` entry is a unique identifier for the key.
         """
         # Auth key entries must each have a unique ID consistent across all units.
         # Secret revision number cannot be used as it is not known to secret observers.
         # Secret `unique_identifier` property is not unique per revision.
         # Therefore, a newly generated UUID is included with the secret contents.
-        return base64.b64encode(secrets.token_bytes(2048)).decode(), str(uuid4())
-
-    def add(self, key: str, key_id: str) -> None:
-        """Append a key to the `slurm.jwks` key file.
-
-        Args:
-            key: The base64-encoded key material to add.
-            key_id: A unique identifier for the key.
-
-        Raises:
-            ValueError: If `key` or `key_id` is empty.
-        """
-        new_entry = self._build_new_entry(key, key_id)
-        data = self.get()
-        data["keys"].append(new_entry)
-        self._write(data)
-
-        _log_security_event(
-            "INFO",
-            "authn_token_created",
-            "slurm-auth",
-            f"New Slurm authentication key added with key ID: {key_id}",
-        )
-
-    def keep_latest_key(self) -> None:
-        """Preserve only the most recently added key in the `slurm.jwks` key file.
-
-        Removes all previously added keys, keeping only the last entry.
-
-        Raises:
-            SlurmOpsError: If the key file contains no keys.
-        """
-        data = self.get()
-        if not data["keys"]:
-            raise SlurmOpsError("No keys found in slurm.jwks")
-
-        # Most recently added key is last in list
-        last_entry = data["keys"][-1]
-        removed_key_ids = [entry["kid"] for entry in data["keys"][:-1]]
-        self._write({"keys": [last_entry]})
-
-        _log_security_event(
-            "INFO",
-            "authn_token_deleted",
-            "slurm-auth",
-            f"Deleted Slurm authentication key IDs: {removed_key_ids}. Current key ID: {last_entry['kid']}",
-        )
+        return {"key": base64.b64encode(secrets.token_bytes(2048)).decode(), "keyid": str(uuid4())}
 
     def get(self) -> dict[str, list[dict[str, str]]]:
         """Read and validate the `slurm.jwks` key file.
@@ -598,24 +612,70 @@ class _SlurmSecretManager:
 
         return data
 
-    def set(self, key: str, key_id: str) -> None:
+    def set(self, content: dict[str, str]) -> None:
         """Replace the `slurm.jwks` key file with a single key entry.
 
         Args:
-            key: The base64-encoded key material to set.
-            key_id: A unique identifier for the key.
+            content: A dict containing `key`, the base64-encoded key material to set, and `keyid`, a
+            unique identifier for the key.
 
         Raises:
-            ValueError: If `key` or `key_id` is empty.
+            ValueError: If `key` or `keyid` is empty.
         """
-        new_entry = self._build_new_entry(key, key_id)
+        new_entry = self._build_new_entry(content["key"], content["keyid"])
         self._write({"keys": [new_entry]})
 
         _log_security_event(
             "INFO",
             "authn_token_created",
             "slurm-auth",
-            f"Slurm authentication key set with key ID: {key_id}",
+            f"Slurm authentication key set with key ID: {content["keyid"]}",
+        )
+
+    def apply(self, content: dict[str, str]) -> None:
+        """Append a key to the `slurm.jwks` key file.
+
+        Args:
+            content: A dict containing `key`, the base64-encoded key material to add, and `keyid`, a
+            unique identifier for the key.
+
+        Raises:
+            ValueError: If `key` or `keyid` is empty.
+        """
+        new_entry = self._build_new_entry(content["key"], content["keyid"])
+        data = self.get()
+        data["keys"].append(new_entry)
+        self._write(data)
+
+        _log_security_event(
+            "INFO",
+            "authn_token_created",
+            "slurm-auth",
+            f"New Slurm authentication key added with key ID: {content["keyid"]}",
+        )
+
+    def keep_latest_key(self) -> None:
+        """Preserve only the most recently added key in the `slurm.jwks` key file.
+
+        Removes all previously added keys, keeping only the last entry.
+
+        Raises:
+            SlurmOpsError: If the key file contains no keys.
+        """
+        data = self.get()
+        if not data["keys"]:
+            raise SlurmOpsError("No keys found in slurm.jwks")
+
+        # Most recently added key is last in list
+        last_entry = data["keys"][-1]
+        removed_keyids = [entry["kid"] for entry in data["keys"][:-1]]
+        self._write({"keys": [last_entry]})
+
+        _log_security_event(
+            "INFO",
+            "authn_token_deleted",
+            "slurm-auth",
+            f"Deleted Slurm authentication key IDs: {removed_keyids}. Current key ID: {last_entry['kid']}",
         )
 
     @property
@@ -634,19 +694,19 @@ class _SlurmSecretManager:
         shutil.chown(self._file, self._user, self._group)
 
     @staticmethod
-    def _build_new_entry(key: str, key_id: str) -> dict[str, str]:
+    def _build_new_entry(key: str, keyid: str) -> dict[str, str]:
         """Build a new key entry for the `slurm.jwks` key file.
 
         Args:
             key: The base64-encoded key material.
-            key_id: A unique identifier for the key.
+            keyid: A unique identifier for the key.
 
         Returns:
             A dictionary representing a JWK entry with `alg`, `kty`, `kid`, and `k` fields,
             as described in the Slurm authentication documentation.
 
         Raises:
-            ValueError: If `key` or `key_id` is empty.
+            ValueError: If `key` or `keyid` is empty.
 
         See Also:
             The format of the key entry is defined in the Slurm documentation:
@@ -654,12 +714,12 @@ class _SlurmSecretManager:
         """
         if not key:
             raise ValueError("Empty key provided")
-        if not key_id:
+        if not keyid:
             raise ValueError("Empty key ID provided")
         return {
             "alg": "HS256",
             "kty": "oct",
-            "kid": key_id,
+            "kid": keyid,
             "k": key,
         }
 

--- a/internal/slurm-ops/tests/unit/test_managers.py
+++ b/internal/slurm-ops/tests/unit/test_managers.py
@@ -178,13 +178,13 @@ class TestManager:
 
     # Test auth key component.
 
-    def test_add_slurm_key(self, mock_slurm_key) -> None:
-        """Test the `<manager>.key.add(...)` method appends a new key."""
+    def test_apply_slurm_key(self, mock_slurm_key) -> None:
+        """Test the `<manager>.key.apply(...)` method appends a new key."""
         new_key = "xyz123=="
         new_key_id = "abcdef12-3456-7890-abcd-ef1234567890"
         new_key_entry = {"alg": "HS256", "kty": "oct", "kid": new_key_id, "k": new_key}
 
-        mock_slurm_key.key.add(new_key, new_key_id)
+        mock_slurm_key.key.apply({"key": new_key, "keyid": new_key_id})
 
         file_contents = json.loads(mock_slurm_key.key.path.read_text())
         assert len(file_contents["keys"]) == 2
@@ -199,7 +199,7 @@ class TestManager:
             "keys": [{"alg": "HS256", "kty": "oct", "kid": new_key_id, "k": new_key}]
         }
 
-        mock_slurm_key.key.add(new_key, new_key_id)
+        mock_slurm_key.key.apply({"key": new_key, "keyid": new_key_id})
         mock_slurm_key.key.keep_latest_key()
 
         file_contents = json.loads(mock_slurm_key.key.path.read_text())
@@ -213,7 +213,7 @@ class TestManager:
             "keys": [{"alg": "HS256", "kty": "oct", "kid": new_key_id, "k": new_key}]
         }
 
-        mock_slurm_key.key.set(new_key, new_key_id)
+        mock_slurm_key.key.set({"key": new_key, "keyid": new_key_id})
 
         file_contents = json.loads(mock_slurm_key.key.path.read_text())
         assert file_contents == new_key_contents
@@ -221,14 +221,14 @@ class TestManager:
     def test_generate_slurm_valid_key(self, mock_slurm_key) -> None:
         """Test the `<manager>.key.generate()` method produces valid keys."""
         # Verify it can be decoded back from Base64
-        key, _ = mock_slurm_key.key.generate()
-        decoded = base64.b64decode(key)
+        key_dict = mock_slurm_key.key.generate()
+        decoded = base64.b64decode(key_dict["key"])
         assert len(decoded) == 2048
 
     def test_generate_slurm_key_is_unique(self, mock_slurm_key) -> None:
         """Test the `<manager>.key.generate()` method produces unique keys."""
         # Statistically, two keys should never be identical
-        assert mock_slurm_key.key.generate()[0] != mock_slurm_key.key.generate()[0]
+        assert mock_slurm_key.key.generate() != mock_slurm_key.key.generate()
 
     # Test `<manager>.jwt` component.
 
@@ -238,13 +238,14 @@ class TestManager:
 
     def test_set_jwt_key(self, mock_jwt_key) -> None:
         """Test the `<manager>.jwt.set(...)` method."""
-        mock_jwt_key.jwt.set(JWT_KEY)
+        mock_jwt_key.jwt.set({"key": JWT_KEY})
         assert mock_jwt_key.jwt.get() == JWT_KEY
 
     def test_generate_jwt_key(self, mock_jwt_key) -> None:
         """Test the `<manager>.jwt.generate()` method."""
-        mock_jwt_key.jwt.generate()
-        assert mock_jwt_key.jwt.get() != JWT_KEY
+        key_dict = mock_jwt_key.jwt.generate()
+        mock_jwt_key.jwt.set(key_dict)
+        assert mock_jwt_key.jwt.get() == key_dict["key"]
 
     # Test manager properties.
 

--- a/internal/slurmdbd-interface/src/charmed_slurm_slurmdbd_interface/__init__.py
+++ b/internal/slurmdbd-interface/src/charmed_slurm_slurmdbd_interface/__init__.py
@@ -17,6 +17,7 @@
 __all__ = [
     "AUTH_KEY_LABEL",
     "DatabaseData",
+    "JWT_KEY_LABEL",
     "SlurmdbdConnectedEvent",
     "SlurmdbdReadyEvent",
     "SlurmdbdDisconnectedEvent",
@@ -33,6 +34,7 @@ import ops
 from charmed_hpc_libs.ops.conditions import ConditionEvaluation, leader
 from charmed_slurm_slurmctld_interface import (
     AUTH_KEY_LABEL,
+    JWT_KEY_LABEL,
     SlurmctldProvider,
     SlurmctldReadyEvent,
     SlurmctldRequirer,
@@ -101,7 +103,7 @@ class SlurmdbdProvider(SlurmctldRequirer):
 
     def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
         super().__init__(
-            charm, integration_name, required_app_data={"auth_secret_id", "jwt_key_id"}
+            charm, integration_name, required_app_data={"auth_secret_id", "jwt_secret_id"}
         )
 
     @leader

--- a/internal/slurmdbd-interface/tests/unit/test_slurmdbd.py
+++ b/internal/slurmdbd-interface/tests/unit/test_slurmdbd.py
@@ -27,6 +27,7 @@ from charmed_slurm_slurmctld_interface import (
 )
 from charmed_slurm_slurmdbd_interface import (
     AUTH_KEY_LABEL,
+    JWT_KEY_LABEL,
     DatabaseData,
     SlurmctldReadyEvent,
     SlurmdbdConnectedEvent,
@@ -106,10 +107,12 @@ class MockSlurmdbdRequirerCharm(ops.CharmBase):
         auth_key_secret = self.app.add_secret(
             {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
         )
+        jwt_key_secret = self.app.add_secret({"key": EXAMPLE_JWT_KEY}, label=JWT_KEY_LABEL)
+
         self.slurmdbd.set_controller_data(
             ControllerData(
                 auth_secret_id=auth_key_secret.get_info().id,
-                jwt_key=EXAMPLE_JWT_KEY,
+                jwt_secret_id=jwt_key_secret.get_info().id,
             ),
             integration_id=event.relation.id,
         )
@@ -195,7 +198,9 @@ class TestSlurmdbdInterface:
     )
     def test_provider_on_slurmctld_ready_event(self, provider_ctx, leader, ready) -> None:
         """Test that the `slurmdbd` provider waits for controller data."""
-        auth_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_AUTH_KEY})
+        auth_key_secret = testing.Secret(
+            tracked_content={"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}
+        )
         jwt_key_secret = testing.Secret(tracked_content={"key": EXAMPLE_JWT_KEY})
 
         slurmdbd_integration_id = 1
@@ -203,15 +208,13 @@ class TestSlurmdbdInterface:
             endpoint=SLURMDBD_INTEGRATION_NAME,
             interface="slurmdbd",
             id=slurmdbd_integration_id,
-            remote_app_name="slurmdbd-requirer",
             remote_app_data=(
                 {
                     "auth_secret_id": json.dumps(auth_key_secret.id),
-                    "jwt_key": '"***"',
-                    "jwt_key_id": json.dumps(jwt_key_secret.id),
+                    "jwt_secret_id": json.dumps(jwt_key_secret.id),
                 }
                 if ready
-                else {"auth_secret_id": '""', "jwt_key": '"***"'}
+                else {"dummy": "data"}  # just empty set {} results in inconsistent scenario
             ),
         )
 
@@ -306,11 +309,8 @@ class TestSlurmdbdInterface:
             # Assert that `auth_secret_id` is set to the `auth_key` secret URI.
             assert integration.local_app_data["auth_secret_id"] != '""'
 
-            # Assert `jwt_key` is redacted in the integration data.
-            assert integration.local_app_data["jwt_key"] == '"***"'
-
-            # Assert that `jwt_key_id` is set to the `jwt_key` secret URI.
-            assert integration.local_app_data["jwt_key_id"] != '""'
+            # Assert that `jwt_secret_id` is set to the `jwt_key` secret URI.
+            assert integration.local_app_data["jwt_secret_id"] != '""'
 
             # Assert that `SlurmdbdConnectedEvent` was emitted only once.
             occurred = defaultdict(lambda: 0)

--- a/internal/slurmdbd-interface/tests/unit/test_slurmdbd.py
+++ b/internal/slurmdbd-interface/tests/unit/test_slurmdbd.py
@@ -214,7 +214,7 @@ class TestSlurmdbdInterface:
                     "jwt_secret_id": json.dumps(jwt_key_secret.id),
                 }
                 if ready
-                else {"dummy": "data"}  # just empty set {} results in inconsistent scenario
+                else {"test": "data"}  # just empty set {} results in inconsistent scenario
             ),
         )
 

--- a/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
+++ b/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
@@ -16,6 +16,7 @@
 
 __all__ = [
     "AUTH_KEY_LABEL",
+    "JWT_KEY_LABEL",
     "ControllerData",
     "SlurmctldConnectedEvent",
     "SlurmctldDisconnectedEvent",
@@ -30,19 +31,18 @@ import json
 import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from string import Template
 from typing import Any
 
 import ops
 from charmed_hpc_libs.interfaces import Interface
-from charmed_hpc_libs.ops import ConditionEvaluation, leader, load_secret, update_secret
+from charmed_hpc_libs.ops import ConditionEvaluation, leader
 from slurmutils import Model, SlurmConfig
 
 _logger = logging.getLogger(__name__)
 
-# Label for the Juju secret storing the Slurm auth key. Used by multiple Slurm services
+# Labels for the Juju secret storing the Slurm auth and JWT keys. Used by multiple Slurm services
 AUTH_KEY_LABEL = "slurm-auth-key"
-JWT_KEY_TEMPLATE_LABEL = Template("integration-$id-jwt-key-secret")
+JWT_KEY_LABEL = "slurm-jwt-key"
 
 
 class _SlurmJSONEncoder(json.JSONEncoder):
@@ -73,13 +73,13 @@ class ControllerData:
             for contacting the `slurmctld` application. The first entry in the list is the
             primary `slurmctld` service. Other entries are failovers.
         jwt_key: Base64-encoded string representing the Slurm JWT key.
-        jwt_key_id: ID of the Slurm JWT key Juju secret for this integration instance.
+        jwt_secret_id: ID of the Slurm JWT key Juju secret for this integration instance.
         slurmconfig: Mapping containing the `slurm.conf` and other included configuration files.
 
     Notes:
         - `sackd` requires:         `auth_secret_id`, `controllers`
         - `slurmd` requires:        `auth_secret_id`, `controllers`
-        - `slurmdbd` requires:      `auth_secret_id`, `jwt_key_id`
+        - `slurmdbd` requires:      `auth_secret_id`, `jwt_secret_id`
         - `slurmrestd` requires:    `auth_secret_id`, `slurmconfig`
     """
 
@@ -88,7 +88,7 @@ class ControllerData:
     auth_secret_id: str = ""
     controllers: list[str] = field(default_factory=list)
     jwt_key: str = ""
-    jwt_key_id: str = ""
+    jwt_secret_id: str = ""
     slurmconfig: dict[str, SlurmConfig] = field(default_factory=dict)
 
     def __post_init__(self) -> None:  # noqa D105
@@ -169,14 +169,6 @@ class SlurmctldProvider(Interface):
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Revoke the departing application's access to Slurm secrets."""
-        if self._stored.unit_departing:
-            return
-
-        if jwt_secret := load_secret(
-            self.charm,
-            label=JWT_KEY_TEMPLATE_LABEL.substitute(id=event.relation.id),
-        ):
-            jwt_secret.remove_all_revisions()
 
     @leader
     def set_controller_data(
@@ -198,17 +190,9 @@ class SlurmctldProvider(Interface):
                 secret = self.model.get_secret(id=data.auth_secret_id)
                 secret.grant(integration)
 
-            if data.jwt_key:
-                secret = update_secret(
-                    self.charm,
-                    JWT_KEY_TEMPLATE_LABEL.substitute(id=integration_id),
-                    {"key": data.jwt_key},
-                )
+            if data.jwt_secret_id:
+                secret = self.model.get_secret(id=data.jwt_secret_id)
                 secret.grant(integration)
-                object.__setattr__(data, "jwt_key_id", secret.id)
-
-        # Redact secrets. "***" indicates that an interface did not unlock a secret.
-        object.__setattr__(data, "jwt_key", "***")
 
         self._save_integration_data(data, self.app, integration_id, encoder=encoder)
 
@@ -284,8 +268,8 @@ class SlurmctldRequirer(Interface):
             auth_key = self.charm.model.get_secret(id=data.auth_secret_id, label=AUTH_KEY_LABEL)
             object.__setattr__(data, "auth_key", auth_key.get_content().get("key"))
             object.__setattr__(data, "auth_key_id", auth_key.get_content().get("keyid"))
-        if data.jwt_key_id:
-            jwt_key = self.charm.model.get_secret(id=data.jwt_key_id)
+        if data.jwt_secret_id:
+            jwt_key = self.charm.model.get_secret(id=data.jwt_secret_id, label=JWT_KEY_LABEL)
             object.__setattr__(data, "jwt_key", jwt_key.get_content().get("key"))
 
         return data

--- a/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
+++ b/pkg/slurmctld-interface/src/charmed_slurm_slurmctld_interface/__init__.py
@@ -72,7 +72,7 @@ class ControllerData:
             List of controller addresses for that can be used by Slurm services
             for contacting the `slurmctld` application. The first entry in the list is the
             primary `slurmctld` service. Other entries are failovers.
-        jwt_key: Base64-encoded string representing the Slurm JWT key.
+        jwt_key: String containing the Slurm JWT key material, often a PEM block.
         jwt_secret_id: ID of the Slurm JWT key Juju secret for this integration instance.
         slurmconfig: Mapping containing the `slurm.conf` and other included configuration files.
 

--- a/pkg/slurmctld-interface/tests/unit/test_slurmctld.py
+++ b/pkg/slurmctld-interface/tests/unit/test_slurmctld.py
@@ -22,6 +22,7 @@ import pytest
 from charmed_hpc_libs.ops.conditions import refresh, wait_unless
 from charmed_slurm_slurmctld_interface import (
     AUTH_KEY_LABEL,
+    JWT_KEY_LABEL,
     ControllerData,
     SlurmctldConnectedEvent,
     SlurmctldDisconnectedEvent,
@@ -66,10 +67,11 @@ class MockSlurmctldProviderCharm(ops.CharmBase):
         auth_key_secret = self.app.add_secret(
             {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID}, label=AUTH_KEY_LABEL
         )
+        jwt_key_secret = self.app.add_secret({"key": EXAMPLE_JWT_KEY}, label=JWT_KEY_LABEL)
         self.slurmctld.set_controller_data(
             ControllerData(
                 auth_secret_id=auth_key_secret.get_info().id,
-                jwt_key=EXAMPLE_JWT_KEY,
+                jwt_secret_id=jwt_key_secret.get_info().id,
                 controllers=EXAMPLE_CONTROLLERS,
                 slurmconfig=EXAMPLE_SLURM_CONFIG,
             ),
@@ -162,12 +164,9 @@ class TestSlurmctldInterface:
 
         integration = state.get_relation(slurmctld_integration_id)
         if leader:
-            # Verify jwt_key is redacted in the integration data.
-            assert integration.local_app_data["jwt_key"] == '"***"'
-
             # Verify that secret IDs have been set (non-empty).
             assert integration.local_app_data["auth_secret_id"] != '""'
-            assert integration.local_app_data["jwt_key_id"] != '""'
+            assert integration.local_app_data["jwt_secret_id"] != '""'
 
             # Verify controllers and slurmconfig are set correctly.
             assert json.loads(integration.local_app_data["controllers"]) == EXAMPLE_CONTROLLERS
@@ -179,15 +178,13 @@ class TestSlurmctldInterface:
     @pytest.mark.parametrize(
         "auth_key,jwt_key",
         (
-            pytest.param(True, "", id="auth-key-only"),
-            pytest.param(False, EXAMPLE_JWT_KEY, id="jwt-key-only"),
-            pytest.param(True, EXAMPLE_JWT_KEY, id="both-keys"),
-            pytest.param(False, "", id="no-keys"),
+            pytest.param(True, False, id="auth-key-only"),
+            pytest.param(False, True, id="jwt-key-only"),
+            pytest.param(True, True, id="both-keys"),
+            pytest.param(False, False, id="no-keys"),
         ),
     )
-    def test_provider_set_controller_data_secret_handling(
-        self, provider_ctx, leader, auth_key, jwt_key
-    ) -> None:
+    def test_provider_set_controller_data_secret_handling(self, leader, auth_key, jwt_key) -> None:
         """Test that `set_controller_data` correctly creates secrets only for non-empty keys."""
         slurmctld_integration_id = 1
         slurmctld_integration = testing.Relation(
@@ -212,15 +209,21 @@ class TestSlurmctldInterface:
                     return
 
                 auth_secret_id = ""
+                jwt_secret_id = ""
                 if auth_key:
                     auth_key_secret = self.app.add_secret(
                         {"key": EXAMPLE_AUTH_KEY, "keyid": EXAMPLE_AUTH_KEY_ID},
                         label=AUTH_KEY_LABEL,
                     )
                     auth_secret_id = auth_key_secret.get_info().id
+                if jwt_key:
+                    jwt_key_secret = self.app.add_secret(
+                        {"key": EXAMPLE_JWT_KEY}, label=JWT_KEY_LABEL
+                    )
+                    jwt_secret_id = jwt_key_secret.get_info().id
 
                 self.slurmctld.set_controller_data(
-                    ControllerData(auth_secret_id=auth_secret_id, jwt_key=jwt_key),
+                    ControllerData(auth_secret_id=auth_secret_id, jwt_secret_id=jwt_secret_id),
                     integration_id=event.relation.id,
                 )
 
@@ -240,9 +243,6 @@ class TestSlurmctldInterface:
         if leader:
             integration = state.get_relation(slurmctld_integration_id)
 
-            # jwt_key is always redacted after set_controller_data.
-            assert integration.local_app_data["jwt_key"] == '"***"'
-
             # Secret IDs are set only when the key was non-empty.
             if auth_key:
                 assert integration.local_app_data["auth_secret_id"] != '""'
@@ -250,49 +250,9 @@ class TestSlurmctldInterface:
                 assert integration.local_app_data["auth_secret_id"] == '""'
 
             if jwt_key:
-                assert integration.local_app_data["jwt_key_id"] != '""'
+                assert integration.local_app_data["jwt_secret_id"] != '""'
             else:
-                assert integration.local_app_data["jwt_key_id"] == '""'
-
-    def test_provider_on_relation_broken_revokes_secrets(self, provider_ctx, leader) -> None:
-        """Test that the `slurmctld` provider revokes secrets when a relation is broken."""
-        auth_key_secret = testing.Secret(
-            tracked_content={"key": EXAMPLE_AUTH_KEY},
-            label="integration-1-auth-key-secret",
-            owner="app",
-        )
-        jwt_key_secret = testing.Secret(
-            tracked_content={"key": EXAMPLE_JWT_KEY},
-            label="integration-1-jwt-key-secret",
-            owner="app",
-        )
-
-        slurmctld_integration_id = 1
-        slurmctld_integration = testing.Relation(
-            endpoint=SLURMCTLD_INTEGRATION_NAME,
-            interface="slurmctld",
-            id=slurmctld_integration_id,
-            remote_app_name="slurmctld-requirer",
-            local_app_data={
-                "auth_key": '"***"',
-                "auth_key_id": json.dumps(auth_key_secret.id),
-                "jwt_key": '"***"',
-                "jwt_key_id": json.dumps(jwt_key_secret.id),
-            },
-        )
-
-        state = provider_ctx.run(
-            provider_ctx.on.relation_broken(slurmctld_integration),
-            testing.State(
-                leader=leader,
-                relations={slurmctld_integration},
-                secrets={auth_key_secret, jwt_key_secret},
-            ),
-        )
-
-        if leader:
-            # Only JWT secret should be removed by the leader.
-            assert jwt_key_secret.id not in {s.id for s in state.secrets}
+                assert integration.local_app_data["jwt_secret_id"] == '""'
 
     # Test requirer-side of the `slurmctld` interface.
 
@@ -342,10 +302,8 @@ class TestSlurmctldInterface:
             # When ready, populate with all required fields; when not ready, leave app data empty.
             remote_app_data=(
                 {
-                    "auth_key": '"***"',
                     "auth_secret_id": json.dumps(auth_key_secret.id),
-                    "jwt_key": '"***"',
-                    "jwt_key_id": json.dumps(jwt_key_secret.id),
+                    "jwt_secret_id": json.dumps(jwt_key_secret.id),
                     "controllers": json.dumps(EXAMPLE_CONTROLLERS),
                 }
                 if ready
@@ -420,8 +378,8 @@ class TestSlurmctldInterface:
             remote_app_data={
                 "auth_key": '""',
                 "auth_secret_id": json.dumps(auth_key_secret.id),
-                "jwt_key": '"***"',
-                "jwt_key_id": json.dumps(jwt_key_secret.id),
+                "jwt_key": '""',
+                "jwt_secret_id": json.dumps(jwt_key_secret.id),
                 "controllers": json.dumps(EXAMPLE_CONTROLLERS),
                 "slurmconfig": json.dumps({k: v.dict() for k, v in EXAMPLE_SLURM_CONFIG.items()}),
             },

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -242,7 +242,7 @@ def test_rotate_auth_key(juju: jubilant.Juju) -> None:
 
     logger.info("testing that the `rotate-auth-key` action updates the Slurm authentication key")
 
-    # Gather existing authentication key from `slurmctld/0`.
+    # Gather existing authentication key from controller unit.
     result = juju.exec("sudo cat /etc/slurm/slurm.jwks", unit=slurmctld_unit)
     initial_key_entry = json.loads(result.stdout)
 
@@ -283,12 +283,118 @@ def test_rotate_auth_key(juju: jubilant.Juju) -> None:
             # Check units can communicate with controller
             assert juju.exec("sinfo", unit=sackd_unit).success
             assert juju.exec("sinfo", unit=slurmd_unit).success
-            # Database does not have client tools installed. Query from the controller
+            # Database and API do not have client tools installed. Query from the controller
             assert juju.exec("sacct", unit=slurmctld_unit).success
-            # TODO: confirm slurmrestd connectivity
+            assert juju.exec("scontrol token", unit=slurmctld_unit).success
+
+
+def _api_get(juju: jubilant.Juju, unit: str, token: str, url: str) -> tuple[str, str]:
+    """Execute an authenticated GET against the Slurm REST API and return (status_code, body)."""
+    result = juju.exec(
+        f"export '{token}';"
+        f" curl --silent --show-error"
+        f" --write-out '\nHTTP_RESPONSE_CODE:%{{http_code}}'"
+        f" --header X-SLURM-USER-TOKEN:$SLURM_JWT"
+        f" --request GET '{url}'",
+        unit=unit,
+    )
+    assert (
+        "HTTP_RESPONSE_CODE:" in result.stdout
+    ), f"no status code in response, stdout: {result.stdout} stderr: {result.stderr}"
+    body, status_line = result.stdout.strip().rsplit("HTTP_RESPONSE_CODE:", 1)
+    return status_line.strip(), body
 
 
 @pytest.mark.order(11)
+def test_rotate_jwt_key(juju: jubilant.Juju) -> None:
+    """Test that the `rotate-jwt-key` action updates the Slurm JSON Web Token key across the cluster."""
+    slurmctld_unit = f"{SLURMCTLD_APP_NAME}/0"
+    slurmdbd_unit = f"{SLURMDBD_APP_NAME}/0"
+    slurmrestd_unit = f"{SLURMRESTD_APP_NAME}/0"
+    query_endpoint = "openapi"
+
+    logger.info("testing that the `rotate-jwt-key` action updates the JSON Web Token key")
+
+    # Confirm existing key on controller and database identical and functional before rotation.
+    cat_cmd = "sudo cat /etc/slurm/jwt_hs256.key"
+    initial_key_controller = juju.exec(cat_cmd, unit=slurmctld_unit).stdout
+    initial_key_database = juju.exec(cat_cmd, unit=slurmdbd_unit).stdout
+    assert (
+        initial_key_controller == initial_key_database
+    ), "initial JWT key on controller and database differ"
+
+    # Use sudo to generate token to ensure access to all API endpoints.
+    initial_token = juju.exec(
+        "sudo scontrol token lifespan=infinite", unit=slurmctld_unit
+    ).stdout.strip()
+
+    # Query for list of all API endpoints.
+    address = juju.status().apps[SLURMRESTD_APP_NAME].units[slurmrestd_unit].public_address
+    base_url = f"http://{address}:6820"
+    status_code, body = _api_get(
+        juju, slurmctld_unit, initial_token, f"{base_url}/{query_endpoint}"
+    )
+    assert status_code == "200", f"failed to query API with initial JWT key, got body: {body}"
+    endpoints = json.loads(body)
+    assert "paths" in endpoints, f"initial API response missing 'paths', got: {body}"
+
+    # Find slurm and slurmdbd diagnostic endpoints.
+    # Example: "/slurm/v0.0.41/diag/" and "/slurmdb/v0.0.41/diag/".
+    all_paths = endpoints["paths"].keys()
+    slurm_diag = next(
+        (p for p in all_paths if p.startswith("/slurm/") and p.endswith("/diag/")), None
+    )
+    slurmdb_diag = next(
+        (p for p in all_paths if p.startswith("/slurmdb/") and p.endswith("/diag/")), None
+    )
+    assert slurm_diag is not None, "failed to find slurm diagnostic endpoint"
+    assert slurmdb_diag is not None, "failed to find slurmdb diagnostic endpoint"
+
+    # Query diagnostic endpoints to confirm initial token validity.
+    diag_urls = [f"{base_url}{slurm_diag}", f"{base_url}{slurmdb_diag}"]
+    for url in diag_urls:
+        status_code, body = _api_get(juju, slurmctld_unit, initial_token, url)
+        assert status_code == "200", f"initial JWT key not functional at {url}, got body: {body}"
+
+    juju.run(slurmctld_unit, "rotate-jwt-key")
+
+    # Wait for action to complete and for all Slurm applications to return to ActiveStatus.
+    juju.wait(
+        lambda status: jubilant.all_active(status, *SLURM_APPS),
+        error=lambda status: jubilant.any_error(status, *SLURM_APPS),
+    )
+
+    # Poll until old key removed and new key present.
+    attempts = tenacity.Retrying(
+        wait=tenacity.wait.wait_exponential(multiplier=2, min=1),
+        stop=tenacity.stop_after_attempt(5),
+        reraise=True,
+    )
+    for attempt in attempts:
+        with attempt:
+            new_key_controller = juju.exec(cat_cmd, unit=slurmctld_unit).stdout
+            new_key_database = juju.exec(cat_cmd, unit=slurmdbd_unit).stdout
+            assert (
+                new_key_controller != initial_key_controller
+            ), "JWT key not rotated on controller"
+            assert (
+                new_key_controller == new_key_database
+            ), "JWT key on controller and database differ after rotation"
+
+    # Check old token no longer functional after rotation.
+    status_code, _ = _api_get(juju, slurmctld_unit, initial_token, diag_urls[0])
+    assert status_code != "200", f"old token still valid after rotation (HTTP {status_code})"
+
+    # Check new key functional.
+    new_token = juju.exec(
+        "sudo scontrol token lifespan=infinite", unit=slurmctld_unit
+    ).stdout.strip()
+    for url in diag_urls:
+        status_code, body = _api_get(juju, slurmctld_unit, new_token, url)
+        assert status_code == "200", f"new JWT key not functional at {url}, got body: {body}"
+
+
+@pytest.mark.order(12)
 def test_job_submission(juju: jubilant.Juju) -> None:
     """Test that a job can be successfully submitted to the Slurm cluster."""
     sackd_unit = f"{SACKD_APP_NAME}/0"
@@ -302,7 +408,7 @@ def test_job_submission(juju: jubilant.Juju) -> None:
     assert sackd_result.stdout == slurmd_result.stdout
 
 
-@pytest.mark.order(12)
+@pytest.mark.order(13)
 def test_gpu_job_submission(juju: jubilant.Juju) -> None:
     """Test that a job requesting a GPU can be successfully submitted to the Slurm cluster.
 

--- a/uv.lock
+++ b/uv.lock
@@ -141,11 +141,11 @@ wheels = [
 
 [[package]]
 name = "charmed-hpc-libs"
-version = "0.1.1"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/ea/355cdfe22f565a701ea60e78dfc59a2328e0d38e43aff8ad9a9aaa02fdb8/charmed_hpc_libs-0.1.1.tar.gz", hash = "sha256:4e55da36f3b3cf3ca32200b2f0198904d0772d8a5394b692bee338c8aa447131", size = 46586, upload-time = "2026-04-08T17:47:38.097Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e1/279750719ae505b969bb604aadd844d05212e5c4ddfef585cfa8e0131e1f/charmed_hpc_libs-0.1.2.tar.gz", hash = "sha256:f86603696d7ca52182073b00d42b6b8d66ea1ce864155aeb6670e6a9481cd415", size = 47026, upload-time = "2026-04-17T14:06:25.893Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/44/e6585173ba2d092504f8ecb5ca8906061d834e2e1fcf700bafc2b2aac0a0/charmed_hpc_libs-0.1.1-py3-none-any.whl", hash = "sha256:3b1124000c602f1287706be5829cd487c23dba46e6ac0b6186c48e50f5a78fa6", size = 24289, upload-time = "2026-04-08T17:47:39.326Z" },
+    { url = "https://files.pythonhosted.org/packages/30/9e/9ceda5fbc3b3459d1687a7756594962fa40df6676bd8252b60109711712b/charmed_hpc_libs-0.1.2-py3-none-any.whl", hash = "sha256:546d01e6b23a0be97393fdd43d5fb72f175d3e36d635629aa3854c436ec488a4", size = 24473, upload-time = "2026-04-17T14:06:26.884Z" },
 ]
 
 [package.optional-dependencies]
@@ -755,11 +755,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]
@@ -843,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.13.0"
+version = "2.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -851,39 +851,39 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/6b/69fd5c7194b21ebde0f8637e2a4ddc766ada29d472bfa6a5ca533d79549a/pydantic-2.13.0.tar.gz", hash = "sha256:b89b575b6e670ebf6e7448c01b41b244f471edd276cd0b6fe02e7e7aca320070", size = 843468, upload-time = "2026-04-13T10:51:35.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/e5/06d23afac9973109d1e3c8ad38e1547a12e860610e327c05ee686827dc37/pydantic-2.13.2.tar.gz", hash = "sha256:b418196607e61081c3226dcd4f0672f2a194828abb9109e9cfb84026564df2d1", size = 843836, upload-time = "2026-04-17T09:31:59.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/d7/c3a52c61f5b7be648e919005820fbac33028c6149994cd64453f49951c17/pydantic-2.13.0-py3-none-any.whl", hash = "sha256:ab0078b90da5f3e2fd2e71e3d9b457ddcb35d0350854fbda93b451e28d56baaf", size = 471872, upload-time = "2026-04-13T10:51:33.343Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ca/b45c378e6e8d0b90577288b533e04e95b7afd61bb1d51b6c263176435489/pydantic-2.13.2-py3-none-any.whl", hash = "sha256:a525087f4c03d7e7456a3de89b64cd693d2229933bb1068b9af6befd5563694e", size = 471947, upload-time = "2026-04-17T09:31:57.541Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.0"
+version = "2.46.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/0a/9414cddf82eda3976b14048cc0fa8f5b5d1aecb0b22e1dcd2dbfe0e139b1/pydantic_core-2.46.0.tar.gz", hash = "sha256:82d2498c96be47b47e903e1378d1d0f770097ec56ea953322f39936a7cf34977", size = 471441, upload-time = "2026-04-13T09:06:33.813Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/bb/4742f05b739b2478459bb16fa8470549518c802e06ddcf3f106c5081315e/pydantic_core-2.46.2.tar.gz", hash = "sha256:37bb079f9ee3f1a519392b73fda2a96379b31f2013c6b467fe693e7f2987f596", size = 471269, upload-time = "2026-04-17T09:10:07.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/d2/206c72ad47071559142a35f71efc29eb16448a4a5ae9487230ab8e4e292b/pydantic_core-2.46.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:66ccedb02c934622612448489824955838a221b3a35875458970521ef17b2f9c", size = 2117060, upload-time = "2026-04-13T09:04:47.443Z" },
-    { url = "https://files.pythonhosted.org/packages/17/2c/7a53b33f91c8b77e696b1a6aa3bed609bf9374bdc0f8dcda681bc7d922b8/pydantic_core-2.46.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a44f27f4d2788ef9876ec47a43739b118c5904d74f418f53398f6ced3bbcacf2", size = 1951802, upload-time = "2026-04-13T09:05:34.591Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/20/90e548c1f6d38800ef11c915881525770ce270d8e5e887563ff046a08674/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f26a1032bcce6ca4b4670eb3f7d8195bd0a8b8f255f1307823e217ca3cfa7c27", size = 1976621, upload-time = "2026-04-13T09:04:03.909Z" },
-    { url = "https://files.pythonhosted.org/packages/20/3c/9c5810ca70b60c623488cdd80f7e9ee1a0812df81e97098b64788719860f/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b8d1412f725060527e56675904b17a2d421dddcf861eecf7c75b9dda47921a4", size = 2056721, upload-time = "2026-04-13T09:04:40.992Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/a3/d6e5f4cdec84278431c75540f90838c9d0a4dfe9402a8f3902073660ff28/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc3d1569edd859cabaa476cabce9eecd05049a7966af7b4a33b541bfd4ca1104", size = 2239634, upload-time = "2026-04-13T09:03:52.478Z" },
-    { url = "https://files.pythonhosted.org/packages/46/42/ef58aacf330d8de6e309d62469aa1f80e945eaf665929b4037ac1bfcebc1/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:38108976f2d8afaa8f5067fd1390a8c9f5cc580175407cda636e76bc76e88054", size = 2315739, upload-time = "2026-04-13T09:05:04.971Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/86/c63b12fafa2d86a515bfd1840b39c23a49302f02b653161bf9c3a0566c50/pydantic_core-2.46.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5a06d8ed01dad5575056b5187e5959b336793c6047920a3441ee5b03533836", size = 2098169, upload-time = "2026-04-13T09:07:27.151Z" },
-    { url = "https://files.pythonhosted.org/packages/76/19/b5b33a2f6be4755b21a20434293c4364be255f4c1a108f125d101d4cc4ee/pydantic_core-2.46.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:04017ace142da9ce27cafd423a480872571b5c7e80382aec22f7d715ca8eb870", size = 2170830, upload-time = "2026-04-13T09:04:39.448Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ae/7559f99a29b7d440012ddb4da897359304988a881efaca912fd2f655652e/pydantic_core-2.46.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2629ad992ed1b1c012e6067f5ffafd3336fcb9b54569449fabb85621f1444ed3", size = 2203901, upload-time = "2026-04-13T09:04:01.048Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/0e/b0ef945a39aeb4ac58da316813e1106b7fbdfbf20ac141c1c27904355ac5/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3068b1e7bd986aebc88f6859f8353e72072538dcf92a7fb9cf511a0f61c5e729", size = 2191789, upload-time = "2026-04-13T09:06:39.915Z" },
-    { url = "https://files.pythonhosted.org/packages/90/f4/830484e07188c1236b013995818888ab93bab8fd88aa9689b1d8fd22220d/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:1e366916ff69ff700aa9326601634e688581bc24c5b6b4f8738d809ec7d72611", size = 2344423, upload-time = "2026-04-13T09:05:12.252Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/ba/e455c18cbdc333177af754e740be4fe9d1de173d65bbe534daf88da02ac0/pydantic_core-2.46.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:485a23e8f4618a1b8e23ac744180acde283fffe617f96923d25507d5cade62ec", size = 2384037, upload-time = "2026-04-13T09:06:24.503Z" },
-    { url = "https://files.pythonhosted.org/packages/78/1f/b35d20d73144a41e78de0ae398e60fdd8bed91667daa1a5a92ab958551ba/pydantic_core-2.46.0-cp312-cp312-win32.whl", hash = "sha256:520940e1b702fe3b33525d0351777f25e9924f1818ca7956447dabacf2d339fd", size = 1967068, upload-time = "2026-04-13T09:05:23.374Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/84/4b6252e9606e8295647b848233cc4137ee0a04ebba8f0f9fb2977655b38c/pydantic_core-2.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:90d2048e0339fa365e5a66aefe760ddd3b3d0a45501e088bc5bc7f4ed9ff9571", size = 2071008, upload-time = "2026-04-13T09:05:21.392Z" },
-    { url = "https://files.pythonhosted.org/packages/39/95/d08eb508d4d5560ccbd226ee5971e5ef9b749aba9b413c0c4ed6e406d4f6/pydantic_core-2.46.0-cp312-cp312-win_arm64.whl", hash = "sha256:a70247649b7dffe36648e8f34be5ce8c5fa0a27ff07b071ea780c20a738c05ce", size = 2036634, upload-time = "2026-04-13T09:05:48.299Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0c/106ed5cc50393d90523f09adcc50d05e42e748eb107dc06aea971137f02d/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:bc0e2fefe384152d7da85b5c2fe8ce2bf24752f68a58e3f3ea42e28a29dfdeb2", size = 2104968, upload-time = "2026-04-13T09:06:26.967Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/71/b494cef3165e3413ee9bbbb5a9eedc9af0ea7b88d8638beef6c2061b110e/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:a2ab0e785548be1b4362a62c4004f9217598b7ee465f1f420fc2123e2a5b5b02", size = 1940442, upload-time = "2026-04-13T09:06:29.332Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/3e/a4d578c8216c443e26a1124f8c1e07c0654264ce5651143d3883d85ff140/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16d45aecb18b8cba1c68eeb17c2bb2d38627ceed04c5b30b882fc9134e01f187", size = 1999672, upload-time = "2026-04-13T09:04:42.798Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/c1/9114560468685525a21770138382fd0cb849aaf351ff2c7b97f760d121e0/pydantic_core-2.46.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5078f6c377b002428e984259ac327ef8902aacae6c14b7de740dd4869a491501", size = 2154533, upload-time = "2026-04-13T09:04:50.868Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ec/2fafa4c86f5d2a69372c7cddef30925fd0e370b1efaf556609c1a0196d8a/pydantic_core-2.46.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ea1ad8c89da31512fe2d249cf0638fb666925bda341901541bc5f3311c6fcc9e", size = 2101729, upload-time = "2026-04-17T09:12:30.042Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/55/be5386c2c4b49af346e8a26b748194ff25757bbb6cf544130854e997af7a/pydantic_core-2.46.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b308da17b92481e0587244631c5529e5d91d04cb2b08194825627b1eca28e21e", size = 1951546, upload-time = "2026-04-17T09:10:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/29/92/89e273a055ce440e6636c756379af35ad86da9d336a560049c3ba5e41c80/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d333a50bdd814a917d8d6a7ee35ba2395d53ddaa882613bc24e54a9d8b129095", size = 1976178, upload-time = "2026-04-17T09:11:49.619Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b3/e4664469cf70c0cb0f7b2f5719d64e5968bb6f38217042c2afa3d3c4ba17/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d00b99590c5bd1fabbc5d28b170923e32c1b1071b1f1de1851a4d14d89eb192", size = 2051697, upload-time = "2026-04-17T09:12:04.917Z" },
+    { url = "https://files.pythonhosted.org/packages/98/58/dbf68213ee06ce51cdd6d8c95f97980e646858c45bd96bd2dfb40433be73/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f0e686960ffe9e65066395af856ac2d52c159043144433602c50c221d81c1ba", size = 2233160, upload-time = "2026-04-17T09:12:00.956Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d3/68092aa0ee6c60ff4de4740eb82db3d4ce338ec89b3cecb978c532472f12/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d1128da41c9cb474e0a4701f9c363ec645c9d1a02229904c76bf4e0a194fde2", size = 2298398, upload-time = "2026-04-17T09:10:29.694Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/51/5d6155eb737db55b0ad354ca5f333ef009f75feb67df2d79a84bace45af6/pydantic_core-2.46.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48649cf2d8c358d79586e9fb2f8235902fcaa2d969ec1c5301f2d1873b2f8321", size = 2094058, upload-time = "2026-04-17T09:12:10.995Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f3/eb4a986197d71319430464ff181226c95adc8f06d932189b158bae5a82f5/pydantic_core-2.46.2-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:b902f0fc7c2cf503865a05718b68147c6cd5d0a3867af38c527be574a9fa6e9d", size = 2130388, upload-time = "2026-04-17T09:12:41.159Z" },
+    { url = "https://files.pythonhosted.org/packages/56/00/44a9c4fe6d0f64b5786d6a8c649d6f0e34ba6c89b3663add1066e54451a2/pydantic_core-2.46.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e80011f808b03d1d87a8f1e76ae3da19a18eb706c823e17981dcf1fae43744fc", size = 2184245, upload-time = "2026-04-17T09:12:36.532Z" },
+    { url = "https://files.pythonhosted.org/packages/78/6b/685b98a834d5e3d1c34a1bde1627525559dd223b75075bc7490cdb24eb33/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b839d5c802e31348b949b6473f8190cddbf7d47475856d8ac995a373ee16ec59", size = 2186842, upload-time = "2026-04-17T09:13:04.054Z" },
+    { url = "https://files.pythonhosted.org/packages/22/64/caa2f5a2ac8b6113adaa410ccdf31ba7f54897a6e54cd0d726fc7e780c88/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:c6b1064f3f9cf9072e1d59dd2936f9f3b668bec1c37039708c9222db703c0d5b", size = 2336066, upload-time = "2026-04-17T09:12:13.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f9/7d2701bf82945b5b9e7df8347be97ef6a36da2846bfe5b4afec299ffe27b/pydantic_core-2.46.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:37a68e6f2ac95578ce3c0564802404b27b24988649616e556c07e77111ed3f1d", size = 2363691, upload-time = "2026-04-17T09:13:42.972Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/65/0dab11574101522941055109419db3cc09db871643dc3fc74e2413215e5b/pydantic_core-2.46.2-cp312-cp312-win32.whl", hash = "sha256:d9ffa75a7ef4b97d6e5e205fabd4304ef01fec09e6f1bdde04b9ad1b07d20289", size = 1958801, upload-time = "2026-04-17T09:11:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2b/df84baa609c676f6450b8ecad44ea59146c805e3371b7b52443c0899f989/pydantic_core-2.46.2-cp312-cp312-win_amd64.whl", hash = "sha256:0551f2d2ddb68af5a00e26497f8025c538f73ef3cb698f8e5a487042cd2792a8", size = 2072634, upload-time = "2026-04-17T09:11:02.407Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4e/e1ce8029fc438086a946739bf9d596f70ff470aad4a8345555920618cabe/pydantic_core-2.46.2-cp312-cp312-win_arm64.whl", hash = "sha256:83aef30f106edcc21a6a4cc44b82d3169a1dbe255508db788e778f3c804d3583", size = 2026188, upload-time = "2026-04-17T09:13:11.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/66c146f421178641bda880b0267c0d57dd84f5fec9ecc8e46be17b480742/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e9fcabd1857492b5bf16f90258babde50f618f55d046b1309972da2396321ff9", size = 2091621, upload-time = "2026-04-17T09:12:47.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b2/c28419aa9fc8055f4ac8e801d1d11c6357351bfa4321ed9bafab3eb98087/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:fb3ec2c7f54c07b30d89983ce78dc32c37dd06a972448b8716d609493802d628", size = 1937059, upload-time = "2026-04-17T09:10:53.554Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ce/cd0824a2db213dc17113291b7a09b9b0ccd9fbf97daa4b81548703341baf/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:130a6c837d819ef33e8c2bf702ed2c3429237ea69807f1140943d6f4bdaf52fa", size = 1997278, upload-time = "2026-04-17T09:12:23.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/69/47283fe3c0c967d3e9e9cd6c42b70907610c8a6f8d6e8381f1bb55f8006c/pydantic_core-2.46.2-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2e25417cec5cd9bddb151e33cb08c50160f317479ecc02b22a95ec18f8fe004", size = 2147096, upload-time = "2026-04-17T09:12:43.124Z" },
 ]
 
 [[package]]
@@ -1088,27 +1088,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.10"
+version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
-    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
-    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
-    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]
@@ -1436,9 +1436,9 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "3.23.0"
+version = "3.23.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR implements a new `rotate-jwt-key` action on `slurmctld` to perform a rotation of the JWT key on both `slurmctld` and `slurmdbd`. Only a single JWT key can be in use at one time so the rotation requires `slurmdbd` downtime during the rotation.

Rotation is performed by:

* Admin runs `juju run slurmctld/leader rotate-jwt-key`
* Controller replaces its existing `jwt_hs256.key`, `slurmdbd` is now using a stale key
* The JWT key Juju secret is updated to a new revision
* The `slurmdbd` unit receives a SecretChangedEvent and replaces its local `jwt_hs256.key` file with the new key, restoring service

To facilitate this, in `slurm-ops`:

* `SecretManager` protocol now defines methods: `generate`, `set`, and `apply` and is implemented by `_JWTSecretManager` and `_SlurmSecretManager`. The `apply` method allows for common code to rotate both keys - it is equivalent to `set` in `_JWTSecretManager` and replaces `add` in `_SlurmSecretManager`.
* Key methods now use `dict[str, str]` as a common key data structure: `{"key": key}` for JWT and `{"key": key, "keyid": keyid}` for auth, allowing for common rotation code.
  * Additionally. this matches the `content` type expected by [`add_secret`](https://documentation.ubuntu.com/ops/latest/reference/ops/#ops.Application.add_secret) and [`set_content`](https://documentation.ubuntu.com/ops/latest/reference/ops/#ops.Secret.set_content), simplifying handling of Secrets.
  * For example, this is now valid: `self.app.add_secret(manager.generate(), label=label)`, as is `manager.set(secret.get_content())`
* Docstrings have been added and updated.
* Key methods have been ordered: create -> read -> write -> extend.

In `charmed_slurm_slurmctld_interface`:

* JWT secret handling is now consistent with the auth secret.
* `JWT_KEY_LABEL` replaces `JWT_KEY_TEMPLATE_LABEL`
* `jwt_key_id` is renamed to `jwt_secret_id`
* JWT secret is not updated within the interface or revoked on `relation-broken`

In `secret-change`:

* `slurmdbd` now handles both auth and JWT key updates using common code
* auth key handling has been simplified on all charms as the common `dict[str, str]` structure no longer requires unpacking of the key values

In `slurmctld`:

* Common code handles JWT and auth key generation in the `install` hook
* Common `_rotate_key()` now handles both JWT and auth key rotation actions

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is a follow-on to https://github.com/charmed-hpc/slurm-charms/pull/207.

## Docs

* [X] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [ ] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

https://github.com/charmed-hpc/docs/pull/132