### PR TITLE
fix(slurmctld): fix HA deployment

### DIFF
--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -252,7 +252,7 @@ class SlurmctldCharm(ops.CharmBase):
         self.unit.open_port("tcp", PROMETHEUS_EXPORTER_PORT)
 
     @refresh
-    @wait_unless(shared_state_mounted)
+    @wait_unless(shared_state_mounted, config_ready)
     def _on_leader_elected(self, event: ops.LeaderElectedEvent) -> None:
         """Refresh controller lists on leader re-election."""
         if not self.model.relations.get(HA_MOUNT_INTEGRATION_NAME):
@@ -407,6 +407,7 @@ class SlurmctldCharm(ops.CharmBase):
         self.slurmctld_peer.update_controller_peer_app_data(cluster_name=cluster_name)
 
     @refresh
+    @wait_unless(config_ready)
     def _on_slurmctld_changed(self, event) -> None:
         """Handle when `slurmctld` units join or leave."""
         # Only a slurm.conf update needed - no other conf files are affected.
@@ -494,7 +495,7 @@ class SlurmctldCharm(ops.CharmBase):
         )
 
     @refresh
-    @wait_unless(database_ready, all_units_observed)
+    @wait_unless(database_ready, all_units_observed, config_ready)
     @block_unless(slurmctld_installed)
     def _on_slurmdbd_ready(self, event: SlurmdbdReadyEvent) -> None:
         """Handle when database data is ready from a `slurmdbd` application."""

--- a/charms/slurmctld/src/state.py
+++ b/charms/slurmctld/src/state.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 import ops
 from charmed_hpc_libs.ops.conditions import ConditionEvaluation
-from constants import HA_MOUNT_INTEGRATION_NAME
+from constants import HA_MOUNT_INTEGRATION_NAME, HA_MOUNT_LOCATION
 from slurm_ops import SlurmOpsError
 
 if TYPE_CHECKING:
@@ -82,24 +82,15 @@ def shared_state_mounted(charm: "SlurmctldCharm") -> ConditionEvaluation:
     if charm.unit.is_leader() and not charm.model.relations.get(HA_MOUNT_INTEGRATION_NAME):
         return ConditionEvaluation(True, "")
 
-    failure = ConditionEvaluation(
-        False, "A shared file system must be provided to enable `slurmctld` high availability"
+    mounted = Path(HA_MOUNT_LOCATION).is_mount()
+    return ConditionEvaluation(
+        mounted,
+        (
+            "A shared file system must be provided to enable `slurmctld` high availability"
+            if not mounted
+            else ""
+        ),
     )
-
-    if not charm.slurmctld.config.path.exists():
-        return failure
-
-    config = charm.slurmctld.config.load()
-    if not config.state_save_location:
-        return failure
-
-    # Check the *parent* as StateSaveLocation is a subdirectory under the shared filesystem in HA
-    # That is, with "HA_MOUNT_LOCATION/checkpoint" we check if "HA_MOUNT_LOCATION" is a mount
-    state_save_parent = Path(config.state_save_location).parent
-    if not state_save_parent.is_mount():
-        return failure
-
-    return ConditionEvaluation(True, "")
 
 
 def peer_ready(charm: "SlurmctldCharm") -> ConditionEvaluation:


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Fixes https://github.com/charmed-hpc/slurm-charms/issues/193. Both HA deployment and HA migration of `slurmctld` now function again.

Changes:
* Use `HA_MOUNT_LOCATION` in `shared_state_mounted` state rather than read path from `slurm.conf`. Solves deadlock if `filesystem-client` was integrated before `_on_start` first run.
* Add missing `@wait_unless(config_ready)` to hooks that require `slurm.conf` to be present. Solves failed reads of `slurm.conf` before it exists and erroneous writes before its initial values are set.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

https://github.com/charmed-hpc/slurm-charms/issues/193

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Not a user-facing change - no docs required.