### PR TITLE
feat(slurmd): add dcgm exporter endpoint for Prometheus

### DIFF
--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -96,8 +96,11 @@ class SlurmdCharm(ops.CharmBase):
             self._on_slurmctld_disconnected,
         )
 
+        # FIXME: Only enable `dcgm` scrape job if GPU is present on the node.
         self.metrics_endpoint = MetricsEndpointProvider(
-            self, PROMETHEUS_SCRAPE_INTEGRATION_NAME, jobs=[NODE_EXPORTER_SCRAPE_CONFIG]
+            self,
+            PROMETHEUS_SCRAPE_INTEGRATION_NAME,
+            jobs=[NODE_EXPORTER_SCRAPE_CONFIG, gpu.DCGM_EXPORTER_SCRAPE_CONFIG],
         )
 
     @refresh
@@ -144,6 +147,9 @@ class SlurmdCharm(ops.CharmBase):
             self.slurmd.node_exporter.set_collectors(NODE_EXPORTER_COLLECTORS)
             self.slurmd.node_exporter.service.enable()
         except (SlurmOpsError, gpu.GPUOpsError, rdma.RDMAOpsError, SnapError) as e:
+            # FIXME: Investigate how to provide more granular status messages
+            #   such as when it's the `dcgm-exporter` snap that fails to install
+            #   and not the Nvidia drivers.
             error_message = {
                 SlurmOpsError: "Failed to install `slurmd`",
                 gpu.GPUOpsError: "Failed to install GPU drivers",

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -98,8 +98,12 @@ class SlurmdCharm(ops.CharmBase):
         )
 
         scrape_jobs = [NODE_EXPORTER_SCRAPE_CONFIG]
-        if self.gpu.dcgm.exporter.is_active():
-            scrape_jobs.append(DCGM_EXPORTER_SCRAPE_CONFIG)
+        # FIXME: Replace with `is_installed` once method is added to `SlurmOpsManager`.
+        try:
+            if self.gpu.dcgm.exporter.is_active():
+                scrape_jobs.append(DCGM_EXPORTER_SCRAPE_CONFIG)
+        except SnapError:
+            pass
         self.metrics_endpoint = MetricsEndpointProvider(
             self,
             PROMETHEUS_SCRAPE_INTEGRATION_NAME,

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -98,7 +98,8 @@ class SlurmdCharm(ops.CharmBase):
         )
 
         scrape_jobs = [NODE_EXPORTER_SCRAPE_CONFIG]
-        # FIXME: Replace with `is_installed` once method is added to `SlurmOpsManager`.
+        # FIXME: https://github.com/charmed-hpc/hpc-libs/issues/133
+        #  Replace with `is_installed` once method is added to `SnapOpsManager`.
         try:
             if self.gpu.dcgm.exporter.is_active():
                 scrape_jobs.append(DCGM_EXPORTER_SCRAPE_CONFIG)
@@ -154,12 +155,13 @@ class SlurmdCharm(ops.CharmBase):
             self.slurmd.node_exporter.set_collectors(NODE_EXPORTER_COLLECTORS)
             self.slurmd.node_exporter.service.enable()
         except (SlurmOpsError, GPUOpsError, rdma.RDMAOpsError, SnapError) as e:
-            # FIXME: Investigate how to provide more granular status messages
-            #   such as when it's the `dcgm-exporter` snap that fails to install
-            #   and not the Nvidia drivers.
+            # FIXME: https://github.com/charmed-hpc/hpc-libs/issues/134
+            #  Investigate how to provide more granular status messages
+            #  such as when it's the `dcgm-exporter` snap that fails to install
+            #  and not the Nvidia drivers.
             error_message = {
                 SlurmOpsError: "Failed to install `slurmd`",
-                GPUOpsError: "Failed to install GPU drivers",
+                GPUOpsError: "Failed to install GPU packages",
                 rdma.RDMAOpsError: "Failed to install RDMA drivers",
                 SnapError: "Failed to install `node-exporter`",
             }

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -18,7 +18,6 @@
 
 import logging
 
-import gpu
 import ops
 import rdma
 from charmed_hpc_libs.errors import SnapError, SystemdError
@@ -35,6 +34,7 @@ from charmed_slurm_slurmd_interface import (
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from config import ConfigManager
 from constants import PROMETHEUS_SCRAPE_INTEGRATION_NAME, SLURMD_INTEGRATION_NAME, SLURMD_PORT
+from gpu import DCGM_EXPORTER_SCRAPE_CONFIG, GPUOpsError, NvidiaGPUManager
 from pydantic import ValidationError
 from slurm_ops import (
     NODE_EXPORTER_COLLECTORS,
@@ -59,6 +59,7 @@ class SlurmdCharm(ops.CharmBase):
         super().__init__(framework)
 
         self.slurmd = SlurmdManager(self.app.name, snap=False)
+        self.gpu = NvidiaGPUManager()
         try:
             self.configmgr = self.load_config(ConfigManager, partition_name=self.app.name)
         except ValidationError as e:
@@ -96,11 +97,13 @@ class SlurmdCharm(ops.CharmBase):
             self._on_slurmctld_disconnected,
         )
 
-        # FIXME: Only enable `dcgm` scrape job if GPU is present on the node.
+        scrape_jobs = [NODE_EXPORTER_SCRAPE_CONFIG]
+        if self.gpu.dcgm.exporter.is_active():
+            scrape_jobs.append(DCGM_EXPORTER_SCRAPE_CONFIG)
         self.metrics_endpoint = MetricsEndpointProvider(
             self,
             PROMETHEUS_SCRAPE_INTEGRATION_NAME,
-            jobs=[NODE_EXPORTER_SCRAPE_CONFIG, gpu.DCGM_EXPORTER_SCRAPE_CONFIG],
+            jobs=scrape_jobs,
         )
 
     @refresh
@@ -128,7 +131,7 @@ class SlurmdCharm(ops.CharmBase):
             self.unit.set_workload_version(self.slurmd.version())
 
             self.unit.status = ops.MaintenanceStatus("Installing GPU drivers")
-            gpu_enabled = gpu.autoinstall()
+            gpu_enabled = self.gpu.autoinstall()
             if gpu_enabled:
                 self.unit.status = ops.MaintenanceStatus("Successfully installed GPU drivers")
             else:
@@ -146,13 +149,13 @@ class SlurmdCharm(ops.CharmBase):
             self.slurmd.node_exporter.set_web_listen_address(f":{NODE_EXPORTER_PORT}")
             self.slurmd.node_exporter.set_collectors(NODE_EXPORTER_COLLECTORS)
             self.slurmd.node_exporter.service.enable()
-        except (SlurmOpsError, gpu.GPUOpsError, rdma.RDMAOpsError, SnapError) as e:
+        except (SlurmOpsError, GPUOpsError, rdma.RDMAOpsError, SnapError) as e:
             # FIXME: Investigate how to provide more granular status messages
             #   such as when it's the `dcgm-exporter` snap that fails to install
             #   and not the Nvidia drivers.
             error_message = {
                 SlurmOpsError: "Failed to install `slurmd`",
-                gpu.GPUOpsError: "Failed to install GPU drivers",
+                GPUOpsError: "Failed to install GPU drivers",
                 rdma.RDMAOpsError: "Failed to install RDMA drivers",
                 SnapError: "Failed to install `node-exporter`",
             }

--- a/charms/slurmd/src/gpu.py
+++ b/charms/slurmd/src/gpu.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Manage GPU driver installation on compute node."""
+"""Manage the Nvidia GPU lifecycle on individual compute nodes."""
+
+__all__ = ["DCGM_EXPORTER_SCRAPE_CONFIG", "GPUOpsError", "NvidiaGPUManager"]
 
 import logging
+from functools import cached_property
 
 # ubuntu-drivers requires apt_pkg for package operations
 import apt_pkg  # pyright: ignore [reportMissingImports]
-import charms.operator_libs_linux.v0.apt as apt
 import UbuntuDrivers.detect  # pyright: ignore [reportMissingImports]
 from charmed_hpc_libs.errors import SnapError
 from charmed_hpc_libs.ops import DCGMManager
+from charmlibs import apt
 from slurm_ops import UNIT_TO_NODE_NAME_RELABEL_CONFIG
 
 _logger = logging.getLogger(__name__)
@@ -45,28 +48,27 @@ class GPUOpsError(Exception):
         return self.args[0]
 
 
-class GPUDriverDetector:
-    """Detects GPU driver and kernel packages appropriate for the current hardware."""
+class NvidiaGPUManager:
+    """Manage Nvidia GPU resources on Slurm compute nodes."""
 
-    def __init__(self):
-        """Initialize detection interfaces."""
-        apt_pkg.init()
+    @cached_property
+    def dcgm(self) -> DCGMManager:
+        """Get the DCGM (Nvidia's Data Center GPU Manager) lifecycle manager."""
+        return DCGMManager()
 
-    def _system_gpgpu_driver_packages(self) -> dict:
-        """Detect the available GPGPU drivers for this node."""
-        return UbuntuDrivers.detect.system_gpgpu_driver_packages()
+    def autoinstall(self) -> bool:
+        """Autodetect available GPUs and install drivers.
 
-    def _get_linux_modules_metapackage(self, driver) -> str:
-        """Retrieve the modules metapackage for the combination of current kernel and given driver.
+        Returns:
+            True if drivers were installed, False otherwise.
 
-        For example, linux-modules-nvidia-535-server-aws for driver nvidia-driver-535-server
+        Raises:
+            GPUOpsError: Raised if error is encountered during package install.
         """
-        return UbuntuDrivers.detect.get_linux_modules_metapackage(apt_pkg.Cache(None), driver)
+        _logger.info("detecting GPUs and installing drivers")
 
-    def system_packages(self) -> list[str]:
-        """Return a list of GPU drivers and kernel module packages for this node."""
-        packages = self._system_gpgpu_driver_packages()
-
+        apt_pkg.init()
+        packages = UbuntuDrivers.detect.system_gpgpu_driver_packages()
         # Gather list of driver and kernel modules to install.
         install_packages = []
         for driver_package in packages:
@@ -78,46 +80,32 @@ class GPUDriverDetector:
 
                 # Retrieve modules metapackage for combination of current kernel and recommended driver,
                 # For example, linux-modules-nvidia-535-server-aws
-                modules_metapackage = self._get_linux_modules_metapackage(driver_package)
+                modules_metapackage = UbuntuDrivers.detect.get_linux_modules_metapackage(
+                    apt_pkg.Cache(None), driver_package
+                )
 
                 # Add to list of packages to install
                 install_packages += [driver_metapackage, modules_metapackage]
 
-        return [p for p in install_packages if p]
+        targets = [p for p in install_packages if p]
+        if len(targets) == 0:
+            _logger.info("no GPU drivers requiring installation")
+            return False
 
+        _logger.info("installing GPU driver packages: %s", targets)
+        try:
+            apt.add_package(targets)
+        except (apt.PackageNotFoundError, apt.PackageError) as e:
+            raise GPUOpsError(f"failed to install packages {targets}. reason: {e}")
 
-def autoinstall() -> bool:
-    """Autodetect available GPUs and install drivers.
+        _logger.info("installing `dcgm` snap")
+        try:
+            self.dcgm.install()
+            self.dcgm.set_dcgm_exporter_address(f":{DCGM_EXPORTER_PORT}")
+            # Restart `dcgm-exporter` if it's already running to apply new port configuration.
+            self.dcgm.exporter.restart()
+            self.dcgm.exporter.enable()
+        except SnapError as e:
+            raise GPUOpsError(f"failed to install and start `dcgm-exporter` service. reason: {e}")
 
-    Returns:
-        True if drivers were installed, False otherwise.
-
-    Raises:
-        GPUOpsError: Raised if error is encountered during package install.
-    """
-    _logger.info("detecting GPUs and installing drivers")
-    detector = GPUDriverDetector()
-    install_packages = detector.system_packages()
-
-    if len(install_packages) == 0:
-        _logger.info("no GPU drivers requiring installation")
-        return False
-
-    _logger.info("installing GPU driver packages: %s", install_packages)
-    try:
-        apt.add_package(install_packages)
-    except (apt.PackageNotFoundError, apt.PackageError) as e:
-        raise GPUOpsError(f"failed to install packages {install_packages}. reason: {e}")
-
-    _logger.info("installing `dcgm` snap")
-    try:
-        dcgm = DCGMManager()
-        dcgm.install()
-        dcgm.set_dcgm_exporter_address(f":{DCGM_EXPORTER_PORT}")
-        # Restart `dcgm-exporter` if it's already running to apply new port configuration.
-        dcgm.exporter.restart()
-        dcgm.exporter.enable()
-    except SnapError as e:
-        raise GPUOpsError(f"failed to install and start `dcgm-exporter` service. reason: {e}")
-
-    return True
+        return True

--- a/charms/slurmd/src/gpu.py
+++ b/charms/slurmd/src/gpu.py
@@ -20,8 +20,20 @@ import logging
 import apt_pkg  # pyright: ignore [reportMissingImports]
 import charms.operator_libs_linux.v0.apt as apt
 import UbuntuDrivers.detect  # pyright: ignore [reportMissingImports]
+from charmed_hpc_libs.errors import SnapError
+from charmed_hpc_libs.ops import DCGMManager
+from slurm_ops import UNIT_TO_NODE_NAME_RELABEL_CONFIG
 
 _logger = logging.getLogger(__name__)
+
+DCGM_EXPORTER_PORT = 9101
+DCGM_EXPORTER_SCRAPE_CONFIG = {
+    "job_name": "dcgm-exporter",
+    "metrics_path": "/metrics",
+    "scrape_interval": "60s",
+    "static_configs": [{"targets": [f"*:{DCGM_EXPORTER_PORT}"]}],
+    "relabel_configs": [UNIT_TO_NODE_NAME_RELABEL_CONFIG],
+}
 
 
 class GPUOpsError(Exception):
@@ -96,5 +108,16 @@ def autoinstall() -> bool:
         apt.add_package(install_packages)
     except (apt.PackageNotFoundError, apt.PackageError) as e:
         raise GPUOpsError(f"failed to install packages {install_packages}. reason: {e}")
+
+    _logger.info("installing `dcgm` snap")
+    try:
+        dcgm = DCGMManager()
+        dcgm.install()
+        dcgm.set_dcgm_exporter_address(f":{DCGM_EXPORTER_PORT}")
+        # Restart `dcgm-exporter` if it's already running to apply new port configuration.
+        dcgm.exporter.restart()
+        dcgm.exporter.enable()
+    except SnapError as e:
+        raise GPUOpsError(f"failed to install and start `dcgm-exporter` service. reason: {e}")
 
     return True

--- a/charms/slurmd/tests/unit/conftest.py
+++ b/charms/slurmd/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +44,19 @@ def mock_charm(
     fs.create_file("/etc/slurm/slurm.jwks", create_missing_dirs=True)
     fs.create_file("/etc/default/slurmd", create_missing_dirs=True)
     fs.create_dir("/usr/sbin")
+    # TODO: Simplify charm lifecycle patches once Observer pattern is implemented.
+    #   The `dcgm-exporter` manager must be patched to prevent a computer crashing
+    #   memory leak will that is triggered by the unit tests when creating the scenario
+    #   `Context` object for the `SlurmdCharm` object. Deeper investigation shows that
+    #   mocking `subprocess.run` does not play nicely with `pyfakefs`, and this seems to be where
+    #   the memory leak is originating from. It is specifically triggered when `ops.main`
+    #   is called by `Scenario` and the `SlurmdCharm` object's `__init__` method is called.
+    #   The suspicion is that either `pyfakefs` or the `subprocess.run` mock is causing
+    #   unbounded data duplication in memory when creating the fake filesystem.
+    mocker.patch(
+        "charmed_hpc_libs.ops.machine.nvidia.DCGMManager.exporter",
+        new_callable=mocker.PropertyMock(),
+    )
     mocker.patch("subprocess.run")
 
     return mock_ctx

--- a/charms/slurmd/tests/unit/conftest.py
+++ b/charms/slurmd/tests/unit/conftest.py
@@ -46,7 +46,7 @@ def mock_charm(
     fs.create_dir("/usr/sbin")
     # TODO: Simplify charm lifecycle patches once Observer pattern is implemented.
     #   The `dcgm-exporter` manager must be patched to prevent a computer crashing
-    #   memory leak will that is triggered by the unit tests when creating the scenario
+    #   memory leak that is triggered by the unit tests when creating the scenario
     #   `Context` object for the `SlurmdCharm` object. Deeper investigation shows that
     #   mocking `subprocess.run` does not play nicely with `pyfakefs`, and this seems to be where
     #   the memory leak is originating from. It is specifically triggered when `ops.main`

--- a/charms/slurmd/tests/unit/test_charm.py
+++ b/charms/slurmd/tests/unit/test_charm.py
@@ -77,7 +77,9 @@ class TestSlurmdCharm:
             mocker.patch("rdma.install")
 
             # Patch `gpu` module.
-            mocker.patch("gpu.autoinstall", lambda: mock_gpu_autoinstall_success)
+            mocker.patch(
+                "gpu.NvidiaGPUManager.autoinstall", lambda _: mock_gpu_autoinstall_success
+            )
 
             state = manager.run()
 

--- a/internal/slurm-ops/src/slurm_ops/__init__.py
+++ b/internal/slurm-ops/src/slurm_ops/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "SLURMD_USER",
     "SLURMRESTD_GROUP",
     "SLURMRESTD_USER",
+    "UNIT_TO_NODE_NAME_RELABEL_CONFIG",
     "SlurmOpsError",
     # From `sackd.py`
     "SackdManager",
@@ -53,6 +54,7 @@ from .core import (
     SLURMD_USER,
     SLURMRESTD_GROUP,
     SLURMRESTD_USER,
+    UNIT_TO_NODE_NAME_RELABEL_CONFIG,
     SecretManager,
     SlurmOpsError,
 )

--- a/internal/slurm-ops/src/slurm_ops/core/__init__.py
+++ b/internal/slurm-ops/src/slurm_ops/core/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "SLURMD_GROUP",
     "SLURMRESTD_USER",
     "SLURMRESTD_GROUP",
+    "UNIT_TO_NODE_NAME_RELABEL_CONFIG",
     # From `errors.py`
     "SlurmOpsError",
     # From `options.py`
@@ -51,6 +52,7 @@ from .constants import (
     SLURMD_USER,
     SLURMRESTD_GROUP,
     SLURMRESTD_USER,
+    UNIT_TO_NODE_NAME_RELABEL_CONFIG,
 )
 from .errors import SlurmOpsError
 from .options import marshal_options, parse_options

--- a/internal/slurm-ops/src/slurm_ops/core/constants.py
+++ b/internal/slurm-ops/src/slurm_ops/core/constants.py
@@ -14,6 +14,17 @@
 
 """Constants used within the `slurm-ops` package."""
 
+# Dynamically create the "node" label using the unit name and ID number.
+# This "node" label matches nodes' registered names in Slurm. This relabeling
+# makes it easier to match scraped `node-exporter` metrics with Slurm exporter metrics
+# in Prometheus alert rules.
+UNIT_TO_NODE_NAME_RELABEL_CONFIG = {
+    "source_labels": ["juju_unit"],
+    "target_label": "node",
+    "regex": r"(\S+)\/(\d+)",
+    "replacement": "${1}-${2}",
+}
+
 NODE_EXPORTER_COLLECTORS = ["systemd"]
 NODE_EXPORTER_PLUGS = ["hardware-observe", "mount-observe", "network-observe", "system-observe"]
 NODE_EXPORTER_PORT = 9100
@@ -24,18 +35,7 @@ NODE_EXPORTER_SCRAPE_CONFIG = {
     "static_configs": [
         {"targets": [f"*:{NODE_EXPORTER_PORT}"]},
     ],
-    # Dynamically create the "node" label using the unit name and ID number.
-    # This "node" label matches nodes' registered names in Slurm. This relabeling
-    # makes it easier to match scraped `node-exporter` metrics with Slurm exporter metrics
-    # in Prometheus alert rules.
-    "relabel_configs": [
-        {
-            "source_labels": ["juju_unit"],
-            "target_label": "node",
-            "regex": r"(\S+)\/(\d+)",
-            "replacement": "${1}-${2}",
-        }
-    ],
+    "relabel_configs": [UNIT_TO_NODE_NAME_RELABEL_CONFIG],
 }
 
 SLURM_USER = "slurm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
     "aiosmtpd == 1.4.6",
     "jubilant ~= 1.0",
     "pytest ~= 9.0",
-    "pytest-mock ~= 3.14",
     "pytest-order ~= 1.4",
     "pytest-mock ~= 3.14",
     "tenacity ~= 8.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ dev = [
     # Integration
     "aiosmtpd == 1.4.6",
     "jubilant ~= 1.0",
-    "pytest ~= 7.2",
+    "pytest ~= 9.0",
     "pytest-mock ~= 3.14",
-    "pytest-order ~= 1.3",
+    "pytest-order ~= 1.4",
     "pytest-mock ~= 3.14",
     "tenacity ~= 8.2",
 

--- a/repository.py
+++ b/repository.py
@@ -58,7 +58,7 @@ class BuildTool:
         def reader(pipe):
             with pipe:
                 for line in pipe:
-                    line.replace(str(BUILD_PATH), str(CHARMS_PATH))
+                    line = line.replace(str(BUILD_PATH), str(CHARMS_PATH))
                     print(line, end="")
 
         kwargs["text"] = True

--- a/uv.lock
+++ b/uv.lock
@@ -128,11 +128,11 @@ wheels = [
 
 [[package]]
 name = "charmed-hpc-libs"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/b7/3da83c0ab3b9eed17b24657d241fba8651c7d47bca3ec005a621206b9651/charmed_hpc_libs-0.2.0.tar.gz", hash = "sha256:96197fc218b307c156fc69db18ad06f6761e60d1b863b4acca7b1ce19c86d392", size = 49642, upload-time = "2026-04-20T20:20:54.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/d2/45fd4b4b249912f44ede807fe68f29e449f0ce9c9586eee33c4cb6838db4/charmed_hpc_libs-0.3.0.tar.gz", hash = "sha256:4dac724bcec0650560662413cfc8f9f8813dc5af5c9324b42583ce7d3ef9387a", size = 50517, upload-time = "2026-04-24T14:55:18.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/35/e0292ba65d5cc71fb4867c6efcaa0c7990da4442e863b0a3788a93c003c6/charmed_hpc_libs-0.2.0-py3-none-any.whl", hash = "sha256:35930be367f35ee3bef05461a2640d6a7e66871cba980c318d512fa45524502f", size = 27502, upload-time = "2026-04-20T20:20:53.228Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/89/8f64221c5ea9d0f817eb6ba5f1a553c1218a5ff4461da25f53a28576ffc4/charmed_hpc_libs-0.3.0-py3-none-any.whl", hash = "sha256:5a4412bc1593f9a65927063e057dcc507fd944558f4e9a1da465e0e4281b404b", size = 29195, upload-time = "2026-04-24T14:55:16.84Z" },
 ]
 
 [package.optional-dependencies]
@@ -452,11 +452,11 @@ all = [
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -599,15 +599,15 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
 ]
 
 [[package]]
@@ -645,20 +645,20 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -795,6 +795,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pylint"
 version = "4.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -814,30 +823,31 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -854,14 +864,14 @@ wheels = [
 
 [[package]]
 name = "pytest-order"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544, upload-time = "2024-08-22T12:29:54.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/76/c7b4a2ad3758a3c2757f532c6e931aa5e387781512a71b67b6ddc19d9ef8/pytest_order-1.4.0.tar.gz", hash = "sha256:327fb6eee1ae771051da13d2a0d9306d947e87f9ab8f4d6302e5d122c7472691", size = 49891, upload-time = "2026-04-26T12:37:43.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609, upload-time = "2024-08-22T12:29:53.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d0/c62c07141151f259faddff6bd591f28235c37dd0c486160d0d2a0d4e6e5a/pytest_order-1.4.0-py3-none-any.whl", hash = "sha256:05b1710cf16bb2123294eec5bdfaee513322ff1926c0dfa86eb8be632eb264a1", size = 14918, upload-time = "2026-04-26T12:37:41.123Z" },
 ]
 
 [[package]]
@@ -978,27 +988,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -1111,9 +1121,9 @@ requires-dist = [
     { name = "pylint", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "~=7.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "~=9.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "~=3.14" },
-    { name = "pytest-order", marker = "extra == 'dev'", specifier = "~=1.3" },
+    { name = "pytest-order", marker = "extra == 'dev'", specifier = "~=1.4" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = "~=1.1.1" },
     { name = "pyyaml", marker = "extra == 'dev'" },
     { name = "rpds-py", specifier = "~=0.23.1" },


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds a dcgm exporter endpoint to the slurmd charm. This exporter is provided by the `dcgm` snap. The snap package provides all the necessary dependencies to successfully scrape metrics from your Nvidia GPUs.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to our ongoing work to add GPU observability into Charmed HPC.

### Known limitations

Right now, the dcgm scrape configuration is added by default to the `metrics-endpoint` integration databag even if a slurmd unit does not have a GPU present. This isn't a huge issue as Prometheus will just complain that it failed to scrape the endpoint, however, Prometheus will still call out that it cannot successfully scrape the endpoint.

I have a "working" implementation that conditionally adds the DCGM scrape job to the `MetricsEndpointProvider` object, however, for some godforsaken reason it caused a memory leak in the unit tests that crashed my PC twice. It worked in integration tests, but effectively DoS'd any machine that attempted to run the unit tests. My suspicion for why this is busted is with the potentially funky logic we have in the unit test fixtures, but I felt that diving into this issue was too big a change for this PR.

I have a strong conviction that we'll be able to circumvent this memory leak in the unit tests with the Observer pattern, but we'll have to discuss tomorrow if we want to shift over to the Observer pattern for at least the `metrics-endpoint` interface to get around this issue in the unit tests.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

I have a separate PR brewing that will update that will document the added alert rules.