### PR TITLE
feat: add alerts for login/compute node service and GPU failures

### DIFF
--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -66,7 +66,10 @@ class SackdCharm(ops.CharmBase):
         )
 
         self.metrics_endpoint = MetricsEndpointProvider(
-            self, PROMETHEUS_SCRAPE_INTEGRATION_NAME, jobs=[NODE_EXPORTER_SCRAPE_CONFIG]
+            self,
+            PROMETHEUS_SCRAPE_INTEGRATION_NAME,
+            alert_rules_path="./src/cos/alert_rules/prometheus",
+            jobs=[NODE_EXPORTER_SCRAPE_CONFIG]
         )
 
     @refresh

--- a/charms/sackd/src/cos/alert_rules/prometheus/general.rules
+++ b/charms/sackd/src/cos/alert_rules/prometheus/general.rules
@@ -1,0 +1,70 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groups:
+  - name: SlurmLoginNode
+    rules:
+      - alert: SlurmLoginNodeSackdServiceIsInactive
+        expr: node_systemd_unit_state{name="sackd.service", state="inactive"} != 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: `slurmd` service on login node {{ $labels.node }} is inactive
+          description: |
+            The Slurm authentication and credential kiosk service, `sackd`, has been inactive for
+            more than 5 minutes on login node {{ $labels.node }}.
+
+            Possible Causes:
+
+              - The `sackd` service was stopped manually or failed to start after a reboot.
+              - A configuration or packaging change prevented the service from starting correctly.
+              - The login node is under resource pressure or experiencing host-level issues.
+              - Supporting authentication or credential services required by `sackd` are unavailable.
+
+            Potential Remediation steps:
+
+              - Check service status and logs with `systemctl status sackd` and `journalctl -u sackd -n 200`.
+              - Verify recent changes to `sackd` configuration, dependencies, or packages and roll back if needed.
+              - Restart the service with `systemctl restart sackd` and confirm it remains active.
+              - Check login node resource usage and host health if the service repeatedly stops.
+
+            LABELS={{ $labels }}
+
+      - alert: SlurmLoginNodeSackdServiceHasFailed
+        expr: node_systemd_unit_state{name="sackd.service", state="failed"} != 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: `sackd` service on login node {{ $labels.node }} has failed
+          description: |
+            The Slurm authentication and credential kiosk service, `sackd`, has failed
+            on login node {{ $labels.node }}.
+
+            Possible causes:
+
+              - The `sackd` service crashed due to an unhandled error or malformed configuration.
+              - A dependency such as networking, authentication, or credential handling failed.
+              - Disk, memory, or permission issues prevented the service from running correctly.
+              - A recent update introduced an incompatibility or startup regression.
+
+            Potential remediation steps:
+
+              - Inspect the failure reason with `systemctl status sackd` and `journalctl -u sackd -n 200`.
+              - Review recent configuration or package changes and revert or correct them if necessary.
+              - Restart the service with `systemctl restart sackd` after addressing the root cause.
+              - Investigate host health, permissions, and available resources on the login node.
+
+            LABELS={{ $labels }}

--- a/charms/sackd/src/cos/alert_rules/prometheus/general.rules
+++ b/charms/sackd/src/cos/alert_rules/prometheus/general.rules
@@ -21,7 +21,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: `slurmd` service on login node {{ $labels.node }} is inactive
+          summary: `sackd` service on login node {{ $labels.node }} is inactive
           description: |
             The Slurm authentication and credential kiosk service, `sackd`, has been inactive for
             more than 5 minutes on login node {{ $labels.node }}.

--- a/charms/sackd/src/cos/alert_rules/prometheus/general.rules
+++ b/charms/sackd/src/cos/alert_rules/prometheus/general.rules
@@ -19,7 +19,7 @@ groups:
         expr: node_systemd_unit_state{name="sackd.service", state="inactive"} != 0
         for: 5m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: `sackd` service on login node {{ $labels.node }} is inactive
           description: |

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -108,6 +108,7 @@ class SlurmdCharm(ops.CharmBase):
         self.metrics_endpoint = MetricsEndpointProvider(
             self,
             PROMETHEUS_SCRAPE_INTEGRATION_NAME,
+            alert_rules_path="./src/cos/alert_rules/prometheus",
             jobs=scrape_jobs,
         )
 

--- a/charms/slurmd/src/cos/alert_rules/prometheus/general.rules
+++ b/charms/slurmd/src/cos/alert_rules/prometheus/general.rules
@@ -1,0 +1,69 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groups:
+  - name: SlurmComputeNode
+    rules:
+      - alert: SlurmComputeNodeSlurmdServiceIsInactive
+        expr: node_systemd_unit_state{name="slurmd.service", state="inactive"} != 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: `slurmd` service on compute node {{ $labels.node }} is inactive
+          description: |
+            The Slurm compute node service, `slurmd`, has been inactive for more than 5 minutes
+            on compute node {{ $labels.node }}.
+
+            Possible causes:
+
+              - The `slurmd` service was stopped manually or failed to start after a reboot.
+              - The compute node has network, configuration, or registration problems preventing startup.
+              - The node is under resource pressure or experiencing host-level instability.
+              - A dependency or package update introduced a startup regression.
+
+            Potential remediation steps:
+
+              - Check the service state and logs with `systemctl status slurmd` and `journalctl -u slurmd -n 200`.
+              - Verify recent changes to `slurm.conf`, node configuration, or packages and correct any issues.
+              - Restart the service with `systemctl restart slurmd` and confirm it remains active.
+              - Inspect node health, resource usage, and network connectivity if the service continues to stop.
+
+            LABELS={{ $labels }}
+      - alert: SlurmComputeNodeSlurmdServiceHasFailed
+        expr: node_systemd_unit_state{name="slurmd.service", state="failed"} != 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: `slurmd` service on compute node {{ $labels.node }} has failed
+          description: |
+            The Slurm compute node service, `slurmd`, has failed on compute node
+            {{ $labels.node }}.
+
+            Possible causes:
+
+              - The `slurmd` service crashed because of an unhandled error or invalid configuration.
+              - Hardware, kernel, or filesystem issues caused the daemon to fail.
+              - Network or identity mismatches prevented the node from registering properly.
+              - Resource exhaustion or permission issues interfered with daemon startup.
+
+            Potential remediation steps:
+
+              - Inspect the failure reason with `systemctl status slurmd` and `journalctl -u slurmd -n 200`.
+              - Review node logs (`dmesg`, `/var/log/syslog`, and any scheduler logs) for hardware or kernel errors.
+              - Correct configuration, network, or hostname issues before restarting the service.
+              - Restart `slurmd` after remediation and verify the node returns to service.
+
+            LABELS={{ $labels }}

--- a/charms/slurmd/src/cos/alert_rules/prometheus/general.rules
+++ b/charms/slurmd/src/cos/alert_rules/prometheus/general.rules
@@ -19,7 +19,7 @@ groups:
         expr: node_systemd_unit_state{name="slurmd.service", state="inactive"} != 0
         for: 5m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: `slurmd` service on compute node {{ $labels.node }} is inactive
           description: |

--- a/charms/slurmd/src/cos/alert_rules/prometheus/nvidia-gpu.rules
+++ b/charms/slurmd/src/cos/alert_rules/prometheus/nvidia-gpu.rules
@@ -1,0 +1,73 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groups:
+  - name: SlurmComputeNodeNvidiaGPU
+    rules:
+      - alert: SlurmComputeNodeNvidiaGPUIsOverheating
+        expr: DCGM_FI_DEV_GPU_TEMP > 90
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: GPU {{ $labels.gpu }} is overheating on compute node {{ $labels.node }}
+          description: |
+            GPU {{ $labels.gpu }} on compute node {{ $labels.node }} has exceeded 90°C.
+            The current temperature is {{ $value }}°C.
+
+            Possible causes:
+
+              - Restricted airflow, blocked vents, or a failed cooling fan in the server.
+              - High ambient temperature or excessive workload on the GPU.
+              - GPU heatsink, thermal paste, or chassis cooling degradation.
+              - A host-level issue causing sustained high utilization or thermal throttling.
+
+            Potential remediation steps:
+
+              - Check node cooling and airflow, including fans, vents, and rack temperature.
+              - Reduce GPU workload or pause jobs on the affected node while it cools down.
+              - Inspect system and GPU logs for thermal warnings and hardware faults.
+              - If temperatures remain high, drain the node and investigate the hardware before returning it to service.
+
+            LABELS={{ $labels }}
+
+      - alert: SlurmComputeNodeGPUXIDErrorsDetected
+        expr: rate(DCGM_FI_DEV_XID_ERRORS[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Critical XID errors detected on GPU {{ $labels.gpu }} on compute node {{ $labels.node }}
+          description: |
+            GPU {{ $labels.gpu }} on compute node {{ $labels.node }} is reporting critical XID errors.
+            This may lead to users seeing application crashes or data corruption.
+
+            Possible causes:
+
+              - A GPU driver reset, kernel fault, or CUDA runtime failure.
+              - Failing or unstable GPU hardware causing XID error reports.
+              - PCIe bus issues, power instability, or firmware problems.
+              - Application bugs or workloads that trigger driver-level errors.
+
+            Potential remediation steps:
+
+              - Check `dmesg`, `/var/log/syslog`, and NVIDIA DCGM logs for the XID code and context.
+              - Verify driver, firmware, and CUDA stack versions are compatible and up to date.
+              - Drain the node if errors persist, then restart the GPU driver or reboot the host as appropriate.
+              - Run vendor diagnostics or replace the GPU if the hardware continues to report XID errors.
+
+            You can consult XID error catalogue to obtain further context about specific XID error codes:
+            https://docs.nvidia.com/deploy/xid-errors/analyzing-xid-catalog.html
+
+            LABELS={{ $labels }}

--- a/charms/slurmd/src/cos/alert_rules/prometheus/nvidia-gpu.rules
+++ b/charms/slurmd/src/cos/alert_rules/prometheus/nvidia-gpu.rules
@@ -48,10 +48,12 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: Critical XID errors detected on GPU {{ $labels.gpu }} on compute node {{ $labels.node }}
+          summary: XID errors detected on GPU {{ $labels.gpu }} on compute node {{ $labels.node }}
           description: |
             GPU {{ $labels.gpu }} on compute node {{ $labels.node }} is reporting critical XID errors.
             This may lead to users seeing application crashes or data corruption.
+
+            XID error number: {{ value }}
 
             Possible causes:
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds alert rules for local failures on `sackd` and `slurmd` units, and it adds a couple alert rules for capturing potential GPU failures such as GPU devices overheating or a high rate of XID errors are being emitted. I verified the GPU alert rules

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to our ongoing work to improve the observability of Charmed HPC.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

I have one big PR that I'll be opening that'll add reference documentation for all the new alert rules.