### PR TITLE
fix(sackd/slurmd): rename `node` label to `juju_unit_slurm_name` label

### DIFF
--- a/charms/sackd/src/cos/alert_rules/prometheus/general.rules
+++ b/charms/sackd/src/cos/alert_rules/prometheus/general.rules
@@ -21,10 +21,10 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: `sackd` service on login node {{ $labels.node }} is inactive
+          summary: `sackd` service on login node {{ $labels.juju_unit_slurm_name }} is inactive
           description: |
             The Slurm authentication and credential kiosk service, `sackd`, has been inactive for
-            more than 5 minutes on login node {{ $labels.node }}.
+            more than 5 minutes on login node {{ $labels.juju_unit_slurm_name }}.
 
             Possible Causes:
 
@@ -48,10 +48,10 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: `sackd` service on login node {{ $labels.node }} has failed
+          summary: `sackd` service on login node {{ $labels.juju_unit_slurm_name }} has failed
           description: |
             The Slurm authentication and credential kiosk service, `sackd`, has failed
-            on login node {{ $labels.node }}.
+            on login node {{ $labels.juju_unit_slurm_name }}.
 
             Possible causes:
 

--- a/charms/slurmd/src/cos/alert_rules/prometheus/general.rules
+++ b/charms/slurmd/src/cos/alert_rules/prometheus/general.rules
@@ -21,10 +21,10 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: `slurmd` service on compute node {{ $labels.node }} is inactive
+          summary: `slurmd` service on compute node {{ $labels.juju_unit_slurm_name }} is inactive
           description: |
             The Slurm compute node service, `slurmd`, has been inactive for more than 5 minutes
-            on compute node {{ $labels.node }}.
+            on compute node {{ $labels.juju_unit_slurm_name }}.
 
             Possible causes:
 
@@ -47,10 +47,10 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: `slurmd` service on compute node {{ $labels.node }} has failed
+          summary: `slurmd` service on compute node {{ $labels.juju_unit_slurm_name }} has failed
           description: |
             The Slurm compute node service, `slurmd`, has failed on compute node
-            {{ $labels.node }}.
+            {{ $labels.juju_unit_slurm_name }}.
 
             Possible causes:
 

--- a/charms/slurmd/src/cos/alert_rules/prometheus/nvidia-gpu.rules
+++ b/charms/slurmd/src/cos/alert_rules/prometheus/nvidia-gpu.rules
@@ -21,9 +21,9 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: GPU {{ $labels.gpu }} is overheating on compute node {{ $labels.node }}
+          summary: GPU {{ $labels.gpu }} is overheating on compute node {{ $labels.juju_unit_slurm_name }}
           description: |
-            GPU {{ $labels.gpu }} on compute node {{ $labels.node }} has exceeded 90°C.
+            GPU {{ $labels.gpu }} on compute node {{ $labels.juju_unit_slurm_name }} has exceeded 90°C.
             The current temperature is {{ $value }}°C.
 
             Possible causes:
@@ -48,9 +48,9 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: XID errors detected on GPU {{ $labels.gpu }} on compute node {{ $labels.node }}
+          summary: XID errors detected on GPU {{ $labels.gpu }} on compute node {{ $labels.juju_unit_slurm_name }}
           description: |
-            GPU {{ $labels.gpu }} on compute node {{ $labels.node }} is reporting critical XID errors.
+            GPU {{ $labels.gpu }} on compute node {{ $labels.juju_unit_slurm_name }} is reporting critical XID errors.
             This may lead to users seeing application crashes or data corruption.
 
             XID error number: {{ value }}

--- a/internal/slurm-ops/src/slurm_ops/core/constants.py
+++ b/internal/slurm-ops/src/slurm_ops/core/constants.py
@@ -14,13 +14,13 @@
 
 """Constants used within the `slurm-ops` package."""
 
-# Dynamically create the "node" label using the unit name and ID number.
-# This "node" label matches nodes' registered names in Slurm. This relabeling
+# Dynamically create the "juju_unit_slurm_name" label using the unit name and ID number.
+# This "juju_unit_slurm_name" label matches units' registered names in Slurm. This relabeling
 # makes it easier to match scraped `node-exporter` metrics with Slurm exporter metrics
 # in Prometheus alert rules.
 UNIT_TO_NODE_NAME_RELABEL_CONFIG = {
     "source_labels": ["juju_unit"],
-    "target_label": "node",
+    "target_label": "juju_unit_slurm_name",
     "regex": r"(\S+)\/(\d+)",
     "replacement": "${1}-${2}",
 }


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR fixes the collision I was seeing in COS where the `node` label we were injecting into the `node-exporter` metrics were colliding with the `node` label from the Slurm metrics exporter. I chose the name `juju_unit_slurm_name` for the new label. I considered using `sackd_node_name` and `slurmd_node_name`, but then I realized that the 
`juju_application`, `juju_charm`, and `juju_unit` labels already tell use which service the log message is coming from. E.g. `juju_charm` will tells us if the metrics are coming from a `sackd` or `slurmd` application.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Fixes a collision I noticed last night that cause our compute node dashboard in Grafana to lock ugly. The dashboard confuses login node names with compute node names due to the label name collision.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing bugfix.