### PR TITLE
fix: drop `hpc-libs` dependency from git source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "pydantic ~= 2.0",
     "rpds-py ~= 0.23.1",
     "cosl ~= 1.0",
-    "hpc-libs[all]",
     "charmed-hpc-libs[all] >= 0.1.0",
     "slurm-ops",
     "charmed-slurm-slurmctld-interface",
@@ -85,7 +84,6 @@ charmed-slurm-slurmd-interface = { workspace = true }
 charmed-slurm-slurmdbd-interface = { workspace = true }
 charmed-slurm-slurmrestd-interface = { workspace = true }
 ubuntu-drivers-common = { git = "https://github.com/canonical/ubuntu-drivers-common", rev = "554b91edfd3699625dbed90f679abb31a897b76e" }
-hpc-libs = { git = "https://github.com/charmed-hpc/hpc-libs", rev = "9fba44f1729eba44be5577f679e5c03f588bcfff" }
 
 [tool.uv]
 dependency-metadata = [{ name = "ubuntu-drivers-common", version = "0.10.0" }]

--- a/uv.lock
+++ b/uv.lock
@@ -438,19 +438,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hpc-libs"
-version = "0.1.2"
-source = { git = "https://github.com/charmed-hpc/hpc-libs?rev=9fba44f1729eba44be5577f679e5c03f588bcfff#9fba44f1729eba44be5577f679e5c03f588bcfff" }
-
-[package.optional-dependencies]
-all = [
-    { name = "ops" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "slurmutils" },
-]
-
-[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1054,7 +1041,6 @@ dependencies = [
     { name = "charmed-slurm-slurmdbd-interface" },
     { name = "charmed-slurm-slurmrestd-interface" },
     { name = "cosl" },
-    { name = "hpc-libs", extra = ["all"] },
     { name = "influxdb" },
     { name = "nvidia-ml-py" },
     { name = "ops" },
@@ -1108,7 +1094,6 @@ requires-dist = [
     { name = "dbus-fast", marker = "extra == 'dev'", specifier = ">=1.90.2" },
     { name = "distro", marker = "extra == 'dev'", specifier = "==1.9.0" },
     { name = "flake8", marker = "extra == 'dev'" },
-    { name = "hpc-libs", extras = ["all"], git = "https://github.com/charmed-hpc/hpc-libs?rev=9fba44f1729eba44be5577f679e5c03f588bcfff" },
     { name = "influxdb", specifier = "==5.3.2" },
     { name = "jubilant", marker = "extra == 'dev'", specifier = "~=1.0" },
     { name = "nvidia-ml-py", specifier = "==12.560.30" },


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR removes the `hpc-libs` dependency we were pulling via `git` from both the _pyproject.toml_ and _uv.lock_ files. `charmed-hpc-libs` is now the only dependency that we are pulling in.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Required to fix conflicts between `hpc-libs` and Dependabot for fixing identified CVEs in the Slurm charms.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change to improve the time to remediate CVEs in Slurm charm dependencies.