### PR TITLE
feat: build Slurm charms with the `uv` plugin instead of the `charm` plugin

### DIFF
--- a/charms/sackd/charmcraft.yaml
+++ b/charms/sackd/charmcraft.yaml
@@ -36,8 +36,12 @@ parts:
     source: .
     build-snaps:
       - astral-uv
+    override-build: |
+      # Regenerate lockfile to use vendored subpackages from `slurm-charms`.
+      uv lock
+      craftctl default
     build-environment:
-      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
+      - UV_FROZEN: "false"  # Allow lockfile to be updated in `override-build`.
 
 provides:
   metrics-endpoint:

--- a/charms/sackd/charmcraft.yaml
+++ b/charms/sackd/charmcraft.yaml
@@ -32,8 +32,12 @@ platforms:
 
 parts:
   charm:
-    build-packages:
-      - git
+    plugin: uv
+    source: .
+    build-snaps:
+      - astral-uv
+    build-environment:
+      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
 
 provides:
   metrics-endpoint:

--- a/charms/sackd/pyproject.toml
+++ b/charms/sackd/pyproject.toml
@@ -3,9 +3,9 @@ name = "sackd"
 version = "0.0"
 requires-python = "==3.12.*"
 dependencies = [
-    "ops",
+    "ops ~= 3.0",
     "charmed-hpc-libs[ops] >= 0.1.0",
-    "cosl",
+    "cosl ~= 1.0",
     "charmed-slurm-sackd-interface",
     "slurm-ops"
 ]

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -72,8 +72,12 @@ platforms:
 
 parts:
   charm:
-    build-packages:
-      - git
+    plugin: uv
+    source: .
+    build-snaps:
+      - astral-uv
+    build-environment:
+      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
 
 config:
   options:

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -76,8 +76,12 @@ parts:
     source: .
     build-snaps:
       - astral-uv
+    override-build: |
+      # Regenerate lockfile to use vendored subpackages from `slurm-charms`.
+      uv lock
+      craftctl default
     build-environment:
-      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
+      - UV_FROZEN: "false"  # Allow lockfile to be updated in `override-build`.
 
 config:
   options:

--- a/charms/slurmctld/pyproject.toml
+++ b/charms/slurmctld/pyproject.toml
@@ -3,10 +3,11 @@ name = "slurmctld"
 version = "0.0"
 requires-python = "==3.12.*"
 dependencies = [
-    "ops",
-    "slurmutils",
-    "influxdb",
-    "psutil",
+    "ops ~= 3.0",
+    "slurmutils<2.0.0,>=1.1.1",
+    "influxdb == 5.3.2",
+    "pydantic ~= 2.0",
+    "psutil ~= 7.0",
     "charmed-hpc-libs[ops] >= 0.1.0",
     "charmed-slurm-slurmctld-interface",
     "charmed-slurm-oci-runtime-interface",
@@ -15,7 +16,7 @@ dependencies = [
     "charmed-slurm-slurmdbd-interface",
     "charmed-slurm-slurmrestd-interface",
     "charmlibs-apt",
-    "cosl",
+    "cosl ~= 1.0",
     "slurm-ops",
 ]
 

--- a/charms/slurmd/charmcraft.yaml
+++ b/charms/slurmd/charmcraft.yaml
@@ -40,12 +40,20 @@ platforms:
 
 parts:
   charm:
+    plugin: uv
+    source: .
+    build-snaps:
+      - astral-uv
     build-packages:
+      # Required to build `python-apt` and `ubuntu-drivers-common`.
       - git
+      - libapt-pkg-dev
       - libdrm-dev
       - libkmod-dev
       - libpci-dev
       - pkgconf
+    build-environment:
+      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
 
 provides:
   metrics-endpoint:

--- a/charms/slurmd/charmcraft.yaml
+++ b/charms/slurmd/charmcraft.yaml
@@ -52,8 +52,12 @@ parts:
       - libkmod-dev
       - libpci-dev
       - pkgconf
+    override-build: |
+      # Regenerate lockfile to use vendored subpackages from `slurm-charms`.
+      uv lock
+      craftctl default
     build-environment:
-      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
+      - UV_FROZEN: "false"  # Allow lockfile to be updated in `override-build`.
 
 provides:
   metrics-endpoint:

--- a/charms/slurmd/pyproject.toml
+++ b/charms/slurmd/pyproject.toml
@@ -3,12 +3,14 @@ name = "slurmd"
 version = "0.0"
 requires-python = "==3.12.*"
 dependencies = [
-    "ops",
-    "slurmutils",
+    "ops ~= 3.0",
+    "slurmutils<2.0.0,>=1.1.1",
     "ubuntu-drivers-common",
     "charmed-hpc-libs[ops] >= 0.1.0",
     "charmed-slurm-slurmd-interface",
-    "cosl",
+    "cosl ~= 1.0",
+    "pydantic ~= 2.0",
+    "python-apt",
     "slurm-ops",
 ]
 
@@ -16,4 +18,14 @@ dependencies = [
 libraries = [
     "operator-libs-linux.apt",
     "prometheus_k8s.prometheus_scrape"
+]
+
+[tool.uv.sources]
+python-apt = { git = "https://git.launchpad.net/python-apt", rev = "d44043b6df5cb010f3496fc31033c0b6e1f4f021" }
+ubuntu-drivers-common = { git = "https://github.com/canonical/ubuntu-drivers-common", rev = "df01d1c365a9ec82656283fbc360fd420ffcf1e3" }
+
+[tool.uv]
+dependency-metadata = [
+    { name = "python-apt", version = "3.1.0" },
+    { name = "ubuntu-drivers-common", version = "0.10.3" }
 ]

--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -52,12 +52,12 @@ platforms:
 
 parts:
   charm:
-    build-packages:
-      - git
-    charm-binary-python-packages:
-      - cryptography ~= 44.0.0
-      - rpds-py ~= 0.23.1
-
+    plugin: uv
+    source: .
+    build-snaps:
+      - astral-uv
+    build-environment:
+      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
 
 config:
   options:

--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -56,8 +56,12 @@ parts:
     source: .
     build-snaps:
       - astral-uv
+    override-build: |
+      # Regenerate lockfile to use vendored subpackages from `slurm-charms`.
+      uv lock
+      craftctl default
     build-environment:
-      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
+      - UV_FROZEN: "false"  # Allow lockfile to be updated in `override-build`.
 
 config:
   options:

--- a/charms/slurmdbd/pyproject.toml
+++ b/charms/slurmdbd/pyproject.toml
@@ -3,11 +3,12 @@ name = "slurmdbd"
 version = "0.0"
 requires-python = "==3.12.*"
 dependencies = [
-    "ops",
-    "slurmutils",
+    "ops ~= 3.0",
+    "slurmutils<2.0.0,>=1.1.1",
     "charmed-hpc-libs[ops] >= 0.1.0",
     "charmed-slurm-slurmdbd-interface",
-    "cosl",
+    "cosl ~= 1.0",
+    "pydantic ~= 2.0",
     "slurm-ops"
 ]
 

--- a/charms/slurmrestd/charmcraft.yaml
+++ b/charms/slurmrestd/charmcraft.yaml
@@ -29,8 +29,12 @@ platforms:
 
 parts:
   charm:
-    build-packages:
-      - git
+    plugin: uv
+    source: .
+    build-snaps:
+      - astral-uv
+    build-environment:
+      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
 
 provides:
   slurmctld:

--- a/charms/slurmrestd/charmcraft.yaml
+++ b/charms/slurmrestd/charmcraft.yaml
@@ -33,8 +33,12 @@ parts:
     source: .
     build-snaps:
       - astral-uv
+    override-build: |
+      # Regenerate lockfile to use vendored subpackages from `slurm-charms`.
+      uv lock
+      craftctl default
     build-environment:
-      - UV_FROZEN: "false"  # Generate charm lockfile at build time.
+      - UV_FROZEN: "false"  # Allow lockfile to be updated in `override-build`.
 
 provides:
   slurmctld:

--- a/charms/slurmrestd/pyproject.toml
+++ b/charms/slurmrestd/pyproject.toml
@@ -3,8 +3,8 @@ name = "slurmrestd"
 version = "0.0"
 requires-python = "==3.12.*"
 dependencies = [
-    "ops",
-    "slurmutils",
+    "ops ~= 3.0",
+    "slurmutils<2.0.0,>=1.1.1",
     "charmed-hpc-libs[ops] >= 0.1.0",
     "charmed-slurm-slurmrestd-interface",
     "slurm-ops"

--- a/internal/slurm-ops/pyproject.toml
+++ b/internal/slurm-ops/pyproject.toml
@@ -20,7 +20,14 @@ authors = [
     { name = "Ubuntu High-Performance Computing", email = "hpc-ubuntu-group@canonical.com" },
 ]
 requires-python = ">=3.12"
-dependencies = ["charmed-hpc-libs[ops]", "charmlibs-apt", "slurmutils", "nvidia-ml-py"]
+dependencies = [
+    "charmed-hpc-libs[ops]",
+    "charmlibs-apt ~= 1.0",
+    "cryptography ~= 48.0",
+    "distro ~= 1.0",
+    "nvidia-ml-py == 12.560.30",
+    "slurmutils<2.0.0,>=1.1.1",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "cryptography~=46.0.5",
     "distro == 1.9.0",
     "python-dotenv~=1.2.2",
-    "dbus-fast >= 1.90.2",
     "pyfakefs == 5.10.1",
     "coverage[toml]",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "cryptography~=46.0.5",
     "distro == 1.9.0",
     "python-dotenv~=1.2.2",
-    "pycryptodome == 3.20.0",
     "dbus-fast >= 1.90.2",
     "pyfakefs == 5.10.1",
     "coverage[toml]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,32 +16,39 @@
 name = "slurm-charms"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = [
-    "ops ~= 3.0",
-    "slurmutils<2.0.0,>=1.1.1",
-    "influxdb == 5.3.2",
-    "nvidia-ml-py == 12.560.30",
-    "psutil == 7.2.1",
-    "pydantic ~= 2.0",
-    "rpds-py ~= 0.23.1",
-    "cosl ~= 1.0",
+
+[project.optional-dependencies]
+dev = [
+    # repository.py
+    "rtoml ~= 0.0",
+
+    # Development
     "charmed-hpc-libs[all] >= 0.1.0",
-    "slurm-ops",
+    "charmlibs-apt ~= 1.0",
     "charmed-slurm-slurmctld-interface",
     "charmed-slurm-oci-runtime-interface",
     "charmed-slurm-sackd-interface",
     "charmed-slurm-slurmd-interface",
     "charmed-slurm-slurmdbd-interface",
     "charmed-slurm-slurmrestd-interface",
-]
+    "cosl ~= 1.0",
+    "cryptography ~= 48.0",
+    "distro ~= 1.0",
+    "influxdb == 5.3.2",
+    "nvidia-ml-py == 12.560.30",
+    "ops ~= 3.0",
+    "psutil ~= 7.0",
+    "pydantic ~= 2.0",
+    "slurm-ops",
+    "slurmutils<2.0.0,>=1.1.1",
 
-[project.optional-dependencies]
-dev = [
     # Tests
+    "charmed-hpc-libs[all] >= 0.1.0",
     "ops[testing] ~= 3.0",
     "python-dotenv~=1.2.2",
     "pyfakefs == 5.10.1",
     "coverage[toml]",
+    "psutil ~= 7.0",
 
     # Integration
     "aiosmtpd == 1.4.6",
@@ -79,10 +86,15 @@ charmed-slurm-sackd-interface = { workspace = true }
 charmed-slurm-slurmd-interface = { workspace = true }
 charmed-slurm-slurmdbd-interface = { workspace = true }
 charmed-slurm-slurmrestd-interface = { workspace = true }
-ubuntu-drivers-common = { git = "https://github.com/canonical/ubuntu-drivers-common", rev = "554b91edfd3699625dbed90f679abb31a897b76e" }
+python-apt = { git = "https://git.launchpad.net/python-apt", rev = "d44043b6df5cb010f3496fc31033c0b6e1f4f021" }
+ubuntu-drivers-common = { git = "https://github.com/canonical/ubuntu-drivers-common", rev = "df01d1c365a9ec82656283fbc360fd420ffcf1e3" }
+
 
 [tool.uv]
-dependency-metadata = [{ name = "ubuntu-drivers-common", version = "0.10.0" }]
+dependency-metadata = [
+    { name = "python-apt", version = "3.1.0" },
+    { name = "ubuntu-drivers-common", version = "0.10.3" }
+]
 
 [tool.repository]
 external-libraries = [
@@ -92,11 +104,6 @@ external-libraries = [
     { lib = "filesystem-client.mount_info", version = "0.1" },
     { lib = "smtp-integrator.smtp", version = "0.19" },
     { lib = "prometheus_k8s.prometheus_scrape", version = "0.58" }
-]
-binary-packages = [
-    "pydantic-core",
-    "rpds-py",
-    "cryptography"
 ]
 
 # Testing tools configuration
@@ -140,6 +147,7 @@ lint.extend-ignore = [
     "D413",
 ]
 lint.ignore = ["E501", "D107"]
+lint.mccabe.max-complexity = 15
 lint.per-file-ignores = { "**/tests/*" = [
     "D100",
     "D101",
@@ -148,6 +156,3 @@ lint.per-file-ignores = { "**/tests/*" = [
     "D104",
 ] }
 extend-exclude = ["__pycache__", "*.egg_info"]
-
-[tool.ruff.lint.mccabe]
-max-complexity = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ dependencies = [
 dev = [
     # Tests
     "ops[testing] ~= 3.0",
-    "cryptography~=46.0.5",
-    "distro == 1.9.0",
     "python-dotenv~=1.2.2",
     "pyfakefs == 5.10.1",
     "coverage[toml]",

--- a/repository.py
+++ b/repository.py
@@ -27,7 +27,7 @@ PUBLIC_PKGS_PATH = ROOT_DIR / "pkg"
 PRIVATE_PKGS_PATH = ROOT_DIR / "internal"
 PYPROJECT_FILE = "pyproject.toml"
 CHARMCRAFT_FILE = "charmcraft.yaml"
-LOCK_FILE = "uv.lock"
+LOCK_FILE = ROOT_DIR / "uv.lock"
 LIBS_CHARM_PATH = BUILD_PATH / "libs"
 
 
@@ -170,7 +170,7 @@ class Repository:
             raise RepositoryError(f"Failed to read file `{ROOT_DIR / PYPROJECT_FILE}`")
 
         try:
-            with open(ROOT_DIR / LOCK_FILE) as fin:
+            with open(LOCK_FILE) as fin:
                 uv_lock = rtoml.load(fin)
         except OSError:
             raise RepositoryError("Failed to read uv.lock file")
@@ -351,6 +351,10 @@ def stage_charm(
         except OSError:
             raise RepositoryError(f"Failed to write file `{charm.build_path / CHARMCRAFT_FILE}`")
 
+        # Inject uv lockfile into build directories. The lockfile is used by `charmcraft` to determine
+        # the version of charm dependencies to pull in.
+        shutil.copy(LOCK_FILE, charm.build_path)
+
         # Create a version file and pack it into the charm. This is dynamically generated to ensure
         # that the git revision of the charm is always recorded in this version file.
         git_hash = (
@@ -371,14 +375,13 @@ def stage_charm(
         version_file = Path(charm.build_path / "version")
         version_file.write_text(git_hash)
 
-    for lib in charm.libraries:
-        src = LIBS_CHARM_PATH / "lib" / "charms" / lib.path
-        dest = charm.build_path / "lib" / "charms" / lib.path
-        logger.debug("Copying %s to %s", lib, dest)
-        if not dry_run:
-            copy(src, dest)
+        for lib in charm.libraries:
+            src = LIBS_CHARM_PATH / "lib" / "charms" / lib.path
+            dest = charm.build_path / "lib" / "charms" / lib.path
+            logger.debug("Copying %s to %s", lib, dest)
+            if not dry_run:
+                copy(src, dest)
 
-    if not dry_run:
         with open(charm.build_path / "pyproject.toml", "r") as fin:
             pyproject = rtoml.load(fin)
 

--- a/repository.py
+++ b/repository.py
@@ -183,22 +183,6 @@ class Repository:
         except KeyError:
             self.external_libraries = []
 
-        try:
-            binary_packages = project["tool"]["repository"]["binary-packages"]
-
-            resolved_binary_packages = {
-                bin_pkg: package["version"]
-                for bin_pkg in binary_packages
-                for package in uv_lock["package"]
-                if package["name"] == bin_pkg
-            }
-        except KeyError:
-            resolved_binary_packages = {}
-        except StopIteration:
-            raise RepositoryError("Could not find package in the lock file")
-        except OSError:
-            raise RepositoryError(f"Failed to read file `{ROOT_DIR / LOCK_FILE}`")
-
         self.internal_libraries = []
         for charm in CHARMS_PATH.iterdir():
             path = charm / "lib"
@@ -235,7 +219,6 @@ class Repository:
                     path,
                     libraries=self.libraries,
                     packages=self.packages,
-                    binary_packages=resolved_binary_packages,
                     uv_lock=uv_lock,
                 )
             )
@@ -256,7 +239,6 @@ def load_charm(
     *,
     libraries: Collection[CharmLibrary],
     packages: Collection[Package],
-    binary_packages: Mapping[str, str],
     uv_lock: Mapping[str, Any],
 ) -> Charm | None:
     try:
@@ -288,10 +270,6 @@ def load_charm(
             if pkg_dep["name"] not in deps:
                 deps.add(pkg_dep["name"])
                 pending.append(pkg_dep["name"])
-
-    metadata["parts"]["charm"]["charm-binary-python-packages"] = [
-        f"{package}=={version}" for package, version in binary_packages.items() if package in deps
-    ]
 
     libs = []
     try:
@@ -401,32 +379,31 @@ def stage_charm(
             copy(src, dest)
 
     if not dry_run:
-        UV.run_command(
-            [
-                "--quiet",
-                "export",
-                "--package",
-                charm.name,
-                "--frozen",
-                "--no-hashes",
-                "--no-emit-workspace",
-                "--format=requirements-txt",
-                "-o",
-                str(charm.build_path / "requirements.txt"),
-            ]
-        )
+        with open(charm.build_path / "pyproject.toml", "r") as fin:
+            pyproject = rtoml.load(fin)
 
-    if not dry_run:
-        with open(charm.build_path / "requirements.txt", "+a") as f:
-            print("# ===== Local packages =====", file=f)
-            for pkg in charm.packages:
-                filename = f"{pkg.name.replace('-', '_')}-{pkg.version}.tar.gz"
-                src = BUILD_PATH / "dist" / filename
-                dest = charm.build_path / "dist" / filename
-                logger.debug("Copying %s to %s", src, dest)
-                if not dry_run:
-                    copy(src, dest)
-                print(f"./dist/{filename}", file=f)
+        for pkg in charm.packages:
+            filename = f"{pkg.name.replace('-', '_')}-{pkg.version}.tar.gz"
+            src = BUILD_PATH / "dist" / filename
+            dest = charm.build_path / "dist" / filename
+            logger.debug("Copying %s to %s", src, dest)
+            copy(src, dest)
+
+            # Remove any package names from the dependencies fields that conflicts
+            # with local, vendored packages. Replace removed package name with the file path
+            # of the local equivalent package.
+            try:
+                pyproject["project"]["dependencies"].remove(pkg.name)
+            except ValueError:
+                pass
+
+            # Inject local subpackage into charm dependencies.
+            pyproject["project"]["dependencies"].append(
+                f"{pkg.name} @ file:///${{PROJECT_ROOT}}/dist/{filename}"
+            )
+
+        with open(charm.build_path / "pyproject.toml", "wt") as fout:
+            rtoml.dump(pyproject, fout)
 
     logger.info("staged charm %s at %s", charm.path.name, charm.build_path)
 

--- a/repository.py
+++ b/repository.py
@@ -11,13 +11,13 @@ import os
 import shutil
 import subprocess
 import sys
-import tomllib
 from collections.abc import Collection, Mapping, MutableSequence
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Thread
 from typing import Any
 
+import rtoml
 import yaml
 
 ROOT_DIR = Path(__file__).parent.resolve()
@@ -164,14 +164,14 @@ class Repository:
         """Load the monorepo information."""
         UV.run_command(["lock", "--quiet"])
         try:
-            with (ROOT_DIR / PYPROJECT_FILE).open(mode="rb") as f:
-                project = tomllib.load(f)
+            with open(ROOT_DIR / PYPROJECT_FILE, mode="r") as fin:
+                project = rtoml.load(fin)
         except OSError:
             raise RepositoryError(f"Failed to read file `{ROOT_DIR / PYPROJECT_FILE}`")
 
         try:
-            with (ROOT_DIR / LOCK_FILE).open(mode="rb") as f:
-                uv_lock = tomllib.load(f)
+            with open(ROOT_DIR / LOCK_FILE) as fin:
+                uv_lock = rtoml.load(fin)
         except OSError:
             raise RepositoryError("Failed to read uv.lock file")
 
@@ -260,8 +260,8 @@ def load_charm(
     uv_lock: Mapping[str, Any],
 ) -> Charm | None:
     try:
-        with (charm / PYPROJECT_FILE).open(mode="rb") as f:
-            project = tomllib.load(f)
+        with open(charm / PYPROJECT_FILE, mode="r") as fin:
+            project = rtoml.load(fin)
     except NotADirectoryError:
         logger.info("skipping %s because it is not a charm directory", charm)
         return None
@@ -319,8 +319,8 @@ def load_charm(
 
 def load_package(package: Path) -> Package | None:
     try:
-        with (package / PYPROJECT_FILE).open(mode="rb") as f:
-            metadata = tomllib.load(f)
+        with open(package / PYPROJECT_FILE, mode="r") as fin:
+            metadata = rtoml.load(fin)
     except NotADirectoryError:
         logger.info("skipping %s because it is not a package directory", package)
         return None

--- a/uv.lock
+++ b/uv.lock
@@ -20,8 +20,12 @@ members = [
 ]
 
 [[manifest.dependency-metadata]]
+name = "python-apt"
+version = "3.1.0"
+
+[[manifest.dependency-metadata]]
 name = "ubuntu-drivers-common"
-version = "0.10.0"
+version = "0.10.3"
 
 [[package]]
 name = "aiosmtpd"
@@ -355,54 +359,41 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
-]
-
-[[package]]
-name = "dbus-fast"
-version = "4.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/cd/402b0e524bdf37d8b1d22b1d926c538bf1d2eedf115ea1d401c6c08a7d81/dbus_fast-4.0.4.tar.gz", hash = "sha256:43137f0b73a7adbf7d5c0e9eb9d8d34df9e6e0aeafade2166e641c52dfe0a853", size = 75260, upload-time = "2026-04-02T04:41:16.47Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/a5/3d68c39b6c157b4542a154030d3d75123124190420d3c2d9733e554cc131/dbus_fast-4.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:139b462190f7421e55fec421108f824425a559b3d9a5e0b15421e68275735bad", size = 680584, upload-time = "2026-04-02T04:50:00.085Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/cf/86b4b7057d11af1549135234612e40401c69f339551a1c0cd011439a6b8b/dbus_fast-4.0.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00a3db08cf1d98bbedfb73467b774fd49adcf83935b8a92f6c552ce78d93491f", size = 792151, upload-time = "2026-04-02T04:50:02.014Z" },
-    { url = "https://files.pythonhosted.org/packages/95/e5/056a5845b19202336caed7d3b18896c75ec059b68c16f4ded71749c9e0a2/dbus_fast-4.0.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74183b4ef4cc79a9cd1a46e006c19d00ce9abc7d99d36e6adcd094f414446d38", size = 844081, upload-time = "2026-04-02T04:50:04.007Z" },
-    { url = "https://files.pythonhosted.org/packages/25/03/aa1ef750da5f4cfd15eac9892c05ff95b6380cdc44d5bb63b8379c63e81f/dbus_fast-4.0.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:003f042b1299ebac900d6ee30e8ab2a29988937f56792894da7b5d39a26b1f5f", size = 799573, upload-time = "2026-04-02T04:50:05.58Z" },
-    { url = "https://files.pythonhosted.org/packages/22/0c/2338ca2a51eca2392eddd1c1854a5127a8deb705a65a1fc66dc49d1a5557/dbus_fast-4.0.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87be8a41330481c3d3a5e30af10ec713e4f08fe0d6c36f5a401eaef7b5526417", size = 852067, upload-time = "2026-04-02T04:50:07.348Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -701,24 +692,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycryptodome"
-version = "3.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/ed/19223a0a0186b8a91ebbdd2852865839237a21c74f1fbc4b8d5b62965239/pycryptodome-3.20.0.tar.gz", hash = "sha256:09609209ed7de61c2b560cc5c8c4fbf892f8b15b1faf7e4cbffac97db1fffda7", size = 4794232, upload-time = "2024-01-10T11:30:59.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/96/b0d494defb3346378086848a8ece5ddfd138a66c4a05e038fca873b2518c/pycryptodome-3.20.0-cp35-abi3-macosx_10_9_universal2.whl", hash = "sha256:ac1c7c0624a862f2e53438a15c9259d1655325fc2ec4392e66dc46cdae24d044", size = 2427142, upload-time = "2024-01-10T11:30:10.711Z" },
-    { url = "https://files.pythonhosted.org/packages/24/80/56a04e2ae622d7f38c1c01aef46a26c6b73a2ad15c9705a8e008b5befb03/pycryptodome-3.20.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76658f0d942051d12a9bd08ca1b6b34fd762a8ee4240984f7c06ddfb55eaf15a", size = 1590045, upload-time = "2024-01-10T11:30:14.431Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/94/82ebfa5c83d980907ceebf79b00909a569d258bdfd9b0264d621fa752cfd/pycryptodome-3.20.0-cp35-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f35d6cee81fa145333137009d9c8ba90951d7d77b67c79cbe5f03c7eb74d8fe2", size = 2061748, upload-time = "2024-01-10T11:30:16.551Z" },
-    { url = "https://files.pythonhosted.org/packages/af/20/5f29ec45462360e7f61e8688af9fe4a0afae057edfabdada662e11bf97e7/pycryptodome-3.20.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76cb39afede7055127e35a444c1c041d2e8d2f1f9c121ecef573757ba4cd2c3c", size = 2135687, upload-time = "2024-01-10T11:30:18.61Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/1f/6bc4beb4adc07b847e5d3fddbec4522c2c3aa05df9e61b91dc4eff6a4946/pycryptodome-3.20.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49a4c4dc60b78ec41d2afa392491d788c2e06edf48580fbfb0dd0f828af49d25", size = 2164262, upload-time = "2024-01-10T11:30:20.99Z" },
-    { url = "https://files.pythonhosted.org/packages/30/4b/cbc67cda0efd55d7ddcc98374c4b9c853022a595ed1d78dd15c961bc7f6e/pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fb3b87461fa35afa19c971b0a2b7456a7b1db7b4eba9a8424666104925b78128", size = 2054347, upload-time = "2024-01-10T11:30:23.407Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/08/01987ab75ca789247a88c8b2f0ce374ef7d319e79589e0842e316a272662/pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:acc2614e2e5346a4a4eab6e199203034924313626f9620b7b4b38e9ad74b7e0c", size = 2192762, upload-time = "2024-01-10T11:30:25.512Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/bf/798630923b67f4201059c2d690105998f20a6a8fb9b5ab68d221985155b3/pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:210ba1b647837bfc42dd5a813cdecb5b86193ae11a3f5d972b9a0ae2c7e9e4b4", size = 2155230, upload-time = "2024-01-10T11:30:27.609Z" },
-    { url = "https://files.pythonhosted.org/packages/39/12/5fe7f5b9212dda9f5a26f842a324d6541fe1ca8059602124ff30db1e874b/pycryptodome-3.20.0-cp35-abi3-win32.whl", hash = "sha256:8d6b98d0d83d21fb757a182d52940d028564efe8147baa9ce0f38d057104ae72", size = 1723464, upload-time = "2024-01-10T11:30:30.271Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/90/d131c0eb643290230dfa4108b7c2d135122d88b714ad241d77beb4782a76/pycryptodome-3.20.0-cp35-abi3-win_amd64.whl", hash = "sha256:9b3ae153c89a480a0ec402e23db8d8d84a3833b65fa4b15b81b83be9d637aab9", size = 1759588, upload-time = "2024-01-10T11:30:33.031Z" },
-]
-
-[[package]]
 name = "pydantic"
 version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -862,6 +835,11 @@ wheels = [
 ]
 
 [[package]]
+name = "python-apt"
+version = "3.1.0"
+source = { git = "https://git.launchpad.net/python-apt?rev=d44043b6df5cb010f3496fc31033c0b6e1f4f021#d44043b6df5cb010f3496fc31033c0b6e1f4f021" }
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -974,6 +952,27 @@ wheels = [
 ]
 
 [[package]]
+name = "rtoml"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/11/2655729f675411fc82588d6cf598758a2339d56c5a2fa6eb89f3302ec484/rtoml-0.13.0.tar.gz", hash = "sha256:974522c887b47abc0bb62ee8ae9e44d3a0c2cdac9d60ba0ed01c5a40df0ea424", size = 43171, upload-time = "2025-10-19T04:59:00.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/1e/835105f9953ff5a04f1332ff651a185d7c9fa5b333ca6557789621f0bce6/rtoml-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e94c60ee00b6625c1e0f42d411edc8aa1c4fcf09c183347eb362a7b87e36f199", size = 329825, upload-time = "2025-10-19T04:58:21.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/7bd910e8c9a4a8f8d3da8ad7e8c5c63b3227ad9704a04c765b1947c16982/rtoml-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e15f554e62b3b1661bd2ee5972f0a2d3dca925753481c6022b3f31d05634bb4", size = 312637, upload-time = "2025-10-19T04:58:22.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/da/3529447a6b68c0df993845a82f6c64c0755dfa4ea8fc36873845df9b2217/rtoml-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8a2d9c8234d245334765a89f65b0d934f403629423f70f30a688fc8194e8ed1", size = 338019, upload-time = "2025-10-19T04:58:23.414Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8a/9b85639084b018b012c821c5a530b5c025347dcadb7e5794b9b14bd9adc2/rtoml-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7fb0c9f266136a2072d082bc781e49c27422e740505788573ad9cdc58015f58e", size = 366171, upload-time = "2025-10-19T04:58:24.31Z" },
+    { url = "https://files.pythonhosted.org/packages/27/dd/2d9348f6c77a9ec65449696bfd50a539e793b5b5595bd2e4036b6f0cf1fa/rtoml-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2fe4a2443246b56e1fb25f298acb7f3d93da0623d52ef76dbfb2abeb0cfbdfaf", size = 382874, upload-time = "2025-10-19T04:58:25.185Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8a/f350209d8b316a64a734d379cf62927222d58341d2b1665d1854a6bb2933/rtoml-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4a8896475cfb4ef68fd2dda2ad3aacecb6d9c40696e85f47ad8b18b8f003b42", size = 406552, upload-time = "2025-10-19T04:58:26.057Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b4/c1c51adca7b4cf364e80ba9f4c42be3fa95f3ddef6c022b97688addb441e/rtoml-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a0939d03ce3dc5340645e0cb191e82d248dff5a77d6646139c5f9ac8531799d", size = 346034, upload-time = "2025-10-19T04:58:27.298Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4f/3ce38a91e253bb671452ba3b1e11f74197e35318457e638aa3b4d59e06da/rtoml-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:763f8b86db927e1bb6e6d65c676a03c6431f1de1037ae896c3a0984353573547", size = 372957, upload-time = "2025-10-19T04:58:28.244Z" },
+    { url = "https://files.pythonhosted.org/packages/19/58/c4a1ddcc2402fe3b773ee55c03e002682b797297f1dcf5ea362d6ab0ae3e/rtoml-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ff2f38ffbd3c8bfdc60513ef8efdc732fa205bd53a45226559df5605cb1431d5", size = 519510, upload-time = "2025-10-19T04:58:29.226Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/03/1232dc261e35521a73000bf48e9c04451248d1ff9e668949e06549bb87c8/rtoml-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ba2fbc1f1fa7bff8d722fd2539dc9962064b6193b90424625b2d4fe87726f945", size = 518664, upload-time = "2025-10-19T04:58:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/46/5c853e1deab5cbc98564f43cde565e47793889d9c72ca24cf45fb1f637e6/rtoml-0.13.0-cp312-cp312-win32.whl", hash = "sha256:ed5120b56e568df8f297e7a8228b2f2c258daaee3af8b690584cbc0dce1d7f05", size = 217896, upload-time = "2025-10-19T04:58:31.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ec/31ce0a96a0800c060bfbb61d243029f44baf1eb45c1469d70b1768f5b820/rtoml-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:1af5785c1f0119d523c77461de8c910e87f6254d3786f9768a8e16ec8250d42d", size = 222748, upload-time = "2025-10-19T04:58:32.016Z" },
+    { url = "https://files.pythonhosted.org/packages/04/15/b92baaf70147932b66a451b07a4cdd36e6d68a59cd6a47bce9c532acba11/rtoml-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:564903f2ea90191ac172f89a47a3d6b7d633ff7e2ac92b82590924ad6e1452ba", size = 212862, upload-time = "2025-10-19T04:58:32.942Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1014,8 +1013,8 @@ dependencies = [
 requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"], specifier = ">=0.1.0" },
     { name = "charmed-slurm-sackd-interface", editable = "internal/sackd-interface" },
-    { name = "cosl" },
-    { name = "ops" },
+    { name = "cosl", specifier = "~=1.0" },
+    { name = "ops", specifier = "~=3.0" },
     { name = "slurm-ops", editable = "internal/slurm-ops" },
 ]
 
@@ -1032,7 +1031,11 @@ wheels = [
 name = "slurm-charms"
 version = "0.0"
 source = { virtual = "." }
-dependencies = [
+
+[package.optional-dependencies]
+dev = [
+    { name = "aiosmtpd" },
+    { name = "black" },
     { name = "charmed-hpc-libs", extra = ["all"] },
     { name = "charmed-slurm-oci-runtime-interface" },
     { name = "charmed-slurm-sackd-interface" },
@@ -1040,30 +1043,19 @@ dependencies = [
     { name = "charmed-slurm-slurmd-interface" },
     { name = "charmed-slurm-slurmdbd-interface" },
     { name = "charmed-slurm-slurmrestd-interface" },
-    { name = "cosl" },
-    { name = "influxdb" },
-    { name = "nvidia-ml-py" },
-    { name = "ops" },
-    { name = "psutil" },
-    { name = "pydantic" },
-    { name = "rpds-py" },
-    { name = "slurm-ops" },
-    { name = "slurmutils" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "aiosmtpd" },
-    { name = "black" },
+    { name = "charmlibs-apt" },
     { name = "codespell" },
+    { name = "cosl" },
     { name = "coverage" },
     { name = "cryptography" },
-    { name = "dbus-fast" },
     { name = "distro" },
     { name = "flake8" },
+    { name = "influxdb" },
     { name = "jubilant" },
+    { name = "nvidia-ml-py" },
     { name = "ops", extra = ["testing"] },
-    { name = "pycryptodome" },
+    { name = "psutil" },
+    { name = "pydantic" },
     { name = "pyfakefs" },
     { name = "pylint" },
     { name = "pyright" },
@@ -1072,7 +1064,10 @@ dev = [
     { name = "pytest-order" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "rtoml" },
     { name = "ruff" },
+    { name = "slurm-ops" },
+    { name = "slurmutils" },
     { name = "tenacity" },
 ]
 
@@ -1080,28 +1075,27 @@ dev = [
 requires-dist = [
     { name = "aiosmtpd", marker = "extra == 'dev'", specifier = "==1.4.6" },
     { name = "black", marker = "extra == 'dev'" },
-    { name = "charmed-hpc-libs", extras = ["all"], specifier = ">=0.1.0" },
-    { name = "charmed-slurm-oci-runtime-interface", editable = "pkg/slurm-oci-runtime-interface" },
-    { name = "charmed-slurm-sackd-interface", editable = "internal/sackd-interface" },
-    { name = "charmed-slurm-slurmctld-interface", editable = "pkg/slurmctld-interface" },
-    { name = "charmed-slurm-slurmd-interface", editable = "internal/slurmd-interface" },
-    { name = "charmed-slurm-slurmdbd-interface", editable = "internal/slurmdbd-interface" },
-    { name = "charmed-slurm-slurmrestd-interface", editable = "internal/slurmrestd-interface" },
+    { name = "charmed-hpc-libs", extras = ["all"], marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "charmed-slurm-oci-runtime-interface", marker = "extra == 'dev'", editable = "pkg/slurm-oci-runtime-interface" },
+    { name = "charmed-slurm-sackd-interface", marker = "extra == 'dev'", editable = "internal/sackd-interface" },
+    { name = "charmed-slurm-slurmctld-interface", marker = "extra == 'dev'", editable = "pkg/slurmctld-interface" },
+    { name = "charmed-slurm-slurmd-interface", marker = "extra == 'dev'", editable = "internal/slurmd-interface" },
+    { name = "charmed-slurm-slurmdbd-interface", marker = "extra == 'dev'", editable = "internal/slurmdbd-interface" },
+    { name = "charmed-slurm-slurmrestd-interface", marker = "extra == 'dev'", editable = "internal/slurmrestd-interface" },
+    { name = "charmlibs-apt", marker = "extra == 'dev'", specifier = "~=1.0" },
     { name = "codespell", marker = "extra == 'dev'" },
-    { name = "cosl", specifier = "~=1.0" },
+    { name = "cosl", marker = "extra == 'dev'", specifier = "~=1.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
-    { name = "cryptography", marker = "extra == 'dev'", specifier = "~=46.0.5" },
-    { name = "dbus-fast", marker = "extra == 'dev'", specifier = ">=1.90.2" },
-    { name = "distro", marker = "extra == 'dev'", specifier = "==1.9.0" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = "~=48.0" },
+    { name = "distro", marker = "extra == 'dev'", specifier = "~=1.0" },
     { name = "flake8", marker = "extra == 'dev'" },
-    { name = "influxdb", specifier = "==5.3.2" },
+    { name = "influxdb", marker = "extra == 'dev'", specifier = "==5.3.2" },
     { name = "jubilant", marker = "extra == 'dev'", specifier = "~=1.0" },
-    { name = "nvidia-ml-py", specifier = "==12.560.30" },
-    { name = "ops", specifier = "~=3.0" },
+    { name = "nvidia-ml-py", marker = "extra == 'dev'", specifier = "==12.560.30" },
+    { name = "ops", marker = "extra == 'dev'", specifier = "~=3.0" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'", specifier = "~=3.0" },
-    { name = "psutil", specifier = "==7.2.1" },
-    { name = "pycryptodome", marker = "extra == 'dev'", specifier = "==3.20.0" },
-    { name = "pydantic", specifier = "~=2.0" },
+    { name = "psutil", marker = "extra == 'dev'", specifier = "~=7.0" },
+    { name = "pydantic", marker = "extra == 'dev'", specifier = "~=2.0" },
     { name = "pyfakefs", marker = "extra == 'dev'", specifier = "==5.10.1" },
     { name = "pylint", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
@@ -1111,10 +1105,10 @@ requires-dist = [
     { name = "pytest-order", marker = "extra == 'dev'", specifier = "~=1.4" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = "~=1.2.2" },
     { name = "pyyaml", marker = "extra == 'dev'" },
-    { name = "rpds-py", specifier = "~=0.23.1" },
+    { name = "rtoml", marker = "extra == 'dev'", specifier = "~=0.0" },
     { name = "ruff", marker = "extra == 'dev'" },
-    { name = "slurm-ops", editable = "internal/slurm-ops" },
-    { name = "slurmutils", specifier = ">=1.1.1,<2.0.0" },
+    { name = "slurm-ops", marker = "extra == 'dev'", editable = "internal/slurm-ops" },
+    { name = "slurmutils", marker = "extra == 'dev'", specifier = ">=1.1.1,<2.0.0" },
     { name = "tenacity", marker = "extra == 'dev'", specifier = "~=8.2" },
 ]
 provides-extras = ["dev"]
@@ -1126,6 +1120,8 @@ source = { editable = "internal/slurm-ops" }
 dependencies = [
     { name = "charmed-hpc-libs", extra = ["ops"] },
     { name = "charmlibs-apt" },
+    { name = "cryptography" },
+    { name = "distro" },
     { name = "nvidia-ml-py" },
     { name = "slurmutils" },
 ]
@@ -1133,9 +1129,11 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"] },
-    { name = "charmlibs-apt" },
-    { name = "nvidia-ml-py" },
-    { name = "slurmutils" },
+    { name = "charmlibs-apt", specifier = "~=1.0" },
+    { name = "cryptography", specifier = "~=48.0" },
+    { name = "distro", specifier = "~=1.0" },
+    { name = "nvidia-ml-py", specifier = "==12.560.30" },
+    { name = "slurmutils", specifier = ">=1.1.1,<2.0.0" },
 ]
 
 [[package]]
@@ -1155,6 +1153,7 @@ dependencies = [
     { name = "influxdb" },
     { name = "ops" },
     { name = "psutil" },
+    { name = "pydantic" },
     { name = "slurm-ops" },
     { name = "slurmutils" },
 ]
@@ -1169,12 +1168,13 @@ requires-dist = [
     { name = "charmed-slurm-slurmdbd-interface", editable = "internal/slurmdbd-interface" },
     { name = "charmed-slurm-slurmrestd-interface", editable = "internal/slurmrestd-interface" },
     { name = "charmlibs-apt" },
-    { name = "cosl" },
-    { name = "influxdb" },
-    { name = "ops" },
-    { name = "psutil" },
+    { name = "cosl", specifier = "~=1.0" },
+    { name = "influxdb", specifier = "==5.3.2" },
+    { name = "ops", specifier = "~=3.0" },
+    { name = "psutil", specifier = "~=7.0" },
+    { name = "pydantic", specifier = "~=2.0" },
     { name = "slurm-ops", editable = "internal/slurm-ops" },
-    { name = "slurmutils" },
+    { name = "slurmutils", specifier = ">=1.1.1,<2.0.0" },
 ]
 
 [[package]]
@@ -1186,6 +1186,8 @@ dependencies = [
     { name = "charmed-slurm-slurmd-interface" },
     { name = "cosl" },
     { name = "ops" },
+    { name = "pydantic" },
+    { name = "python-apt" },
     { name = "slurm-ops" },
     { name = "slurmutils" },
     { name = "ubuntu-drivers-common" },
@@ -1195,11 +1197,13 @@ dependencies = [
 requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"], specifier = ">=0.1.0" },
     { name = "charmed-slurm-slurmd-interface", editable = "internal/slurmd-interface" },
-    { name = "cosl" },
-    { name = "ops" },
+    { name = "cosl", specifier = "~=1.0" },
+    { name = "ops", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.0" },
+    { name = "python-apt", git = "https://git.launchpad.net/python-apt?rev=d44043b6df5cb010f3496fc31033c0b6e1f4f021" },
     { name = "slurm-ops", editable = "internal/slurm-ops" },
-    { name = "slurmutils" },
-    { name = "ubuntu-drivers-common", git = "https://github.com/canonical/ubuntu-drivers-common?rev=554b91edfd3699625dbed90f679abb31a897b76e" },
+    { name = "slurmutils", specifier = ">=1.1.1,<2.0.0" },
+    { name = "ubuntu-drivers-common", git = "https://github.com/canonical/ubuntu-drivers-common?rev=df01d1c365a9ec82656283fbc360fd420ffcf1e3" },
 ]
 
 [[package]]
@@ -1211,6 +1215,7 @@ dependencies = [
     { name = "charmed-slurm-slurmdbd-interface" },
     { name = "cosl" },
     { name = "ops" },
+    { name = "pydantic" },
     { name = "slurm-ops" },
     { name = "slurmutils" },
 ]
@@ -1219,10 +1224,11 @@ dependencies = [
 requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"], specifier = ">=0.1.0" },
     { name = "charmed-slurm-slurmdbd-interface", editable = "internal/slurmdbd-interface" },
-    { name = "cosl" },
-    { name = "ops" },
+    { name = "cosl", specifier = "~=1.0" },
+    { name = "ops", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.0" },
     { name = "slurm-ops", editable = "internal/slurm-ops" },
-    { name = "slurmutils" },
+    { name = "slurmutils", specifier = ">=1.1.1,<2.0.0" },
 ]
 
 [[package]]
@@ -1241,9 +1247,9 @@ dependencies = [
 requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"], specifier = ">=0.1.0" },
     { name = "charmed-slurm-slurmrestd-interface", editable = "internal/slurmrestd-interface" },
-    { name = "ops" },
+    { name = "ops", specifier = "~=3.0" },
     { name = "slurm-ops", editable = "internal/slurm-ops" },
-    { name = "slurmutils" },
+    { name = "slurmutils", specifier = ">=1.1.1,<2.0.0" },
 ]
 
 [[package]]
@@ -1300,8 +1306,8 @@ wheels = [
 
 [[package]]
 name = "ubuntu-drivers-common"
-version = "0.10.0"
-source = { git = "https://github.com/canonical/ubuntu-drivers-common?rev=554b91edfd3699625dbed90f679abb31a897b76e#554b91edfd3699625dbed90f679abb31a897b76e" }
+version = "0.10.3"
+source = { git = "https://github.com/canonical/ubuntu-drivers-common?rev=df01d1c365a9ec82656283fbc360fd420ffcf1e3#df01d1c365a9ec82656283fbc360fd420ffcf1e3" }
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates our build tooling so that the Slurm charms are built using the `uv` plugin instead of the "deprecated" `charm` plugin. Key changes include:

1. Updating each of the charms' _charmcraft.yaml_ files to use the `uv` plugin.
2. Updating each of the workspace _pyproject.toml_ files to explicitly declare a charms' required dependencies. There were several places where we were implicitly pulling in dependencies which made the `uv` plugin unhappy.
3. Manually declaring `python-apt` as a dependency. The new way charmcraft packs charms doesn't allow dependencies from outside a packed charms' virtual environment to be used, so this was breaking the `slurmd` charm's `gpu` module when it attempted to import the `apt_pkg` model.
4. Dropping several dependencies like `dbus-fast` and `pycryptodome` which are no longer used in any of the Slurm charms.
5. Patching _repository.py_ to inject local dependencies into _pyproject.toml_ files. This is required to provide local packages to `uv` since it doesn't operate on _requirements.txt_ files. This change required introducing `rtoml` as a development dependency since Python's built-in `tomllib` doesn't have writing capabilities.
6. Dropping `charm-binary-python-packages` completely. This option is no longer required since `uv` is capable of pulling prebuilt wheels. No more fancy magic with _uv.lock_.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/charmed-hpc/slurm-charms/issues/200

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing build tooling change.