### PR TITLE
fix: drop unused systemd charm library from dependency declarations

### DIFF
--- a/charms/slurmd/pyproject.toml
+++ b/charms/slurmd/pyproject.toml
@@ -15,6 +15,5 @@ dependencies = [
 [tool.repository]
 libraries = [
     "operator-libs-linux.apt",
-    "operator-libs-linux.systemd",
     "prometheus_k8s.prometheus_scrape"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ dependency-metadata = [{ name = "ubuntu-drivers-common", version = "0.10.0" }]
 [tool.repository]
 external-libraries = [
     { lib = "operator-libs-linux.apt", version = "0.16" },
-    { lib = "operator-libs-linux.systemd", version = "1.4" },
     { lib = "data-platform-libs.data_interfaces", version = "0.41" },
     { lib = "grafana-agent.cos_agent", version = "0.20" },
     { lib = "filesystem-client.mount_info", version = "0.1" },


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR removes the systemd charm library from the _pyproject.toml_ files where it was still referenced. The library wasn't called anywhere within the charms, so only the _pyproject.toml_ files had to be updated.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes https://github.com/charmed-hpc/slurm-charms/issues/232

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change to clean up the Slurm charm dependencies.