### PR TITLE
feat(ci): use centralized `backporting` action for backporting changes to branches

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,4 +1,18 @@
-name: Pull Request Backporting using Git Backporting
+# Copyright 2024-2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Pull request backporting using git backporting
 
 on:
   pull_request_target:
@@ -13,27 +27,7 @@ permissions:
   pull-requests: write # so it can create pull requests
 
 jobs:
-  backporting:
-    name: "Backporting"
-    # Only react to merged PRs for security reasons.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
-    if: >
-      github.event.pull_request.merged
-      && (
-        github.event.action == 'closed'
-          && contains(github.event.pull_request.labels.*.name, 'backport')
-        || (
-          github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport')
-        )
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Backporting
-        uses: kiegroup/git-backporting@8c412dcb1fe477d5d362fa447e5fb7864d3de271 # main
-        with:
-          target-branch: experimental
-          pull-request: ${{ github.event.pull_request.url }}
-          auth: ${{ secrets.GITHUB_TOKEN }}
-          enable-err-notification: true
-          auto-no-squash: true
+  backport:
+    uses: charmed-hpc/.github/.github/workflows/backport.yaml@main
+    with:
+      branches: '["25.11"]'


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the `backporting` action to target the 25.11 branch. It also updates the `backporting` action to use a standard action from `charmed-hpc/.github` so that backporting is consistent across all our repositories.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- backporting CI pipeline is currently busted.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing development tooling change.