### PR TITLE
feat: fully deprecate the `apt` charm library in the Slurm charms

### DIFF
--- a/charms/slurmd/pyproject.toml
+++ b/charms/slurmd/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
 
 [tool.repository]
 libraries = [
-    "operator-libs-linux.apt",
     "prometheus_k8s.prometheus_scrape"
 ]
 

--- a/charms/slurmd/src/rdma.py
+++ b/charms/slurmd/src/rdma.py
@@ -17,7 +17,7 @@
 import logging
 from pathlib import Path
 
-import charms.operator_libs_linux.v0.apt as apt
+from charmlibs import apt
 
 _logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,14 @@ dev = [
 
     # Development
     "charmed-hpc-libs[all] >= 0.1.0",
-    "charmlibs-apt ~= 1.0",
+    "slurm-ops",
     "charmed-slurm-slurmctld-interface",
     "charmed-slurm-oci-runtime-interface",
     "charmed-slurm-sackd-interface",
     "charmed-slurm-slurmd-interface",
     "charmed-slurm-slurmdbd-interface",
     "charmed-slurm-slurmrestd-interface",
+    "charmlibs-apt ~= 1.0",
     "cosl ~= 1.0",
     "cryptography ~= 48.0",
     "distro ~= 1.0",
@@ -98,7 +99,6 @@ dependency-metadata = [
 
 [tool.repository]
 external-libraries = [
-    { lib = "operator-libs-linux.apt", version = "0.16" },
     { lib = "data-platform-libs.data_interfaces", version = "0.41" },
     { lib = "grafana-agent.cos_agent", version = "0.20" },
     { lib = "filesystem-client.mount_info", version = "0.1" },


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR banishes the last usages of the deprecated `apt` charm library from the Slurm charms. The `rdma` module had to be updated to use `charmlibs-apt`, and I had to remove references to the `apt` charm library from the top-level and slurmd workspace _pyproject.toml_ files.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes https://github.com/charmed-hpc/slurm-charms/issues/230

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing dependency deprecation/update.