### PR TITLE
docs: add READMEs for Slurm integration interface implementations

### DIFF
--- a/internal/sackd-interface/README.md
+++ b/internal/sackd-interface/README.md
@@ -1,0 +1,131 @@
+# `charmed-slurm-sackd-interface`
+
+## Usage
+
+This package provides the integration interface implementation for the `sackd` interface. It enables `sackd`
+(Slurm authentication and credential kiosk daemon) applications to receive controller data from `slurmctld`,
+including authentication secrets and controller addresses.
+
+To install, add `charmed-slurm-sackd-interface` to your Python dependencies _pyproject.toml_.
+Then in your Python code, import as:
+
+```python
+from charmed_slurm_sackd_interface import (
+    SackdProvider,
+    SackdRequirer,
+    controller_ready,
+)
+```
+
+## Direction
+
+The `sackd` interface implements a provider/requirer pattern.
+The Provider is the `sackd` application that receives controller data from `slurmctld`.
+The Requirer is the `slurmctld` application that provides authentication secrets and controller addresses to `sackd`.
+
+```mermaid
+flowchart TD
+    Requirer -- auth_secret_id, controllers --> Provider
+```
+
+## Behavior
+
+The `slurmctld` requirer provides controller data (authentication secret and controller addresses) to
+the `sackd` provider through the relation databag. The `sackd` provider validates that required fields
+are present before considering the integration ready.
+
+### Provider
+
+- Is expected to validate that the application databag contains `auth_secret_id` and `controllers` before becoming ready.
+- Is expected to emit `SlurmctldConnectedEvent` when the relation to `slurmctld` is created.
+- Is expected to emit `SlurmctldReadyEvent` when valid controller data is available.
+- Is expected to emit `SlurmctldDisconnectedEvent` when the relation is broken.
+
+### Requirer
+
+- Is expected to emit `SackdConnectedEvent` when a new `sackd` application is connected.
+- Is expected to publish `ControllerData` with at least `auth_secret_id` and `controllers` fields populated.
+
+## Integration data
+
+Data is exchanged through the Juju integration application databag. The `slurmctld` requirer sets `auth_secret_id`
+and `controllers` on its application databag. The authentication key itself is stored as a Juju Secret,
+with only the secret ID in the databag. The `sackd` provider resolves the secret to retrieve the
+actual key material.
+
+[[Source]](src/charmed_slurm_sackd_interface/__init__.py)
+
+### Example
+
+```yaml
+provider:
+  app: {}
+  unit: {}
+requirer:
+  app:
+    auth_secret_id: "secret:abc123"
+    controllers: '["10.0.0.1", "10.0.0.2"]'
+  unit: {}
+```
+
+## Examples
+
+### Provider charm
+
+```python
+"""Example sackd charm receiving controller data from slurmctld."""
+
+import ops
+from charmed_slurm_sackd_interface import SackdProvider, controller_ready
+
+
+class SackdCharm(ops.CharmBase):
+    """A sackd charm that receives controller data."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmctld = SackdProvider(self, "slurmctld")
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_ready, self._on_slurmctld_ready
+        )
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_disconnected, self._on_slurmctld_disconnected
+        )
+
+    def _on_slurmctld_ready(self, event: ops.RelationEvent) -> None:
+        """Handle when controller data is available."""
+        data = self.slurmctld.get_controller_data()
+        # Use data.auth_key and data.controllers to configure sackd
+
+    def _on_slurmctld_disconnected(self, event: ops.RelationEvent) -> None:
+        """Handle when controller data is no longer available."""
+```
+
+### Requirer charm
+
+```python
+"""Example slurmctld charm providing controller data to sackd."""
+
+import ops
+from charmed_slurm_sackd_interface import SackdConnectedEvent, SackdRequirer
+from charmed_slurm_slurmctld_interface import ControllerData
+
+
+class SlurmctldCharm(ops.CharmBase):
+    """The slurmctld charm that provides controller data to sackd."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.sackd = SackdRequirer(self, "sackd")
+        self.framework.observe(
+            self.sackd.on.sackd_connected, self._on_sackd_connected
+        )
+
+    def _on_sackd_connected(self, event: SackdConnectedEvent) -> None:
+        """Provide controller data when a sackd application connects."""
+        data = ControllerData(
+            auth_secret_id="secret:abc123",
+            controllers=["10.0.0.1"],
+        )
+        self.sackd.set_controller_data(data, integration_id=event.relation.id)
+```

--- a/internal/sackd-interface/README.md
+++ b/internal/sackd-interface/README.md
@@ -6,7 +6,7 @@ This package provides the integration interface implementation for the `sackd` i
 It enables charmed applications providing the `sackd` service (Slurm auth and cred kiosk daemon)
 to exchange Slurm management data with charmed applications that require the `sackd` service.
 
-The `sackd` requirer provides controller data (authentication secret and controller addresses) to
+The `sackd` requirer supplies controller data (authentication secret and controller addresses) to
 the `sackd` provider through the integration databag. The `sackd` provider validates that required fields
 are present before considering the integration ready.
 
@@ -49,11 +49,7 @@ actual key material.
 - Is expected to emit `SackdConnectedEvent` when a new `sackd` application is connected.
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `controllers` fields populated.
 
-## Integration data
-
-[[Source]](src/charmed_slurm_sackd_interface/__init__.py)
-
-### Example
+## Example integration data
 
 ```yaml
 provider:
@@ -66,7 +62,7 @@ requirer:
   unit: {}
 ```
 
-## Examples
+## Example usages
 
 ### Provider charm
 

--- a/internal/sackd-interface/README.md
+++ b/internal/sackd-interface/README.md
@@ -2,11 +2,17 @@
 
 ## Usage
 
-This package provides the integration interface implementation for the `sackd` interface. It enables `sackd`
-(Slurm authentication and credential kiosk daemon) applications to receive controller data from `slurmctld`,
-including authentication secrets and controller addresses.
+This package provides the integration interface implementation for the `sackd` interface.
+It enables charmed applications providing the `sackd` service (Slurm auth and cred kiosk daemon)
+to exchange Slurm management data with charmed applications that require the `sackd` service.
 
-To install, add `charmed-slurm-sackd-interface` to your Python dependencies _pyproject.toml_.
+The `sackd` requirer provides controller data (authentication secret and controller addresses) to
+the `sackd` provider through the integration databag. The `sackd` provider validates that required fields
+are present before considering the integration ready.
+
+## Installation
+
+Add `charmed-slurm-sackd-interface` to your Python dependencies _pyproject.toml_.
 Then in your Python code, import as:
 
 ```python
@@ -19,20 +25,17 @@ from charmed_slurm_sackd_interface import (
 
 ## Direction
 
-The `sackd` interface implements a provider/requirer pattern.
-The Provider is the `sackd` application that receives controller data from `slurmctld`.
-The Requirer is the `slurmctld` application that provides authentication secrets and controller addresses to `sackd`.
-
 ```mermaid
-flowchart TD
+flowchart BT
     Requirer -- auth_secret_id, controllers --> Provider
 ```
 
 ## Behavior
 
-The `slurmctld` requirer provides controller data (authentication secret and controller addresses) to
-the `sackd` provider through the relation databag. The `sackd` provider validates that required fields
-are present before considering the integration ready.
+Data is exchanged through the Juju integration application databag. The `sackd` requirer sets `auth_secret_id`
+and `controllers` on its application databag. The authentication key itself is stored as a Juju Secret,
+with only the secret ID in the databag. The `sackd` provider resolves the secret to retrieve the
+actual key material.
 
 ### Provider
 
@@ -47,11 +50,6 @@ are present before considering the integration ready.
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `controllers` fields populated.
 
 ## Integration data
-
-Data is exchanged through the Juju integration application databag. The `slurmctld` requirer sets `auth_secret_id`
-and `controllers` on its application databag. The authentication key itself is stored as a Juju Secret,
-with only the secret ID in the databag. The `sackd` provider resolves the secret to retrieve the
-actual key material.
 
 [[Source]](src/charmed_slurm_sackd_interface/__init__.py)
 

--- a/internal/slurmd-interface/README.md
+++ b/internal/slurmd-interface/README.md
@@ -3,11 +3,17 @@
 ## Usage
 
 This package provides the integration interface implementation for the `slurmd` interface.
-It enables `slurmd` (Slurm compute daemon) applications to exchange data with the `slurmctld` controller.
-`slurmd` receives authentication secrets and controller addresses, and provides partition
-configuration back to `slurmctld`.
+It enables charmed applications providing the `slurmd` service (Slurm compute daemon)
+to exchange partition and Slurm management data with charmed applications that require the
+`slurmd` service.
 
-To install, add `charmed-slurm-slurmd-interface` to your Python dependencies.
+The `slurmd` requirer provides controller data (authentication secret and controller addresses) to
+the `slurmd` provider. In turn, the `slurmd` provider publishes its partition configuration so
+that the `slurmd` requirer can incorporate compute nodes into the cluster configuration.
+
+## Installation
+
+Add `charmed-slurm-slurmd-interface` to your Python dependencies.
 Then in your Python code, import as:
 
 ```python
@@ -22,21 +28,21 @@ from charmed_slurm_slurmd_interface import (
 
 ## Direction
 
-The `slurmd` interface implements a provider/requirer pattern.
-The Provider is the `slurmd` application that provides partition data to `slurmctld` and receives controller data.
-The Requirer is the `slurmctld` application that provides controller data and consumes partition configuration from `slurmd`.
-
 ```mermaid
 flowchart TD
-    Provider -- partition --> Requirer
-    Requirer -- auth_secret_id, controllers --> Provider
+    A["Provider"]
+    B["Requirer"]
+
+    A -- partitionconfig --> B
+    B -- auth_secret_id, controllers --> A
 ```
 
 ## Behavior
 
-The `slurmctld` requirer provides controller data (authentication secret and controller addresses) to the `slurmd`
-provider. In turn, the `slurmd` provider publishes its partition configuration so that `slurmctld` can incorporate
-compute nodes into the cluster configuration.
+Data is exchanged through the Juju integration application databag in both directions.
+The `slurmd` requirer sets controller data (including Juju Secret IDs for authentication keys) on
+its application databag. The `slurmd` provider sets partition configuration data on its own application databag
+as a JSON-serialized `Partition` object from `slurmutils`.
 
 ### Provider
 
@@ -56,11 +62,6 @@ compute nodes into the cluster configuration.
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `controllers` fields populated.
 
 ## Integration data
-
-Data is exchanged through the Juju integration application databag in both directions.
-The `slurmd` requirer sets controller data (including Juju Secret IDs for authentication keys) on
-its application databag. The `slurmd` provider sets partition data on its own application databag as a JSON-serialized
-`Partition` object from `slurmutils`.
 
 [[Source]](src/charmed_slurm_slurmd_interface/__init__.py)
 

--- a/internal/slurmd-interface/README.md
+++ b/internal/slurmd-interface/README.md
@@ -3,11 +3,11 @@
 ## Usage
 
 This package provides the integration interface implementation for the `slurmd` interface.
-It enables charmed applications providing the `slurmd` service (Slurm compute daemon)
+It enables charmed applications that provide the `slurmd` service (Slurm compute daemon)
 to exchange partition and Slurm management data with charmed applications that require the
 `slurmd` service.
 
-The `slurmd` requirer provides controller data (authentication secret and controller addresses) to
+The `slurmd` requirer supplies controller data (authentication secret and controller addresses) to
 the `slurmd` provider. In turn, the `slurmd` provider publishes its partition configuration so
 that the `slurmd` requirer can incorporate compute nodes into the cluster configuration.
 
@@ -61,11 +61,7 @@ as a JSON-serialized `Partition` object from `slurmutils`.
 - Is expected to call `get_compute_data` to retrieve `ComputeData`.
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `controllers` fields populated.
 
-## Integration data
-
-[[Source]](src/charmed_slurm_slurmd_interface/__init__.py)
-
-### Example
+## Example integration data
 
 ```yaml
 provider:
@@ -79,7 +75,7 @@ requirer:
   unit: {}
 ```
 
-## Examples
+## Example usages
 
 ### Provider charm
 

--- a/internal/slurmd-interface/README.md
+++ b/internal/slurmd-interface/README.md
@@ -1,0 +1,152 @@
+# `charmed-slurm-slurmd-interface`
+
+## Usage
+
+This package provides the integration interface implementation for the `slurmd` interface.
+It enables `slurmd` (Slurm compute daemon) applications to exchange data with the `slurmctld` controller.
+`slurmd` receives authentication secrets and controller addresses, and provides partition
+configuration back to `slurmctld`.
+
+To install, add `charmed-slurm-slurmd-interface` to your Python dependencies.
+Then in your Python code, import as:
+
+```python
+from charmed_slurm_slurmd_interface import (
+    ComputeData,
+    SlurmdProvider,
+    SlurmdRequirer,
+    controller_ready,
+    partition_ready,
+)
+```
+
+## Direction
+
+The `slurmd` interface implements a provider/requirer pattern.
+The Provider is the `slurmd` application that provides partition data to `slurmctld` and receives controller data.
+The Requirer is the `slurmctld` application that provides controller data and consumes partition configuration from `slurmd`.
+
+```mermaid
+flowchart TD
+    Provider -- partition --> Requirer
+    Requirer -- auth_secret_id, controllers --> Provider
+```
+
+## Behavior
+
+The `slurmctld` requirer provides controller data (authentication secret and controller addresses) to the `slurmd`
+provider. In turn, the `slurmd` provider publishes its partition configuration so that `slurmctld` can incorporate
+compute nodes into the cluster configuration.
+
+### Provider
+
+- Is expected to validate that the application databag contains `auth_secret_id` and `controllers` before becoming ready.
+- Is expected to call `set_compute_data` to publish `ComputeData` containing the partition configuration.
+- Is expected to only set compute data as the application leader.
+- Is expected to emit `SlurmctldConnectedEvent` when the relation to `slurmctld` is created (leader only).
+- Is expected to emit `SlurmctldReadyEvent` when valid controller data is available.
+- Is expected to emit `SlurmctldDisconnectedEvent` when the relation is broken.
+
+### Requirer
+
+- Is expected to emit `SlurmdConnectedEvent` when a new `slurmd` application is connected (leader only).
+- Is expected to emit `SlurmdReadyEvent` when partition data is available in the `slurmd` application databag (leader only).
+- Is expected to emit `SlurmdDisconnectedEvent` when the `slurmd` application is disconnected (leader only).
+- Is expected to call `get_compute_data` to retrieve `ComputeData`.
+- Is expected to publish `ControllerData` with at least `auth_secret_id` and `controllers` fields populated.
+
+## Integration data
+
+Data is exchanged through the Juju integration application databag in both directions.
+The `slurmd` requirer sets controller data (including Juju Secret IDs for authentication keys) on
+its application databag. The `slurmd` provider sets partition data on its own application databag as a JSON-serialized
+`Partition` object from `slurmutils`.
+
+[[Source]](src/charmed_slurm_slurmd_interface/__init__.py)
+
+### Example
+
+```yaml
+provider:
+  app:
+    partition: '{"PartitionName": "compute", "Nodes": "node[01-10]", "State": "UP"}'
+  unit: {}
+requirer:
+  app:
+    auth_secret_id: "secret:abc123"
+    controllers: '["10.0.0.1", "10.0.0.2"]'
+  unit: {}
+```
+
+## Examples
+
+### Provider charm
+
+```python
+"""Example slurmd charm providing partition data to slurmctld."""
+
+import ops
+from charmed_slurm_slurmd_interface import ComputeData, SlurmdProvider
+from slurmutils import Partition
+
+
+class SlurmdCharm(ops.CharmBase):
+    """A slurmd charm that provides partition configuration."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmctld = SlurmdProvider(self, "slurmctld")
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_ready, self._on_slurmctld_ready
+        )
+
+    def _on_slurmctld_ready(self, event: ops.RelationEvent) -> None:
+        """Publish partition data once controller data is available."""
+        partition = Partition(
+            {"PartitionName": "compute", "Nodes": "node[01-10]", "State": "UP"}
+        )
+        self.slurmctld.set_compute_data(ComputeData(partition=partition))
+```
+
+### Requirer charm
+
+```python
+"""Example slurmctld charm consuming partition data from slurmd."""
+
+import ops
+from charmed_slurm_slurmd_interface import ComputeData, SlurmdConnectedEvent, SlurmdRequirer
+from charmed_slurm_slurmctld_interface import ControllerData
+
+
+class SlurmctldCharm(ops.CharmBase):
+    """The slurmctld charm that consumes partition data from slurmd."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmd = SlurmdRequirer(self, "slurmd")
+        self.framework.observe(
+            self.slurmd.on.slurmd_connected, self._on_slurmd_connected
+        )
+        self.framework.observe(
+            self.slurmd.on.slurmd_ready, self._on_slurmd_ready
+        )
+        self.framework.observe(
+            self.slurmd.on.slurmd_disconnected, self._on_slurmd_disconnected
+        )
+
+    def _on_slurmd_connected(self, event: SlurmdConnectedEvent) -> None:
+        """Provide controller data when a slurmd application connects."""
+        data = ControllerData(
+            auth_secret_id="secret:abc123",
+            controllers=["10.0.0.1"],
+        )
+        self.slurmd.set_controller_data(data, integration_id=event.relation.id)
+
+    def _on_slurmd_ready(self, event: ops.RelationEvent) -> None:
+        """Handle when partition data is available."""
+        data: ComputeData = self.slurmd.get_compute_data()
+        # Use data.partition to update slurm.conf
+
+    def _on_slurmd_disconnected(self, event: ops.RelationEvent) -> None:
+        """Handle when a slurmd application is disconnected."""
+```

--- a/internal/slurmdbd-interface/README.md
+++ b/internal/slurmdbd-interface/README.md
@@ -1,0 +1,151 @@
+# `charmed-slurm-slurmdbd-interface`
+
+## Usage
+
+This package provides the integration interface implementation for the `slurmdbd` interface.
+It enables `slurmdbd` (Slurm database daemon) applications to exchange data with the `slurmctld` controller.
+`slurmdbd` receives authentication and JWT secrets, and provides its hostname back to `slurmctld`.
+
+To install, add `charmed-slurm-slurmdbd-interface` to your Python dependencies.
+Then in your Python code, import as:
+
+```python
+from charmed_slurm_slurmdbd_interface import (
+    DatabaseData,
+    SlurmdbdProvider,
+    SlurmdbdRequirer,
+    controller_ready,
+    database_ready,
+)
+```
+
+## Direction
+
+The `slurmdbd` interface implements a provider/requirer pattern.
+The Provider is the `slurmdbd` application that provides its hostname to `slurmctld` and receives controller data.
+The Requirer is the `slurmctld` application that provides authentication and JWT secrets and consumes the database hostname from `slurmdbd`.
+
+```mermaid
+flowchart TD
+    Provider -- hostname --> Requirer
+    Requirer -- auth_secret_id, jwt_secret_id --> Provider
+```
+
+## Behavior
+
+The `slurmctld` requirer provides controller data (authentication secret and JWT secret)
+to the `slurmdbd` provider. In turn, the `slurmdbd` provider publishes its hostname so that
+`slurmctld` can contact the database service.
+
+### Provider
+
+- Is expected to validate that the application databag contains `auth_secret_id` and `jwt_secret_id` before becoming ready.
+- Is expected to call `set_database_data` to publish `DatabaseData` containing the service hostname.
+- Is expected to only interact with the integration as the application leader.
+- Is expected to emit `SlurmctldConnectedEvent` when the relation to `slurmctld` is created (leader only).
+- Is expected to emit `SlurmctldReadyEvent` when valid controller data is available (leader only).
+- Is expected to emit `SlurmctldDisconnectedEvent` when the relation is broken (leader only).
+
+### Requirer
+
+- Is expected to emit `SlurmdbdConnectedEvent` when a new `slurmdbd` application is connected (leader only).
+- Is expected to emit `SlurmdbdReadyEvent` when database data is available in the `slurmdbd` application databag (leader only).
+- Is expected to emit `SlurmdbdDisconnectedEvent` when the `slurmdbd` application is disconnected (leader only).
+- Is expected to call `get_database_data` to retrieve `DatabaseData`.
+- Is expected to publish `ControllerData` with at least `auth_secret_id` and `jwt_secret_id` fields populated.
+
+## Integration data
+
+Data is exchanged through the Juju integration application databag in both directions. The `slurmctld` requirer
+sets controller data including Juju Secret IDs for authentication and JWT keys on its application databag.
+The `slurmdbd` provider sets its hostname on its own application databag.
+
+[[Source]](src/charmed_slurm_slurmdbd_interface/__init__.py)
+
+### Example
+
+```yaml
+provider:
+  app:
+    hostname: "juju-776f33-0"
+  unit: {}
+requirer:
+  app:
+    auth_secret_id: "secret:abc123"
+    jwt_secret_id: "secret:def456"
+  unit: {}
+```
+
+## Examples
+
+### Provider charm
+
+```python
+"""Example slurmdbd charm providing database hostname to slurmctld."""
+
+import ops
+from charmed_slurm_slurmdbd_interface import DatabaseData, SlurmdbdProvider
+
+
+class SlurmdbdCharm(ops.CharmBase):
+    """A slurmdbd charm that provides its hostname to slurmctld."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmctld = SlurmdbdProvider(self, "slurmctld")
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_ready, self._on_slurmctld_ready
+        )
+
+    def _on_slurmctld_ready(self, event: ops.RelationEvent) -> None:
+        """Publish database hostname once controller data is available."""
+        hostname = f"{self.unit.name.replace('/', '-')}.{self.app.name}-endpoints"
+        self.slurmctld.set_database_data(DatabaseData(hostname=hostname))
+```
+
+### Requirer charm
+
+```python
+"""Example slurmctld charm consuming database data from slurmdbd."""
+
+import ops
+from charmed_slurm_slurmdbd_interface import (
+    DatabaseData,
+    SlurmdbdConnectedEvent,
+    SlurmdbdRequirer,
+)
+from charmed_slurm_slurmctld_interface import ControllerData
+
+
+class SlurmctldCharm(ops.CharmBase):
+    """The slurmctld charm that consumes database data from slurmdbd."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmdbd = SlurmdbdRequirer(self, "slurmdbd")
+        self.framework.observe(
+            self.slurmdbd.on.slurmdbd_connected, self._on_slurmdbd_connected
+        )
+        self.framework.observe(
+            self.slurmdbd.on.slurmdbd_ready, self._on_slurmdbd_ready
+        )
+        self.framework.observe(
+            self.slurmdbd.on.slurmdbd_disconnected, self._on_slurmdbd_disconnected
+        )
+
+    def _on_slurmdbd_connected(self, event: SlurmdbdConnectedEvent) -> None:
+        """Provide controller data when slurmdbd connects."""
+        data = ControllerData(
+            auth_secret_id="secret:abc123",
+            jwt_secret_id="secret:def456",
+        )
+        self.slurmdbd.set_controller_data(data, integration_id=event.relation.id)
+
+    def _on_slurmdbd_ready(self, event: ops.RelationEvent) -> None:
+        """Handle when database data is available."""
+        data: DatabaseData = self.slurmdbd.get_database_data()
+        # Use data.hostname to configure AccountingStorageHost in slurm.conf
+
+    def _on_slurmdbd_disconnected(self, event: ops.RelationEvent) -> None:
+        """Handle when slurmdbd is disconnected."""
+```

--- a/internal/slurmdbd-interface/README.md
+++ b/internal/slurmdbd-interface/README.md
@@ -3,10 +3,11 @@
 ## Usage
 
 This package provides the integration interface implementation for the `slurmdbd` interface.
-It enables `slurmdbd` (Slurm database daemon) applications to exchange data with the `slurmctld`
-(Slurm central management daemon) controller, such as authentication, JWT secrets, and hostnames.
+It enables charmed applications that provide the `slurmdbd` service (Slurm database daemon)
+to exchange its hostname configuration and Slurm management data with charmed applications
+that require the `slurmdbd` service.
 
-The `slurmdbd` requirer provides controller data (authentication secret and JWT secret)
+The `slurmdbd` requirer supplies controller data (authentication secret and JWT secret)
 to the `slurmdbd` provider. In turn, the `slurmdbd` provider publishes its hostname so that
 `slurmctld` can contact the database service.
 
@@ -59,11 +60,7 @@ The `slurmdbd` provider sets its hostname on its own application databag.
 - Is expected to call `get_database_data` to retrieve `DatabaseData`.
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `jwt_secret_id` fields populated.
 
-## Integration data
-
-[[Source]](src/charmed_slurm_slurmdbd_interface/__init__.py)
-
-### Example
+## Example integration data
 
 ```yaml
 provider:
@@ -77,7 +74,7 @@ requirer:
   unit: {}
 ```
 
-## Examples
+## Example usages
 
 ### Provider charm
 

--- a/internal/slurmdbd-interface/README.md
+++ b/internal/slurmdbd-interface/README.md
@@ -3,10 +3,16 @@
 ## Usage
 
 This package provides the integration interface implementation for the `slurmdbd` interface.
-It enables `slurmdbd` (Slurm database daemon) applications to exchange data with the `slurmctld` controller.
-`slurmdbd` receives authentication and JWT secrets, and provides its hostname back to `slurmctld`.
+It enables `slurmdbd` (Slurm database daemon) applications to exchange data with the `slurmctld`
+(Slurm central management daemon) controller, such as authentication, JWT secrets, and hostnames.
 
-To install, add `charmed-slurm-slurmdbd-interface` to your Python dependencies.
+The `slurmdbd` requirer provides controller data (authentication secret and JWT secret)
+to the `slurmdbd` provider. In turn, the `slurmdbd` provider publishes its hostname so that
+`slurmctld` can contact the database service.
+
+## Installation
+
+Add `charmed-slurm-slurmdbd-interface` to your Python dependencies.
 Then in your Python code, import as:
 
 ```python
@@ -21,21 +27,20 @@ from charmed_slurm_slurmdbd_interface import (
 
 ## Direction
 
-The `slurmdbd` interface implements a provider/requirer pattern.
-The Provider is the `slurmdbd` application that provides its hostname to `slurmctld` and receives controller data.
-The Requirer is the `slurmctld` application that provides authentication and JWT secrets and consumes the database hostname from `slurmdbd`.
-
 ```mermaid
 flowchart TD
-    Provider -- hostname --> Requirer
-    Requirer -- auth_secret_id, jwt_secret_id --> Provider
+    A[Provider]
+    B[Requirer]
+
+    A -- hostname --> B
+    B -- auth_secret_id, jwt_secret_id --> A
 ```
 
 ## Behavior
 
-The `slurmctld` requirer provides controller data (authentication secret and JWT secret)
-to the `slurmdbd` provider. In turn, the `slurmdbd` provider publishes its hostname so that
-`slurmctld` can contact the database service.
+Data is exchanged through the Juju integration application databag in both directions. The `slurmdbd` requirer
+sets controller data including Juju Secret IDs for authentication and JWT keys on its application databag.
+The `slurmdbd` provider sets its hostname on its own application databag.
 
 ### Provider
 
@@ -55,10 +60,6 @@ to the `slurmdbd` provider. In turn, the `slurmdbd` provider publishes its hostn
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `jwt_secret_id` fields populated.
 
 ## Integration data
-
-Data is exchanged through the Juju integration application databag in both directions. The `slurmctld` requirer
-sets controller data including Juju Secret IDs for authentication and JWT keys on its application databag.
-The `slurmdbd` provider sets its hostname on its own application databag.
 
 [[Source]](src/charmed_slurm_slurmdbd_interface/__init__.py)
 

--- a/internal/slurmrestd-interface/README.md
+++ b/internal/slurmrestd-interface/README.md
@@ -3,10 +3,10 @@
 ## Usage
 
 This package provides the integration interface implementation for the `slurmrestd` interface.
-It enables `slurmrestd` (Slurm REST API daemon) applications to exchange data with
-`slurmctld` (Slurm central management daemon), including authentication secrets and the Slurm configuration.
+It enables charmed applications providing the `slurmrestd` service (Slurm REST API daemon)
+to exchange Slurm management data with charmed applications that require the `slurmrestd` service.
 
-The `slurmrestd` requirer provides controller data (authentication secret and Slurm configuration) to the
+The `slurmrestd` requirer supplies controller data (authentication secret and Slurm configuration) to the
 `slurmrestd` provider. The `slurmrestd` provider does not send data back; it only consumes controller
 data to configure the REST API daemon.
 
@@ -48,11 +48,7 @@ The `slurmrestd` provider consumes this data but does not write to its own appli
 - Is expected to emit `SlurmrestdConnectedEvent` when a new `slurmrestd` application is connected (leader only).
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `slurmconfig` fields populated.
 
-## Integration data
-
-[[Source]](src/charmed_slurm_slurmrestd_interface/__init__.py)
-
-### Example
+## Example integration data
 
 ```yaml
 provider:
@@ -65,7 +61,7 @@ requirer:
   unit: {}
 ```
 
-## Examples
+## Example usages
 
 ### Provider charm
 

--- a/internal/slurmrestd-interface/README.md
+++ b/internal/slurmrestd-interface/README.md
@@ -2,11 +2,17 @@
 
 ## Usage
 
-This package provides the integration interface implementation for the `slurmrestd` interface. It enables
-`slurmrestd` (Slurm REST API daemon) applications to receive controller data from `slurmctld`,
-including authentication secrets and the Slurm configuration.
+This package provides the integration interface implementation for the `slurmrestd` interface.
+It enables `slurmrestd` (Slurm REST API daemon) applications to exchange data with
+`slurmctld` (Slurm central management daemon), including authentication secrets and the Slurm configuration.
 
-To install, add `charmed-slurm-slurmrestd-interface` to your Python dependencies.
+The `slurmrestd` requirer provides controller data (authentication secret and Slurm configuration) to the
+`slurmrestd` provider. The `slurmrestd` provider does not send data back; it only consumes controller
+data to configure the REST API daemon.
+
+## Installation
+
+Add `charmed-slurm-slurmrestd-interface` to your Python dependencies.
 Then in your Python code, import as:
 
 ```python
@@ -19,20 +25,16 @@ from charmed_slurm_slurmrestd_interface import (
 
 ## Direction
 
-The `slurmrestd` interface implements a provider/requirer pattern.
-The Provider is the `slurmrestd` application that receives controller data from `slurmctld`.
-The Requirer is the `slurmctld` application that provides authentication secrets and Slurm configuration to `slurmrestd`.
-
 ```mermaid
-flowchart TD
+flowchart BT
     Requirer -- auth_secret_id, slurmconfig --> Provider
 ```
 
 ## Behavior
 
-The `slurmctld` requirer provides controller data (authentication secret and Slurm configuration) to the
-`slurmrestd` provider. The `slurmrestd` provider does not send data back; it only consumes controller
-data to configure the REST API daemon.
+Data is exchanged through the Juju integration application databag. The `slurmrestd` requirer sets controller
+data including Juju Secret IDs for authentication and the Slurm configuration on its application databag.
+The `slurmrestd` provider consumes this data but does not write to its own application databag.
 
 ### Provider
 
@@ -47,10 +49,6 @@ data to configure the REST API daemon.
 - Is expected to publish `ControllerData` with at least `auth_secret_id` and `slurmconfig` fields populated.
 
 ## Integration data
-
-Data is exchanged through the Juju integration application databag. The `slurmctld` requirer sets controller
-data including Juju Secret IDs for authentication and the Slurm configuration on its application databag.
-The `slurmrestd` provider consumes this data but does not write to its own application databag.
 
 [[Source]](src/charmed_slurm_slurmrestd_interface/__init__.py)
 

--- a/internal/slurmrestd-interface/README.md
+++ b/internal/slurmrestd-interface/README.md
@@ -1,0 +1,130 @@
+# `charmed-slurm-slurmrestd-interface`
+
+## Usage
+
+This package provides the integration interface implementation for the `slurmrestd` interface. It enables
+`slurmrestd` (Slurm REST API daemon) applications to receive controller data from `slurmctld`,
+including authentication secrets and the Slurm configuration.
+
+To install, add `charmed-slurm-slurmrestd-interface` to your Python dependencies.
+Then in your Python code, import as:
+
+```python
+from charmed_slurm_slurmrestd_interface import (
+    SlurmrestdProvider,
+    SlurmrestdRequirer,
+    controller_ready,
+)
+```
+
+## Direction
+
+The `slurmrestd` interface implements a provider/requirer pattern.
+The Provider is the `slurmrestd` application that receives controller data from `slurmctld`.
+The Requirer is the `slurmctld` application that provides authentication secrets and Slurm configuration to `slurmrestd`.
+
+```mermaid
+flowchart TD
+    Requirer -- auth_secret_id, slurmconfig --> Provider
+```
+
+## Behavior
+
+The `slurmctld` requirer provides controller data (authentication secret and Slurm configuration) to the
+`slurmrestd` provider. The `slurmrestd` provider does not send data back; it only consumes controller
+data to configure the REST API daemon.
+
+### Provider
+
+- Is expected to validate that the application databag contains `auth_secret_id` and `slurmconfig` before becoming ready.
+- Is expected to emit `SlurmctldConnectedEvent` when the relation to `slurmctld` is created.
+- Is expected to emit `SlurmctldReadyEvent` when valid controller data is available.
+- Is expected to emit `SlurmctldDisconnectedEvent` when the relation is broken.
+
+### Requirer
+
+- Is expected to emit `SlurmrestdConnectedEvent` when a new `slurmrestd` application is connected (leader only).
+- Is expected to publish `ControllerData` with at least `auth_secret_id` and `slurmconfig` fields populated.
+
+## Integration data
+
+Data is exchanged through the Juju integration application databag. The `slurmctld` requirer sets controller
+data including Juju Secret IDs for authentication and the Slurm configuration on its application databag.
+The `slurmrestd` provider consumes this data but does not write to its own application databag.
+
+[[Source]](src/charmed_slurm_slurmrestd_interface/__init__.py)
+
+### Example
+
+```yaml
+provider:
+  app: {}
+  unit: {}
+requirer:
+  app:
+    auth_secret_id: "secret:abc123"
+    slurmconfig: '{"slurm.conf": {"SlurmctldHost": "controller-0"}}'
+  unit: {}
+```
+
+## Examples
+
+### Provider charm
+
+```python
+"""Example slurmrestd charm receiving controller data from slurmctld."""
+
+import ops
+from charmed_slurm_slurmrestd_interface import SlurmrestdProvider, controller_ready
+
+
+class SlurmrestdCharm(ops.CharmBase):
+    """A slurmrestd charm that receives controller data."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmctld = SlurmrestdProvider(self, "slurmctld")
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_ready, self._on_slurmctld_ready
+        )
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_disconnected, self._on_slurmctld_disconnected
+        )
+
+    def _on_slurmctld_ready(self, event: ops.RelationEvent) -> None:
+        """Handle when controller data is available."""
+        data = self.slurmctld.get_controller_data()
+        # Use data.auth_key and data.slurmconfig to configure slurmrestd
+
+    def _on_slurmctld_disconnected(self, event: ops.RelationEvent) -> None:
+        """Handle when controller data is no longer available."""
+```
+
+### Requirer charm
+
+```python
+"""Example slurmctld charm providing controller data to slurmrestd."""
+
+import ops
+from charmed_slurm_slurmrestd_interface import SlurmrestdConnectedEvent, SlurmrestdRequirer
+from charmed_slurm_slurmctld_interface import ControllerData
+
+
+class SlurmctldCharm(ops.CharmBase):
+    """The slurmctld charm that provides controller data to slurmrestd."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmrestd = SlurmrestdRequirer(self, "slurmrestd")
+        self.framework.observe(
+            self.slurmrestd.on.slurmrestd_connected, self._on_slurmrestd_connected
+        )
+
+    def _on_slurmrestd_connected(self, event: SlurmrestdConnectedEvent) -> None:
+        """Provide controller data when slurmrestd connects."""
+        data = ControllerData(
+            auth_secret_id="secret:abc123",
+            slurmconfig={"slurm.conf": {"SlurmctldHost": "controller-0"}},
+        )
+        self.slurmrestd.set_controller_data(data, integration_id=event.relation.id)
+```

--- a/pkg/slurm-oci-runtime-interface/README.md
+++ b/pkg/slurm-oci-runtime-interface/README.md
@@ -7,9 +7,13 @@
 
 This package provides the integration interface implementation for the `slurm_oci_runtime` interface.
 It enables OCI runtime charms - for example, Apptainer - to share their runtime configuration
-with the `slurmctld` application, which uses it to generate the `oci.conf` configuration file.
+with `slurm_oci_runtime` requirers like the `slurmctld` application. The `slurm_oci_runtime` requirer
+consumes this data to manage the `oci.conf` configuration file. When the integration is broken,
+the requirer is notified so it can remove the OCI runtime configuration.
 
-To install, add `charmed-slurm-oci-runtime-interface` to your Python dependencies.
+# Installation
+
+Add `charmed-slurm-oci-runtime-interface` to your Python dependencies.
 Then in your Python code, import as:
 
 ```python
@@ -22,10 +26,6 @@ from charmed_slurm_oci_runtime_interface import (
 
 ## Direction
 
-The `slurm_oci_runtime` interface implements a provider/requirer pattern.
-The Provider is the OCI runtime application that shares its runtime configuration with `slurmctld`.
-The Requirer is the `slurmctld` application that consumes OCI runtime configuration to build `oci.conf`.
-
 ```mermaid
 flowchart TD
     Provider -- ociconfig --> Requirer
@@ -33,9 +33,9 @@ flowchart TD
 
 ## Behavior
 
-The OCI runtime provider publishes its configuration data once installed and ready. The `slurmctld`
-requirer consumes this data to manage the `oci.conf` configuration file. When the integration is broken,
-the requirer is notified so it can remove the OCI runtime configuration.
+Data is exchanged through the Juju integration application databag. The OCI runtime provider places its
+configuration - an `OCIConfig` structure from `slurmutils` - in its application databag. The
+`slurmctld` requirer reads this data to construct the `oci.conf` configuration file.
 
 ### Provider
 
@@ -52,13 +52,6 @@ the requirer is notified so it can remove the OCI runtime configuration.
 - Is expected to only process events as the application leader.
 
 ## Integration data
-
-Data is exchanged through the Juju integration application databag. The OCI runtime provider places its
-configuration - an `OCIConfig` structure from `slurmutils` - in its application databag. The
-`slurmctld` requirer reads this data to construct the `oci.conf` file.
-
-Additionally, `slurmctld` provides controller data such as authentication secrets or Slurm configuration
-back to the OCI runtime provider through the same integration, using the inherited `slurmctld` base interface.
 
 [[Source]](src/charmed_slurm_oci_runtime_interface/__init__.py)
 

--- a/pkg/slurm-oci-runtime-interface/README.md
+++ b/pkg/slurm-oci-runtime-interface/README.md
@@ -51,11 +51,7 @@ configuration - an `OCIConfig` structure from `slurmutils` - in its application 
 - Is expected to call `get_oci_runtime_data` to retrieve `OCIRuntimeData`.
 - Is expected to only process events as the application leader.
 
-## Integration data
-
-[[Source]](src/charmed_slurm_oci_runtime_interface/__init__.py)
-
-### Example
+## Example integration data
 
 ```yaml
 provider:
@@ -70,7 +66,7 @@ requirer:
   unit: {}
 ```
 
-## Examples
+## Example usages
 
 ### Provider charm
 

--- a/pkg/slurm-oci-runtime-interface/README.md
+++ b/pkg/slurm-oci-runtime-interface/README.md
@@ -1,18 +1,138 @@
-# charmed-slurm-oci-runtime-interface
+# `charmed-slurm-oci-runtime-interface`
 
-Integration interface implementation for the `slurm_oci_runtime` charm integration interface.
-
-This package provides the `OCIRuntimeProvider` and `OCIRuntimeRequirer` classes used
-to integrate OCI runtime charms (e.g. Apptainer) with `slurmctld`.
+![PyPI - Version](https://img.shields.io/pypi/v/charmed-slurm-oci-runtime-interface)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/charmed-slurm-oci-runtime-interface)
 
 ## Usage
+
+This package provides the integration interface implementation for the `slurm_oci_runtime` interface.
+It enables OCI runtime charms - for example, Apptainer - to share their runtime configuration
+with the `slurmctld` application, which uses it to generate the `oci.conf` configuration file.
+
+To install, add `charmed-slurm-oci-runtime-interface` to your Python dependencies.
+Then in your Python code, import as:
 
 ```python
 from charmed_slurm_oci_runtime_interface import (
     OCIRuntimeData,
-    OCIRuntimeDisconnectedEvent,
-    OCIRuntimeReadyEvent,
     OCIRuntimeProvider,
     OCIRuntimeRequirer,
 )
+```
+
+## Direction
+
+The `slurm_oci_runtime` interface implements a provider/requirer pattern.
+The Provider is the OCI runtime application that shares its runtime configuration with `slurmctld`.
+The Requirer is the `slurmctld` application that consumes OCI runtime configuration to build `oci.conf`.
+
+```mermaid
+flowchart TD
+    Provider -- ociconfig --> Requirer
+```
+
+## Behavior
+
+The OCI runtime provider publishes its configuration data once installed and ready. The `slurmctld`
+requirer consumes this data to manage the `oci.conf` configuration file. When the integration is broken,
+the requirer is notified so it can remove the OCI runtime configuration.
+
+### Provider
+
+- Is expected to call `set_oci_runtime_data` to publish `OCIRuntimeData` containing the OCI runtime configuration.
+- Is expected to only interact with the integration as the application leader.
+- Is expected to emit `SlurmctldConnectedEvent` when the relation to `slurmctld` is created.
+- Is expected to emit `SlurmctldReadyEvent` when controller data from `slurmctld` is available.
+
+### Requirer
+
+- Is expected to emit `OCIRuntimeReadyEvent` when OCI runtime data is available in the application databag.
+- Is expected to emit `OCIRuntimeDisconnectedEvent` when the OCI runtime application is disconnected.
+- Is expected to call `get_oci_runtime_data` to retrieve `OCIRuntimeData`.
+- Is expected to only process events as the application leader.
+
+## Integration data
+
+Data is exchanged through the Juju integration application databag. The OCI runtime provider places its
+configuration - an `OCIConfig` structure from `slurmutils` - in its application databag. The
+`slurmctld` requirer reads this data to construct the `oci.conf` file.
+
+Additionally, `slurmctld` provides controller data such as authentication secrets or Slurm configuration
+back to the OCI runtime provider through the same integration, using the inherited `slurmctld` base interface.
+
+[[Source]](src/charmed_slurm_oci_runtime_interface/__init__.py)
+
+### Example
+
+```yaml
+provider:
+  app:
+    ociconfig: '{"RunTimeDefault": "apptainer", "RunTimeEnvExclude": "^SLURM"}'
+  unit: {}
+requirer:
+  app:
+    auth_secret_id: "secret:abc123"
+    controllers: '["10.0.0.1"]'
+    slurmconfig: '{"slurm.conf": {...}}'
+  unit: {}
+```
+
+## Examples
+
+### Provider charm
+
+```python
+"""Example OCI runtime charm providing runtime configuration to slurmctld."""
+
+import ops
+from charmed_slurm_oci_runtime_interface import OCIRuntimeData, OCIRuntimeProvider
+from slurmutils import OCIConfig
+
+
+class ApptainerCharm(ops.CharmBase):
+    """An OCI runtime charm that provides configuration to slurmctld."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.oci_runtime = OCIRuntimeProvider(self, "slurm-oci-runtime")
+        self.framework.observe(
+            self.oci_runtime.on.slurmctld_ready, self._on_slurmctld_ready
+        )
+
+    def _on_slurmctld_ready(self, event: ops.RelationEvent) -> None:
+        """Publish OCI runtime data once slurmctld is connected."""
+        config = OCIConfig({"RunTimeDefault": "apptainer"})
+        self.oci_runtime.set_oci_runtime_data(OCIRuntimeData(ociconfig=config))
+```
+
+### Requirer charm
+
+```python
+"""Example slurmctld charm consuming OCI runtime configuration."""
+
+import ops
+from charmed_slurm_oci_runtime_interface import OCIRuntimeData, OCIRuntimeRequirer
+
+
+class SlurmctldCharm(ops.CharmBase):
+    """The slurmctld charm that consumes OCI runtime configuration."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.oci_runtime = OCIRuntimeRequirer(self, "slurm-oci-runtime")
+        self.framework.observe(
+            self.oci_runtime.on.oci_runtime_ready, self._on_oci_runtime_ready
+        )
+        self.framework.observe(
+            self.oci_runtime.on.oci_runtime_disconnected,
+            self._on_oci_runtime_disconnected,
+        )
+
+    def _on_oci_runtime_ready(self, event: ops.RelationEvent) -> None:
+        """Handle when OCI runtime data is available."""
+        data: OCIRuntimeData = self.oci_runtime.get_oci_runtime_data()
+        # Use data.ociconfig to write oci.conf
+
+    def _on_oci_runtime_disconnected(self, event: ops.RelationEvent) -> None:
+        """Handle when OCI runtime is disconnected."""
 ```

--- a/pkg/slurmctld-interface/README.md
+++ b/pkg/slurmctld-interface/README.md
@@ -1,12 +1,20 @@
-# charmed-slurm-slurmctld-interface
+# `charmed-slurm-slurmctld-interface`
 
-Integration interface implementation for the `slurmctld` Juju charm integration.
-
-This package provides the `SlurmctldProvider` and `SlurmctldRequirer` base classes
-used to build all Slurm integration interfaces, along with common data structures,
-events, and utilities shared between Slurm-related integration interfaces.
+![PyPI - Version](https://img.shields.io/pypi/v/charmed-slurm-slurmctld-interface)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/charmed-slurm-slurmctld-interface)
 
 ## Usage
+
+This package provides the base integration interface implementation for the `slurmctld` interface.
+It defines the `SlurmctldProvider` and `SlurmctldRequirer` base classes that all other Slurm integration
+interfaces inherit from, along with common data structures, events, and utilities shared across
+Slurm-related integrations.
+
+Charms that implement a new Slurm service integration should depend on this package and extend
+`SlurmctldProvider` or `SlurmctldRequirer` as appropriate.
+
+To install, add `charmed-slurm-slurmctld-interface` to your Python dependencies.
+Then in your Python code, import as:
 
 ```python
 from charmed_slurm_slurmctld_interface import (
@@ -14,6 +22,262 @@ from charmed_slurm_slurmctld_interface import (
     SlurmctldProvider,
     SlurmctldRequirer,
     controller_ready,
+    encoder,
 )
 ```
 
+## Direction
+
+The `slurmctld` interface implements a provider/requirer pattern.
+The Provider is the `slurmctld` application that shares controller configuration, authentication keys,
+and JWT keys with other Slurm services. The Requirer is any Slurm service application such as
+`slurmd`, `slurmdbd`, `slurmrestd`, or `sackd` that needs controller data to operate.
+
+```mermaid
+flowchart TD
+    Provider -- auth_secret_id, controllers, jwt_secret_id, slurmconfig --> Requirer
+```
+
+## Behavior
+
+The `slurmctld` provider sets controller data on the application databag for each related integration.
+Authentication and JWT keys are stored as Juju Secrets, and the provider grants access to those secrets
+on a per-integration basis. When an integration is broken, the provider revokes the departing
+application's access to secrets.
+
+The requirer listens for relation lifecycle events and emits higher-level events to
+signal when controller data becomes available or is removed.
+
+### Provider
+
+- Is expected to call `set_controller_data` to publish `ControllerData` to related applications.
+- Is expected to grant access to the `auth_key` and `jwt_key` Juju Secrets when an integration ID is specified.
+- Is expected to revoke secret access when the integration is broken.
+
+### Requirer
+
+- Is expected to emit `SlurmctldConnectedEvent` when a relation is created.
+- Is expected to emit `SlurmctldReadyEvent` when the provider's application databag contains data.
+- Is expected to emit `SlurmctldDisconnectedEvent` when the relation is broken (unless the local unit is departing).
+- Is expected to call `get_controller_data` to retrieve `ControllerData` and resolve secrets into their plaintext values.
+
+## Integration data
+
+Data is exchanged through the Juju integration application databag. Sensitive fields like `auth_key` and `jwt_key`
+are stored as Juju Secrets; only the secret IDs are placed in the databag. The requirer
+resolves secret IDs into their content when reading controller data.
+
+[[Source]](src/charmed_slurm_slurmctld_interface/__init__.py)
+
+### Example
+
+```yaml
+provider:
+  app:
+    auth_secret_id: "secret:abc123"
+    controllers: '["10.0.0.1", "10.0.0.2"]'
+    jwt_secret_id: "secret:def456"
+    slurmconfig: '{"slurm.conf": {...}}'
+  unit: {}
+requirer:
+  app: {}
+  unit: {}
+```
+
+## Examples
+
+### Requirer charm
+
+```python
+"""Example charm consuming slurmctld controller data."""
+
+import ops
+from charmed_slurm_slurmctld_interface import (
+    ControllerData,
+    SlurmctldRequirer,
+)
+
+
+class MySlurmdCharm(ops.CharmBase):
+    """A charm that requires controller data from slurmctld."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.slurmctld = SlurmctldRequirer(self, "slurmctld")
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_ready, self._on_slurmctld_ready
+        )
+        self.framework.observe(
+            self.slurmctld.on.slurmctld_disconnected, self._on_slurmctld_disconnected
+        )
+
+    def _on_slurmctld_ready(self, event: ops.RelationEvent) -> None:
+        """Handle when controller data is available."""
+        data: ControllerData = self.slurmctld.get_controller_data()
+        # Use data.auth_key, data.controllers, etc.
+
+    def _on_slurmctld_disconnected(self, event: ops.RelationEvent) -> None:
+        """Handle when controller data is no longer available."""
+```
+
+### Provider charm
+
+```python
+"""Example charm providing slurmctld controller data."""
+
+import ops
+from charmed_slurm_slurmctld_interface import (
+    ControllerData,
+    SlurmctldProvider,
+)
+
+
+class SlurmctldCharm(ops.CharmBase):
+    """The slurmctld charm that provides controller data."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        self.provider = SlurmctldProvider(self, "slurmctld")
+        self.framework.observe(self.on.leader_elected, self._on_leader_elected)
+
+    def _on_leader_elected(self, event: ops.LeaderElectedEvent) -> None:
+        """Publish controller data to all related applications."""
+        data = ControllerData(
+            auth_secret_id="secret:abc123",
+            controllers=["10.0.0.1"],
+            jwt_secret_id="secret:def456",
+            slurmconfig={},
+        )
+        self.provider.set_controller_data(data)
+```
+
+### Building a downstream interface with `SlurmctldRequirer`
+
+Subclass `SlurmctldRequirer` to build an interface that consumes controller data and
+optionally provides service-specific data back to `slurmctld`. Pass `required_app_data`
+and an `app_data_validator` to control when the integration is considered ready.
+
+```python
+"""Minimal downstream interface that extends SlurmctldRequirer."""
+
+from dataclasses import dataclass
+
+import ops
+from charmed_hpc_libs.ops import leader
+from charmed_slurm_slurmctld_interface import SlurmctldRequirer, encoder
+
+_REQUIRED_APP_DATA = {
+    "auth_secret_id": lambda value: value != '""',
+    "controllers": lambda value: value != "[]",
+}
+
+
+@dataclass(frozen=True)
+class ServiceData:
+    """Data provided by the downstream service back to slurmctld."""
+
+    endpoint: str = ""
+
+
+class ServiceProvider(SlurmctldRequirer):
+    """Interface used on the downstream service to consume controller data."""
+
+    def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
+        super().__init__(
+            charm,
+            integration_name,
+            required_app_data=set(_REQUIRED_APP_DATA),
+            app_data_validator=lambda data: all(
+                v(data[k]) for k, v in _REQUIRED_APP_DATA.items()
+            ),
+        )
+
+    @leader
+    def set_service_data(
+        self, data: ServiceData, /, integration_id: int | None = None
+    ) -> None:
+        """Publish service-specific data on the application databag."""
+        self._save_integration_data(data, self.app, integration_id, encoder=encoder)
+```
+
+### Building a downstream interface with `SlurmctldProvider`
+
+Subclass `SlurmctldProvider` to build an interface used on the `slurmctld` side that
+provides controller data and consumes service-specific data from a downstream application.
+
+```python
+"""Minimal downstream interface that extends SlurmctldProvider."""
+
+from dataclasses import dataclass
+
+import ops
+from charmed_hpc_libs.ops import leader
+from charmed_slurm_slurmctld_interface import SlurmctldProvider
+
+
+@dataclass(frozen=True)
+class ServiceData:
+    endpoint: str = ""
+
+
+class ServiceConnectedEvent(ops.RelationEvent):
+    """Emitted when the downstream service application is connected."""
+
+
+class ServiceReadyEvent(ops.RelationEvent):
+    """Emitted when the downstream service application data is available."""
+
+
+class ServiceDisconnectedEvent(ops.RelationEvent):
+    """Emitted when the downstream service application is disconnected."""
+
+
+class _ServiceRequirerEvents(ops.ObjectEvents):
+    service_connected = ops.EventSource(ServiceConnectedEvent)
+    service_ready = ops.EventSource(ServiceReadyEvent)
+    service_disconnected = ops.EventSource(ServiceDisconnectedEvent)
+
+
+class ServiceRequirer(SlurmctldProvider):
+    """Interface used on slurmctld to consume data from the downstream service."""
+
+    on = _ServiceRequirerEvents()
+
+    def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
+        super().__init__(charm, integration_name, required_app_data={"endpoint"})
+        self.framework.observe(
+            self.charm.on[self._integration_name].relation_created,
+            self._on_relation_created,
+        )
+        self.framework.observe(
+            self.charm.on[self._integration_name].relation_changed,
+            self._on_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[self._integration_name].relation_broken,
+            self._on_relation_broken,
+        )
+
+    @leader
+    def _on_relation_created(self, event: ops.RelationCreatedEvent) -> None:
+        self.on.service_connected.emit(event.relation)
+
+    @leader
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        if not event.relation.data.get(event.relation.app):
+            return
+
+        self.on.service_ready.emit(event.relation)
+
+    @leader
+    def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
+        if self._stored.unit_departing:
+            return
+
+        super()._on_relation_broken(event)
+        self.on.service_disconnected.emit(event.relation)
+
+    def get_service_data(self, integration_id: int | None = None) -> ServiceData:
+        """Retrieve service data from the downstream application databag."""
+        return self._load_integration_data(ServiceData, integration_id=integration_id).pop()
+```

--- a/pkg/slurmctld-interface/README.md
+++ b/pkg/slurmctld-interface/README.md
@@ -5,10 +5,10 @@
 
 ## Usage
 
-This package provides the base integration interface implementation for the other Slurm interfaces.
+This package provides the base building blocks for Slurm-related integration interface implementations.
 It defines the `SlurmctldProvider` and `SlurmctldRequirer` base classes that all other Slurm integration
-interfaces inherit from, along with common data structures, events, and utilities shared across
-Slurm-related integrations.
+interfaces inherit from, along with common data structures, events, and utilities shared across Slurm-related
+integrations.
 
 Authentication and JWT keys are stored as Juju Secrets, and the `slurmctld` provider grants access to
 those secrets on a per-integration basis. When an integration is broken, the provider revokes the departing
@@ -62,11 +62,7 @@ The requirer resolves secret IDs into their content when reading controller data
 - Is expected to emit `SlurmctldDisconnectedEvent` when the relation is broken (unless the local unit is departing).
 - Is expected to call `get_controller_data` to retrieve `ControllerData` and resolve secrets into their plaintext values.
 
-## Integration data
-
-[[Source]](src/charmed_slurm_slurmctld_interface/__init__.py)
-
-### Example
+## Example integration data
 
 ```yaml
 provider:
@@ -81,7 +77,7 @@ requirer:
   unit: {}
 ```
 
-## Examples
+## Example usages
 
 ### Requirer charm
 

--- a/pkg/slurmctld-interface/README.md
+++ b/pkg/slurmctld-interface/README.md
@@ -5,15 +5,25 @@
 
 ## Usage
 
-This package provides the base integration interface implementation for the `slurmctld` interface.
+This package provides the base integration interface implementation for the other Slurm interfaces.
 It defines the `SlurmctldProvider` and `SlurmctldRequirer` base classes that all other Slurm integration
 interfaces inherit from, along with common data structures, events, and utilities shared across
 Slurm-related integrations.
 
-Charms that implement a new Slurm service integration should depend on this package and extend
-`SlurmctldProvider` or `SlurmctldRequirer` as appropriate.
+Authentication and JWT keys are stored as Juju Secrets, and the `slurmctld` provider grants access to
+those secrets on a per-integration basis. When an integration is broken, the provider revokes the departing
+application's access to secrets.
 
-To install, add `charmed-slurm-slurmctld-interface` to your Python dependencies.
+`slurmctld` requirers listen for integration lifecycle events and emit higher-level events to
+signal when controller data becomes available or is removed.
+
+Charms that implement a new Slurm service integration should depend on this package and extend
+`SlurmctldProvider` or `SlurmctldRequirer` as appropriate. `SlurmctldProvider` and `SlurmctldRequirer`
+should not be used directly in charm code.
+
+## Installation
+
+Add `charmed-slurm-slurmctld-interface` to your Python dependencies.
 Then in your Python code, import as:
 
 ```python
@@ -28,11 +38,6 @@ from charmed_slurm_slurmctld_interface import (
 
 ## Direction
 
-The `slurmctld` interface implements a provider/requirer pattern.
-The Provider is the `slurmctld` application that shares controller configuration, authentication keys,
-and JWT keys with other Slurm services. The Requirer is any Slurm service application such as
-`slurmd`, `slurmdbd`, `slurmrestd`, or `sackd` that needs controller data to operate.
-
 ```mermaid
 flowchart TD
     Provider -- auth_secret_id, controllers, jwt_secret_id, slurmconfig --> Requirer
@@ -40,13 +45,9 @@ flowchart TD
 
 ## Behavior
 
-The `slurmctld` provider sets controller data on the application databag for each related integration.
-Authentication and JWT keys are stored as Juju Secrets, and the provider grants access to those secrets
-on a per-integration basis. When an integration is broken, the provider revokes the departing
-application's access to secrets.
-
-The requirer listens for relation lifecycle events and emits higher-level events to
-signal when controller data becomes available or is removed.
+Data is exchanged through the Juju integration application databag. Sensitive fields like `auth_secret_id`
+and `jwt_secret_id` are stored as Juju Secrets; only the secret IDs are placed in the integration databag.
+The requirer resolves secret IDs into their content when reading controller data.
 
 ### Provider
 
@@ -62,10 +63,6 @@ signal when controller data becomes available or is removed.
 - Is expected to call `get_controller_data` to retrieve `ControllerData` and resolve secrets into their plaintext values.
 
 ## Integration data
-
-Data is exchanged through the Juju integration application databag. Sensitive fields like `auth_key` and `jwt_key`
-are stored as Juju Secrets; only the secret IDs are placed in the databag. The requirer
-resolves secret IDs into their content when reading controller data.
 
 [[Source]](src/charmed_slurm_slurmctld_interface/__init__.py)
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds/enhances READMEs for the Slurm charm integration interface implementations. They're styled similar to existing READMEs for integration interface implementations, and borrow elements from github.com/canonical/charmlibs for documenting the structure of interfaces.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Required to partially address https://github.com/charmed-hpc/docs/issues/140. These READMEs will be provided as links to the "Underlying projects and dependencies" reference documentation.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

I will open a PR to update the "Underlying projects and dependencies" reference documentation once this PR is approved and merged.