### PR TITLE
[25.11] fix: drop unused systemd charm library from dependency declarations

### DIFF
--- a/charms/slurmd/pyproject.toml
+++ b/charms/slurmd/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
 [tool.repository]
 libraries = [
     "operator-libs-linux.apt",
-    "operator-libs-linux.systemd",
     "prometheus_k8s.prometheus_scrape"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ dependency-metadata = [
 [tool.repository]
 external-libraries = [
     { lib = "operator-libs-linux.apt", version = "0.16" },
-    { lib = "operator-libs-linux.systemd", version = "1.4" },
     { lib = "data-platform-libs.data_interfaces", version = "0.41" },
     { lib = "grafana-agent.cos_agent", version = "0.20" },
     { lib = "filesystem-client.mount_info", version = "0.1" },


### PR DESCRIPTION
Backport 443c10152259a4fa35b278f61adfc144d8444703