### PR TITLE
feat(ci): change `25.11` branch name to `track/25.11`

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -30,4 +30,4 @@ jobs:
   backport:
     uses: charmed-hpc/.github/.github/workflows/backport.yaml@main
     with:
-      branches: '["25.11"]'
+      branches: '["track/25.11"]'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Release to latest/edge
+name: Release to Charmhub
 
 on:
   push:
     branches:
-      - main
+      - "main"  # latest/edge
+      - "track/*"  # <track>/edge
 
 jobs:
   ci-tests:
@@ -25,8 +26,8 @@ jobs:
     with:
       enable_ha: true
 
-  release-to-charmhub:
-    name: Release to Charmhub
+  release-charm:
+    name: Release charm
     needs:
       - ci-tests
     runs-on: ubuntu-24.04


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates our existing workflow files to use the `track/25.11` branch name instead of `25.11`. This change is to make it easier to use existing automation to build and publish charms rather than ship our own custom tooling.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- PR https://github.com/charmed-hpc/slurm-charms/pull/241 updates the _ci.yaml_ file.
- More granular backport CI logic will be required once we start adding more branches to the Slurm charms repository, but we're focusing on 25.11 primarily for now since it's our first release.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing development tooling change.