### PR TITLE
fix: pass `secret: inherit` to backporting CI action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -31,3 +31,4 @@ jobs:
     uses: charmed-hpc/.github/.github/workflows/backport.yaml@main
     with:
       branches: '["track/25.11"]'
+    secrets: inherit


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the backporting CI action to let our reusable backporting action access the Ubuntu HPC bot PAT token configured for this repository. This token is then used by the backporting action to automatically open backporting PRs and comment on existing pull requests.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

The CI pipeline is currently not running for backport PRs since GitHub automatically supresses events from the `github-actions[bot]` that is currently used to open backport PRs.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing development tooling modification.