### PR TITLE
chore: migrate repo to the canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-** @charmed-hpc/python-reviewers
+** @canonical/hpc-code-reviewers

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   backport:
-    uses: charmed-hpc/.github/.github/workflows/backport.yaml@main
+    uses: canonical/hpc-team/.github/workflows/backport.yaml@main
     with:
       branches: '["track/25.11"]'
     secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: charmed-hpc/.github/.github/workflows/charmed-hpc-ci.yaml@main
+    uses: canonical/hpc-team/.github/workflows/charmed-hpc-ci.yaml@main
     with:
       run-test: false
       setup-commands: &setup_cmds |
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: charmed-hpc/.github/.github/actions/setup-just@main
+      - uses: canonical/hpc-team/.github/actions/setup-just@main
       - run: *setup_cmds
       - run: just unit
 
@@ -78,7 +78,7 @@ jobs:
           sudo rm -rf /usr/local/share/boost
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4
-      - uses: charmed-hpc/.github/.github/actions/setup-just@main
+      - uses: canonical/hpc-team/.github/actions/setup-just@main
       - run: *setup_cmds
       - uses: charmed-kubernetes/actions-operator@main
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,10 @@ Before you start working on your contribution, please familiarize yourself with 
 HPC project's contributing guide]. After you've gone through the main contributing guide,
 you can use this guide for specific information on contributing to the `slurm-charms` repository.
 
-Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat]
-or on [GitHub Discussions].
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat].
 
-[Charmed HPC project's contributing guide]: https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md
+[Charmed HPC project's contributing guide]: https://github.com/canonical/charmed-hpc-docs/blob/main/CONTRIBUTING.md
 [Ubuntu High-Performance Computing Matrix chat]: https://matrix.to/#/#hpc:ubuntu.com
-[GitHub Discussions]: https://github.com/orgs/charmed-hpc/discussions/categories/support
 
 ## Hacking on `slurm-charms`
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Slurm charms
 
-[![CI](https://github.com/charmed-hpc/slurm-charms/actions/workflows/ci.yaml/badge.svg)](https://github.com/charmed-hpc/slurm-charms/actions/workflows/ci.yaml/badge.svg)
-[![Release](https://github.com/charmed-hpc/slurm-charms/actions/workflows/release.yaml/badge.svg)](https://github.com/charmed-hpc/slurm-charms/actions/workflows/release.yaml/badge.svg)
-![GitHub License](https://img.shields.io/github/license/charmed-hpc/slurm-charms)
+[![CI](https://github.com/canonical/slurm-charms/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/slurm-charms/actions/workflows/ci.yaml/badge.svg)
+[![Release](https://github.com/canonical/slurm-charms/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/slurm-charms/actions/workflows/release.yaml/badge.svg)
+![GitHub License](https://img.shields.io/github/license/canonical/slurm-charms)
 [![Matrix](https://img.shields.io/matrix/ubuntu-hpc%3Amatrix.org?logo=matrix&label=ubuntu-hpc)](https://matrix.to/#/#hpc:ubuntu.com)
 
 [Juju](https://juju.is) charms for automating the Day 0 to Day 2 operations of the [Slurm workload manager](https://slurm.schedmd.com/overview.html) ⚖️🐧
@@ -42,8 +42,7 @@ juju integrate slurmdbd:database slurmdbd-mysql-router:database
 If you want to learn more about all the things you can do with the Slurm charms, here are some resources for you to explore:
 
 * [Documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/latest)
-* [Open an issue](https://github.com/charmed-hpc/slurm-charms/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
-* [Ask a question on Github](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
+* [Open an issue](https://github.com/canonical/slurm-charms/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
 
 ## 🛠️ Development
 
@@ -85,7 +84,6 @@ Here’s some links to help you get started with joining the community:
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Join the conversation on Matrix](https://matrix.to/#/#hpc:ubuntu.com)
 * [Get the latest news on Discourse](https://discourse.ubuntu.com/c/hpc/151)
-* [Ask and answer questions on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 
 ## 📋 License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ The preferred way to report a security issue is through [GitHub Security Advisor
 [Privately reporting a security vulnerability][how-to-sec-vuln] for instructions on how to report a security vulnerability
 using GitHub's security advisory feature.
 
-[gsa]: https://github.com/charmed-hpc/slurm-charms/security/advisories/new
+[gsa]: https://github.com/canonical/slurm-charms/security/advisories/new
 [how-to-sec-vuln]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
 
 You may also send email to [security@ubuntu.com](mailto:security@ubuntu.com). Email may optionally be encrypted to OpenPGP

--- a/charms/sackd/README.md
+++ b/charms/sackd/README.md
@@ -36,7 +36,7 @@ constructive feedback. Interested in being involved with development? Check out 
 * [Join our online chat](https://matrix.to/#/#ubuntu-hpc:matrix.org)
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
-* [File a bug report](https://github.com/charmed-hpc/slurm-charms/issues)
+* [File a bug report](https://github.com/canonical/slurm-charms/issues)
 * [Juju SDK docs](https://juju.is/docs/sdk)
 
 ## License

--- a/charms/sackd/charmcraft.yaml
+++ b/charms/sackd/charmcraft.yaml
@@ -16,10 +16,10 @@ links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
 
   issues:
-    - https://github.com/charmed-hpc/slurm-charms/issues
+    - https://github.com/canonical/slurm-charms/issues
 
   source:
-    - https://github.com/charmed-hpc/slurm-charms
+    - https://github.com/canonical/slurm-charms
 
 assumes:
   - juju

--- a/charms/slurmctld/README.md
+++ b/charms/slurmctld/README.md
@@ -29,14 +29,14 @@ $ juju integrate slurmctld:slurmd slurmd:slurmctld
 
 ## Project & Community
 
-The slurmctld operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988) 
-community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and 
+The slurmctld operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988)
+community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and
 constructive feedback. Interested in being involved with the development of the slurmctld operator? Check out these links below:
 
 * [Join our online chat](https://matrix.to/#/#ubuntu-hpc:matrix.org)
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
-* [File a bug report](https://github.com/omnivector-solutions/slurmctld-operator/issues)
+* [File a bug report](https://github.com/canonical/slurm-charms/issues)
 * [Juju SDK docs](https://juju.is/docs/sdk)
 
 ## License

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -29,9 +29,9 @@ description: |
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
   issues:
-    - https://github.com/charmed-hpc/slurm-charms/issues
+    - https://github.com/canonical/slurm-charms/issues
   source:
-    - https://github.com/charmed-hpc/slurm-charms
+    - https://github.com/canonical/slurm-charms
 
 requires:
   slurmd:

--- a/charms/slurmctld/src/charm.py
+++ b/charms/slurmctld/src/charm.py
@@ -890,7 +890,7 @@ class SlurmctldCharm(ops.CharmBase):
             )
 
         if self.slurmrestd.is_joined():
-            # Workaround for: https://github.com/charmed-hpc/slurm-charms/issues/203
+            # Workaround for: https://github.com/canonical/slurm-charms/issues/203
             # TODO: Remove setting of key ID once merging of databag info is implemented. Only the
             # slurmconfig needs updated. The auth Secret ID should not be overwritten
             auth_secret_id = self.model.get_secret(label=AUTH_KEY_LABEL).get_info().id

--- a/charms/slurmd/README.md
+++ b/charms/slurmd/README.md
@@ -55,14 +55,14 @@ $ juju run --quiet slurmd/0 node-config parameters="Weight=5000" --format json |
 
 ## Project & Community
 
-The slurmd operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988) 
-community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and 
+The slurmd operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988)
+community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and
 constructive feedback. Interested in being involved with the development of the slurmd operator? Check out these links below:
 
 * [Join our online chat](https://matrix.to/#/#ubuntu-hpc:matrix.org)
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
-* [File a bug report](https://github.com/omnivector-solutions/slurmctld-operator/issues)
+* [File a bug report](https://github.com/canonical/slurm-charms/issues)
 * [Juju SDK docs](https://juju.is/docs/sdk)
 
 ## License

--- a/charms/slurmd/charmcraft.yaml
+++ b/charms/slurmd/charmcraft.yaml
@@ -26,9 +26,9 @@ description: |
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
   issues:
-    - https://github.com/charmed-hpc/slurm-charms/issues
+    - https://github.com/canonical/slurm-charms/issues
   source:
-    - https://github.com/charmed-hpc/slurm-charms
+    - https://github.com/canonical/slurm-charms
 
 assumes:
   - juju

--- a/charms/slurmd/src/charm.py
+++ b/charms/slurmd/src/charm.py
@@ -98,7 +98,7 @@ class SlurmdCharm(ops.CharmBase):
         )
 
         scrape_jobs = [NODE_EXPORTER_SCRAPE_CONFIG]
-        # FIXME: https://github.com/charmed-hpc/hpc-libs/issues/133
+        # FIXME: https://github.com/canonical/charmed-hpc-libs/issues/133
         #  Replace with `is_installed` once method is added to `SnapOpsManager`.
         try:
             if self.gpu.dcgm.exporter.is_active():
@@ -156,7 +156,7 @@ class SlurmdCharm(ops.CharmBase):
             self.slurmd.node_exporter.set_collectors(NODE_EXPORTER_COLLECTORS)
             self.slurmd.node_exporter.service.enable()
         except (SlurmOpsError, GPUOpsError, rdma.RDMAOpsError, SnapError) as e:
-            # FIXME: https://github.com/charmed-hpc/hpc-libs/issues/134
+            # FIXME: https://github.com/canonical/charmed-hpc-libs/issues/134
             #  Investigate how to provide more granular status messages
             #  such as when it's the `dcgm-exporter` snap that fails to install
             #  and not the Nvidia drivers.
@@ -261,7 +261,7 @@ class SlurmdCharm(ops.CharmBase):
         # Necessary to load new key from file into the service
         # FIXME: slurmd reloading is currently broken. Service restart is used as a workaround but
         # this breaks zero-downtime key rotation. This must be replaced with a reload
-        # See: https://github.com/charmed-hpc/slurm-charms/issues/204
+        # See: https://github.com/canonical/slurm-charms/issues/204
         self.slurmd.service.restart()
 
     @refresh

--- a/charms/slurmdbd/README.md
+++ b/charms/slurmdbd/README.md
@@ -35,14 +35,14 @@ $ juju integrate slurmdbd:database slurmdbd-mysql-router:database
 
 ## Project & Community
 
-The slurmdbd operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988) 
-community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and 
+The slurmdbd operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988)
+community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and
 constructive feedback. Interested in being involved with the development of the slurmdbd operator? Check out these links below:
 
 * [Join our online chat](https://matrix.to/#/#ubuntu-hpc:matrix.org)
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
-* [File a bug report](https://github.com/omnivector-solutions/slurmctld-operator/issues)
+* [File a bug report](https://github.com/canonical/slurm-charms/issues)
 * [Juju SDK docs](https://juju.is/docs/sdk)
 
 ## License

--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -26,9 +26,9 @@ description: |
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
   issues:
-    - https://github.com/charmed-hpc/slurm-charms/issues
+    - https://github.com/canonical/slurm-charms/issues
   source:
-    - https://github.com/charmed-hpc/slurm-charms
+    - https://github.com/canonical/slurm-charms
 
 requires:
   database:

--- a/charms/slurmrestd/README.md
+++ b/charms/slurmrestd/README.md
@@ -39,14 +39,14 @@ $ juju integrate slurmdbd:database slurmdbd-mysql-router:database
 
 ## Project & Community
 
-The slurmrestd operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988) 
-community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and 
+The slurmrestd operator is a project of the [Ubuntu HPC](https://discourse.ubuntu.com/t/high-performance-computing-team/35988)
+community. It is an open source project that is welcome to community involvement, contributions, suggestions, fixes, and
 constructive feedback. Interested in being involved with the development of the slurmrestd operator? Check out these links below:
 
 * [Join our online chat](https://matrix.to/#/#ubuntu-hpc:matrix.org)
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
-* [File a bug report](https://github.com/omnivector-solutions/slurmrestd-operator/issues)
+* [File a bug report](https://github.com/canonical/slurm-charms/issues)
 * [Juju SDK docs](https://juju.is/docs/sdk)
 
 ## License

--- a/charms/slurmrestd/charmcraft.yaml
+++ b/charms/slurmrestd/charmcraft.yaml
@@ -14,10 +14,10 @@ links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
 
   issues:
-    - https://github.com/charmed-hpc/slurm-charms/issues
+    - https://github.com/canonical/slurm-charms/issues
 
   source:
-    - https://github.com/charmed-hpc/slurm-charms
+    - https://github.com/canonical/slurm-charms
 
 assumes:
   - juju

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -292,7 +292,7 @@ class _AptManager(OpsManager):
                         Restart=on-failure
                         RestartSec=10
                         """))
-                # TODO: https://github.com/charmed-hpc/hpc-libs/issues/54 -
+                # TODO: https://github.com/canonical/charmed-hpc-libs/issues/54 -
                 #   Make `sackd` create its service environment file so that we
                 #   aren't required to manually create it here.
                 _logger.debug("creating sackd environment file")
@@ -333,7 +333,7 @@ class _AptManager(OpsManager):
 
                 systemctl("disable", "--now", "munge")
             case "slurmrestd":
-                # TODO: https://github.com/charmed-hpc/hpc-libs/issues/39 -
+                # TODO: https://github.com/canonical/charmed-hpc-libs/issues/39 -
                 #   Make `slurmrestd` package preinst hook create the system user and group
                 #   so that we do not need to do it manually here.
                 _logger.debug("creating slurmrestd user and group")
@@ -465,7 +465,7 @@ class _SnapManager(OpsManager):
         snap("stop", "--disable", "slurm.munged")
 
 
-# TODO: https://github.com/charmed-hpc/hpc-libs/issues/36 -
+# TODO: https://github.com/canonical/charmed-hpc-libs/issues/36 -
 #   Use `jwtctl` to provide backend for generating, setting, and getting
 #   jwt signing key used by `slurmctld` and `slurmdbd`. This way we also
 #   won't need to pass the keyfile path to the `__init__` constructor.


### PR DESCRIPTION
Migrates charmed-hpc org references to the Canonical org.

Reference: [`ghcr.io/charmed-hpc/ubuntu-test:jammy`](https://github.com/canonical/slurm-charms/blob/b802dc3/tests/integration/test_oci_runtime.py#L68) is kept following discussion with the team, as these tests are expected to be rewritten in the near future.