### PR TITLE
feat: add monorepo package publishing workflow

### DIFF
--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Python packages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "pkg/*/pyproject.toml"
+
+jobs:
+  publish:
+    uses: canonical/hpc-team/.github/workflows/publish-monorepo-python-packages.yaml@main


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Add a GitHub Actions workflow that calls the monorepo package publishing callable workflow from `canonical/hpc-team`. The workflow publishes packages from the `pkg/` directory to PyPI when their version is bumped on `main`, per UHPC009.

#### Related Issues, PRs, and Discussions

Closes HPCENG-875.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.