### PR TITLE
fix: pass PYPI_PUBLISH_TOKEN to reusable monorepo publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -24,3 +24,5 @@ on:
 jobs:
   publish:
     uses: canonical/hpc-team/.github/workflows/publish-monorepo-python-packages.yaml@main
+    secrets:
+      PYPI_PUBLISH_TOKEN: ${{ secrets.PYPI_PUBLISH_TOKEN }}


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Pass `PYPI_PUBLISH_TOKEN` to the reusable `publish-monorepo-python-packages.yaml` workflow from `canonical/hpc-team`, which now requires this secret to be explicitly provided by the caller instead of relying on a GitHub environment.

#### Related Issues, PRs, and Discussions

N/A &mdash; chore/fix for updated reusable workflow interface.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.