### PR TITLE
refactor: replace distro with platform

### DIFF
--- a/internal/slurm-ops/pyproject.toml
+++ b/internal/slurm-ops/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "charmed-hpc-libs[ops]",
     "charmlibs-apt ~= 1.0",
     "cryptography ~= 48.0",
-    "distro ~= 1.0",
     "nvidia-ml-py == 12.560.30",
     "slurmutils<2.0.0,>=1.1.1",
 ]

--- a/internal/slurm-ops/src/slurm_ops/core/base.py
+++ b/internal/slurm-ops/src/slurm_ops/core/base.py
@@ -23,6 +23,7 @@ import base64
 import datetime
 import json
 import logging
+import platform
 import secrets
 import shutil
 import socket
@@ -36,7 +37,6 @@ from subprocess import CalledProcessError
 from typing import Any, Protocol
 from uuid import uuid4
 
-import distro
 import yaml
 from charmed_hpc_libs.errors import SnapError, SystemdError
 from charmed_hpc_libs.ops import (
@@ -205,7 +205,7 @@ class _AptManager(OpsManager):
                 enabled=True,
                 repotype="deb",
                 uri=uri,
-                release=distro.codename(),
+                release=platform.freedesktop_os_release().get("VERSION_CODENAME", ""),
                 groups=["main"],
             )
             ppa.import_key(UBUNTU_HPC_PPA_KEY)

--- a/internal/slurm-ops/tests/unit/test_base.py
+++ b/internal/slurm-ops/tests/unit/test_base.py
@@ -138,7 +138,10 @@ class TestAptManager:
         mocker.patch("charmlibs.apt.DebianRepository._get_keyid_by_gpg_key")
         mocker.patch("charmlibs.apt.DebianRepository._dearmor_gpg_key")
         mocker.patch("charmlibs.apt.DebianRepository._write_apt_gpg_keyfile")
-        mocker.patch("distro.codename", return_value="noble")
+        mocker.patch(
+            "platform.freedesktop_os_release",
+            return_value={"VERSION_CODENAME": "noble"},
+        )
 
         # Test that Ubuntu HPC PPA is successfully added to the sources list.
         manager._ops_manager._init_ppa(UBUNTU_HPC_SLURM_PPA_URI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dev = [
     "charmlibs-apt ~= 1.0",
     "cosl ~= 1.0",
     "cryptography ~= 48.0",
-    "distro ~= 1.0",
     "influxdb == 5.3.2",
     "nvidia-ml-py == 12.560.30",
     "ops ~= 3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -406,15 +406,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
 name = "flake8"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1050,7 +1041,6 @@ dev = [
     { name = "cosl" },
     { name = "coverage" },
     { name = "cryptography" },
-    { name = "distro" },
     { name = "flake8" },
     { name = "influxdb" },
     { name = "jubilant" },
@@ -1089,7 +1079,6 @@ requires-dist = [
     { name = "cosl", marker = "extra == 'dev'", specifier = "~=1.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = "~=48.0" },
-    { name = "distro", marker = "extra == 'dev'", specifier = "~=1.0" },
     { name = "flake8", marker = "extra == 'dev'" },
     { name = "influxdb", marker = "extra == 'dev'", specifier = "==5.3.2" },
     { name = "jubilant", marker = "extra == 'dev'", specifier = "~=1.0" },
@@ -1123,7 +1112,6 @@ dependencies = [
     { name = "charmed-hpc-libs", extra = ["ops"] },
     { name = "charmlibs-apt" },
     { name = "cryptography" },
-    { name = "distro" },
     { name = "nvidia-ml-py" },
     { name = "slurmutils" },
 ]
@@ -1133,7 +1121,6 @@ requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"] },
     { name = "charmlibs-apt", specifier = "~=1.0" },
     { name = "cryptography", specifier = "~=48.0" },
-    { name = "distro", specifier = "~=1.0" },
     { name = "nvidia-ml-py", specifier = "==12.560.30" },
     { name = "slurmutils", specifier = ">=1.1.1,<2.0.0" },
 ]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [ ] I have ensured that lint, typecheck, and unit tests complete successfully.

The scoped `slurm-ops` lint, typecheck, and unit tests pass locally. The repository wrapper itself could not be run because `charmcraft` is not installed in this environment, so this remains a draft for CI verification.

## Summary of changes

- use Python's `platform.freedesktop_os_release()` to read `VERSION_CODENAME`
- remove the now-unused `distro` dependency from `slurm-ops`, the development environment, and `uv.lock`
- update the PPA unit test to exercise the standard-library implementation

#### Related Issues, PRs, and Discussions

Closes #256.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

This is an internal dependency replacement with no user-facing behavior or interface changes.

## Validation

- `pytest internal/slurm-ops/tests/unit -q` — 114 passed
- `black --check internal/slurm-ops/src internal/slurm-ops/tests`
- `ruff check internal/slurm-ops/src internal/slurm-ops/tests`
- `codespell internal/slurm-ops/src internal/slurm-ops/tests`
- `pyright internal/slurm-ops/src` — 0 errors
- `git diff --check`
