### PR TITLE
docs(all): update Charmhub metadata descriptions for the Slurm charms

### DIFF
--- a/charms/sackd/charmcraft.yaml
+++ b/charms/sackd/charmcraft.yaml
@@ -1,29 +1,51 @@
+# Copyright 2024-2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: sackd
-type: charm
-
-summary: |
-  Sackd, the login node daemon of Slurm.
-
+summary: >
+  Charmed operator for sackd
 description: |
-  This charm provides sackd to facilitate deployment of a login node for a
-  Slurm cluster.
+  As part of Charmed HPC, this charm deploys and manages sackd, the login node
+  daemon of Slurm. sackd enables authentication to the cluster and retrieval of
+  configuration files when running in configless mode, providing users with a gateway to
+  submit and monitor jobs from a jumphost.
 
-  sackd is the login node daemon of Slurm. It enables authentication to the
-  cluster and retrieval of configuration files when running in configless
-  mode.
+  This charm integrates with the slurmctld charm to register as a
+  login node for a Slurm cluster.
+
+  See the following how-tos in Charmed HPC's documentation for more information about
+  how the sackd charm is used in Charmed HPC:
+
+  - [How to deploy Slurm](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-slurm)
+  - [How to manage Slurm](https://ubuntu.com/hpc/docs/latest/howto/manage/manage-slurm)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
 
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
-
+  documentation: https://ubuntu.com/hpc/docs/latest
   issues:
     - https://github.com/canonical/slurm-charms/issues
-
   source:
     - https://github.com/canonical/slurm-charms
+  website: https://ubuntu.com/hpc
 
 assumes:
   - juju
 
+type: charm
 base: ubuntu@24.04
 platforms:
   amd64:

--- a/charms/sackd/src/charm.py
+++ b/charms/sackd/src/charm.py
@@ -69,7 +69,7 @@ class SackdCharm(ops.CharmBase):
             self,
             PROMETHEUS_SCRAPE_INTEGRATION_NAME,
             alert_rules_path="./src/cos/alert_rules/prometheus",
-            jobs=[NODE_EXPORTER_SCRAPE_CONFIG]
+            jobs=[NODE_EXPORTER_SCRAPE_CONFIG],
         )
 
     @refresh

--- a/charms/slurmctld/charmcraft.yaml
+++ b/charms/slurmctld/charmcraft.yaml
@@ -14,24 +14,38 @@
 # limitations under the License.
 
 name: slurmctld
-summary: |
-  Slurmctld, the central management daemon of Slurm.
+summary: >
+  Charmed operator for slurmctld
 description: |
-  This charm provides slurmctld and the bindings to other utilities
-  that make lifecycle operations a breeze.
+  As part of Charmed HPC, this charm deploys and manages slurmctld, the central
+  management daemon of Slurm. slurmctld monitors all other Slurm daemons and
+  resources, accepts work (jobs), and allocates resources to those jobs. A backup
+  slurmctld server can be deployed to assume management functions in the
+  event that the primary server fails.
 
-  slurmctld is the central management daemon of SLURM. It monitors all other
-  SLURM daemons and resources, accepts work (jobs), and allocates resources
-  to those jobs.  Given the critical functionality of slurmctld, there may be
-  a backup server to assume these functions in the event that the primary
-  server fails.
+  This charm integrates with the other Slurm charms to automate lifecycle
+  operations such as configuration management, authentication key rotation,
+  and compute node state management.
+
+  See the following how-tos and explanations in Charmed HPC's documentation for more
+  information about how the slurmctld charm is used in Charmed HPC:
+
+  - [How to deploy Slurm](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-slurm)
+  - [How to manage Slurm](https://ubuntu.com/hpc/docs/latest/howto/manage/manage-slurm)
+  - [Explanation of slurmctld's high-availability implementation](https://ubuntu.com/hpc/docs/latest/explanation/high-availability)
+  - [Explanation of slurmctld's key rotation implementation](https://ubuntu.com/hpc/docs/latest/explanation/key-rotation)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
 
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
   issues:
     - https://github.com/canonical/slurm-charms/issues
   source:
     - https://github.com/canonical/slurm-charms
+  website: https://ubuntu.com/hpc
 
 requires:
   slurmd:

--- a/charms/slurmd/charmcraft.yaml
+++ b/charms/slurmd/charmcraft.yaml
@@ -14,21 +14,34 @@
 # limitations under the License.
 
 name: slurmd
-summary: |
-  Slurmd, the compute node daemon of Slurm.
+summary: >
+  Charmed operator for slurmd
 description: |
-  This charm provides slurmd and the bindings to other utilities
-  that make lifecycle operations a breeze.
+  As part of Charmed HPC, this charm deploys and manages slurmd,
+  the compute node daemon of Slurm. slurmd monitors all tasks running on
+  the compute node, accepts work (tasks), launches tasks, and kills running
+  tasks upon request.
 
-  slurmd is the compute node daemon of SLURM. It monitors all tasks running
-  on the compute node, accepts work (tasks), launches tasks, and kills
-  running tasks upon request.
+  This charm integrates with the slurmctld charm to register compute nodes
+  as Slurm partitions and automates node configuration management.
+
+  See the following how-tos in Charmed HPC's documentation for more information about
+  how the slurmd charm is used in Charmed HPC:
+
+  - [How to deploy Slurm](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-slurm)
+  - [How to manage Slurm](https://ubuntu.com/hpc/docs/latest/howto/manage/manage-slurm)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
+
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
   issues:
     - https://github.com/canonical/slurm-charms/issues
   source:
     - https://github.com/canonical/slurm-charms
+  website: https://ubuntu.com/hpc
 
 assumes:
   - juju

--- a/charms/slurmdbd/charmcraft.yaml
+++ b/charms/slurmdbd/charmcraft.yaml
@@ -14,21 +14,33 @@
 # limitations under the License.
 
 name: slurmdbd
-summary: |
-  Slurm DBD accounting daemon.
+summary: >
+  Charmed operator for slurmdbd
 description: |
-  This charm provides slurmdbd and the bindings to other utilities
-  that make lifecycle operations a breeze.
+  As part of Charmed HPC, this charm deploys and manages slurmdbd, the Slurm database
+  daemon. slurmdbd provides a secure enterprise-wide interface to a
+  database for Slurm, enabling job accounting and archival of accounting
+  records.
 
-  slurmdbd provides a secure enterprise-wide interface to a database for
-  SLURM. This is particularly useful for archiving accounting records.
+  This charm integrates with a MySQL database or router to store accounting data and
+  exposes this data to slurmctld for job and resource tracking.
+
+  See the following how-to in Charmed HPC's documentation for more information about
+  how the slurmdbd charm is used in Charmed HPC:
+
+  - [How to deploy Slurm](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-slurm)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
 
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
   issues:
     - https://github.com/canonical/slurm-charms/issues
   source:
     - https://github.com/canonical/slurm-charms
+  website: https://ubuntu.com/hpc
 
 requires:
   database:

--- a/charms/slurmrestd/charmcraft.yaml
+++ b/charms/slurmrestd/charmcraft.yaml
@@ -1,23 +1,46 @@
-# Copyright 2020-2024 Omnivector, LLC.
-# See LICENSE file for licensing details.
+# Copyright 2025-2026 Vantage Compute Corporation
+# Copyright 2020-2024 Omnivector, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: slurmrestd
-summary: |
-  Interface to Slurm via REST API.
+summary: >
+  Charmed operator for slurmrestd
 description: |
-  This charm provides slurmrestd and the bindings to other utilities
-  that make lifecycle operations a breeze.
+  As part of Charmed HPC, this charm deploys and manages slurmrestd, the Slurm
+  REST API daemon. slurmrestd provides a REST API interface to Slurm, enabling
+  programmatic access to cluster management, job submission, and monitoring
+  functionality.
 
-  slurmrestd is a REST API interface for SLURM.
+  This charm integrates with the slurmctld charm to expose Slurm's
+  functionality through a RESTful HTTP API.
+
+  See the following how-to in Charmed HPC's documentation for more information about
+  how the slurmrestd charm is used in Charmed HPC:
+
+  - [How to deploy Slurm](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-slurm)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
 
 links:
   contact: https://matrix.to/#/#hpc:ubuntu.com
-
+  documentation: https://ubuntu.com/hpc/docs/latest
   issues:
     - https://github.com/canonical/slurm-charms/issues
-
   source:
     - https://github.com/canonical/slurm-charms
+  website: https://ubuntu.com/hpc
 
 assumes:
   - juju


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the existing _charmcraft.yaml_ files for each of the Slurm charms to include more descriptive descriptions, and include references to Charm HPC and then ubuntu.com/hpc website.

##### Other changes

There was code formatting issue in the `sackd` operator caught by `just fmt`. There was missing comma!

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to our ongoing initiative to get all of the charms in the Charmed HPC "collection" publicly listed on Charmhub.  

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a documentation update to improve how the HPC charms are displayed on Charmhub.